### PR TITLE
Further simplify WC cancellation

### DIFF
--- a/src/stores/walletconnectStore.ts
+++ b/src/stores/walletconnectStore.ts
@@ -62,8 +62,6 @@ export const useWalletconnectStore = (wallet: Ref<WalletType>) => {
       const queuedRequests = web3wallet.value.getPendingSessionRequests();
 
       for (const request of queuedRequests) {
-        console.debug("Checking request:", request);
-
         if (request.topic !== cancellationRequestTopic) continue;
 
         // We'll process the cancellation request itself once we've cancelled all other requests


### PR DESCRIPTION
Since only one request is pending at a time (with all others queued in walletconnect) there is no need for a map or other data structure to track pending requests. Also the one that is pending remains at the front of the queue so is easily accessible. 

We do however need to track the dialog handle so that we can `.hide()` it if a cancellation request arrives from the app.

This PR therefore replaces `pendingRequests` with `pendingDialog`.

`cancelPendingRequestsForTopic` is also modified to ensure that a cancellation request from one app doesn't cancel requests from another.