### PR TITLE
Fix early return missing after error response in bch_signTransaction

### DIFF
--- a/src/stores/walletconnectStore.ts
+++ b/src/stores/walletconnectStore.ts
@@ -87,7 +87,7 @@ export const useWalletconnectStore = (wallet: Ref<WalletType>) => {
     }
 
     async function initweb3wallet() {
-      // Make sure we don't ininialize WC more than once.
+      // Make sure we don't initialize WC more than once.
       // Otherwise, we'll register multiple handlers and end up with multiple dialogs.
       if (isIninialized.value) return;
 
@@ -386,6 +386,7 @@ export const useWalletconnectStore = (wallet: Ref<WalletType>) => {
             const wcErrorMessage = 'Transaction signing request aborted with error: ' + errorMessage;
             const response = { id, jsonrpc: '2.0', result: undefined , error: { message : wcErrorMessage } };
             await web3wallet.value?.respondSessionRequest({ topic, response });
+            return;
           }
 
           // Auto-approve early return


### PR DESCRIPTION
## Summary

Fixes a bug where the `bch_signTransaction` case was missing an early return after sending an error response to the dapp. This caused the code to continue executing and attempt to show a dialog even though the request had already been handled with an error response.

Also fixes a typo in the `initweb3wallet` function comment.

## Changes

- Add missing `return;` statement after error response in bch_signTransaction case (consistent with bch_signMessage)
- Fix typo: 'ininialize' -> 'initialize'

## Testing

This prevents attempting to create a dialog after an error response has already been sent, which would cause unexpected behavior or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)