### PR TITLE
Simplify WC promise handling and logging

### DIFF
--- a/src/stores/walletconnectStore.ts
+++ b/src/stores/walletconnectStore.ts
@@ -195,7 +195,7 @@ export const useWalletconnectStore = (wallet: Ref<WalletType>) => {
         .onCancel(() => {
           void rejectSession(sessionProposal);
         });
-  }
+    }
 
     async function approveSession(
       sessionProposal: WalletKitTypes.SessionProposal,
@@ -580,10 +580,12 @@ export const useWalletconnectStore = (wallet: Ref<WalletType>) => {
       });
     }
 
-    async function rejectSession(wcSessionProposal: WalletKitTypes.SessionProposal){
-      await web3wallet.value?.rejectSession({
+    function rejectSession(wcSessionProposal: WalletKitTypes.SessionProposal){
+      return web3wallet.value?.rejectSession({
         id: wcSessionProposal.id,
         reason: getSdkError('USER_REJECTED'),
+      }).catch((error) => {
+        console.error("Error rejecting session:", error);
       });
     }
 


### PR DESCRIPTION
- Remove extraneous promise contructs
- Improve logs to provide more information and fewer false alarms on console

When the user clicks cancel:

Before:
<img width="1080" height="109" alt="Screenshot 2026-02-23 at 11 56 08" src="https://github.com/user-attachments/assets/cb55a7d9-ac8c-41cd-ac9f-da5557553e12" />

After (verbose):
<img width="1041" height="93" alt="Screenshot 2026-02-23 at 11 54 15" src="https://github.com/user-attachments/assets/c8f3e70b-6e15-4d19-b188-efdb351ab8f6" />

After (default):
<img width="1043" height="52" alt="Screenshot 2026-02-23 at 11 55 00" src="https://github.com/user-attachments/assets/60472462-9950-4ddc-9d21-24fc0b71f7ee" />


Also fixes a bug where error responses were geting dropped. 

Before:
<img width="1281" height="707" alt="Screenshot 2026-02-23 at 14 43 36" src="https://github.com/user-attachments/assets/ca99165b-6b5a-40ae-9c29-5de09fe2ef87" />


<p/>
After:
<img width="2557" height="1414" alt="Screenshot 2026-02-23 at 14 44 34" src="https://github.com/user-attachments/assets/bb1e3a36-e33b-450c-a7a8-3d71d080702c" />

