### PR TITLE
Deduplicate tokenItems components into shared composables and tx helpers

### DIFF
--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -11,7 +11,7 @@
   import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
   import { displayAndLogError } from 'src/utils/errorHandling'
-  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import QrCodeDialog from './qr/qrCodeScanDialog.vue';
 
   const $q = useQuasar()
@@ -198,7 +198,7 @@
       bchSendAmount.value = undefined;
       currencySendAmount.value = undefined;
       destinationAddr.value = "";
-      await showTransactionResult(alertMessage, txId, t('wallet.transactionSuccess'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('wallet.transactionSuccess'));
     } catch(error){
       displayAndLogError(error)
     } finally {

--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -2,7 +2,6 @@
   import { ref, computed, watch, shallowRef } from 'vue'
   import { convert } from 'mainnet-js'
   import { decodeCashAddress } from "@bitauth/libauth"
-  import alertDialog from 'src/components/general/alertDialog.vue'
   import { CurrencySymbols, CurrencyShortNames, type QrCodeElement } from 'src/interfaces/interfaces'
   import { copyToClipboard, formatFiatAmount, convertToCurrency } from 'src/utils/utils';
   import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
@@ -11,7 +10,8 @@
   import { useSettingsStore } from '../stores/settingsStore'
   import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
-  import { caughtErrorToString } from 'src/utils/errorHandling'
+  import { displayAndLogError } from 'src/utils/errorHandling'
+  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
   import QrCodeDialog from './qr/qrCodeScanDialog.vue';
 
   const $q = useQuasar()
@@ -179,58 +179,28 @@
       if (settingsStore.confirmBeforeSending) {
         const truncatedAddr = `${destinationAddr.value.slice(0, 24)}...${destinationAddr.value.slice(-8)}`
         const fiatStr = currencySendAmount.value ? ` (${formatFiatAmount(currencySendAmount.value, settingsStore.currency)})` : ''
-        const confirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('wallet.confirmPayment'),
-            message: `${t('wallet.confirmPaymentMessage', { amount: bchSendAmount.value?.toLocaleString("en-US"), unit: displayUnitLong.value, fiat: fiatStr })}\n${truncatedAddr}`,
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('common.actions.confirm'), color: 'primary', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const confirmed = await confirmDialog(
+          t('wallet.confirmPayment'),
+          `${t('wallet.confirmPaymentMessage', { amount: bchSendAmount.value?.toLocaleString("en-US"), unit: displayUnitLong.value, fiat: fiatStr })}\n${truncatedAddr}`,
+          t('common.actions.confirm')
+        )
         if (!confirmed) return
       }
 
       let amountSats = BigInt(Math.round(bchSendAmount.value * 100_000_000))
       if(settingsStore.bchUnit === 'sat') amountSats = BigInt(bchSendAmount.value)
       const sendBchOutput = { cashaddr: destinationAddr.value, value:amountSats } ;
-      $q.notify({
-        spinner: true,
-        message: t('wallet.sendingTransaction'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending(t('wallet.sendingTransaction'));
       const { txId } = await store.wallet.send([ sendBchOutput ]);
       const formattedAmount = numberFormatter.format(bchSendAmount.value)
       const alertMessage = t('wallet.sent', { amount: formattedAmount + displayUnitLong.value, address: destinationAddr.value })
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId } 
-        }
-      })
-      $q.notify({
-        type: 'positive',
-        message: t('wallet.transactionSuccess')
-      })
-      console.log(alertMessage);
       // reset fields
       bchSendAmount.value = undefined;
       currencySendAmount.value = undefined;
       destinationAddr.value = "";
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('wallet.transactionSuccess'));
     } catch(error){
-      console.log(error)
-      const errorMessage = caughtErrorToString(error);
-      $q.notify({
-        message: errorMessage,
-        icon: 'warning',
-        color: "red"
-      })
+      displayAndLogError(error)
     } finally {
       isSending.value = false;
     }

--- a/src/components/settings/backupWallet.vue
+++ b/src/components/settings/backupWallet.vue
@@ -4,6 +4,7 @@
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
   import { copyToClipboard } from 'src/utils/utils'
+  import { confirmDialog } from 'src/utils/txHelpers'
   import { DERIVATION_PATHS } from 'src/utils/walletUtils'
   import { useI18n } from 'vue-i18n'
   const store = useStore()
@@ -146,16 +147,11 @@
   }
 
   async function copySeedphrase() {
-    const confirmed = await new Promise<boolean>((resolve) => {
-      $q.dialog({
-        title: t('backupWallet.seedPhrase.copyTitle'),
-        message: t('backupWallet.seedPhrase.copyMessage'),
-        cancel: { flat: true, color: 'dark' },
-        ok: { label: t('backupWallet.seedPhrase.copyButton'), color: 'primary', textColor: 'white' },
-        persistent: true
-      }).onOk(() => resolve(true))
-        .onCancel(() => resolve(false))
-    })
+    const confirmed = await confirmDialog(
+      t('backupWallet.seedPhrase.copyTitle'),
+      t('backupWallet.seedPhrase.copyMessage'),
+      t('backupWallet.seedPhrase.copyButton')
+    )
     if (!confirmed) return
     void navigator.clipboard.writeText(store.wallet.mnemonic);
     $q.notify({

--- a/src/components/settings/createTokens.vue
+++ b/src/components/settings/createTokens.vue
@@ -2,9 +2,9 @@
   import { ref, computed } from 'vue';
   import { OpReturnData, sha256, utf8ToBin } from "mainnet-js"
   import { copyToClipboard } from 'src/utils/utils';
-  import alertDialog from 'src/components/general/alertDialog.vue'
   import EmojiItem from '../general/emojiItem.vue';
-    import { caughtErrorToString } from 'src/utils/errorHandling';
+  import { displayAndLogError } from 'src/utils/errorHandling';
+  import { notifySending, showTransactionResult } from 'src/utils/txHelpers';
   import { useStore } from 'src/stores/store'
   import { useQuasar } from 'quasar'
   import { useSettingsStore } from 'src/stores/settingsStore';
@@ -31,12 +31,7 @@
     try{
       store.plannedTokenId = undefined;
       const walletAddr = store.wallet.getDepositAddress();
-      $q.notify({
-        spinner: true,
-        message: t('createTokens.notifications.preparingPreGenesis'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending(t('createTokens.notifications.preparingPreGenesis'));
       const { txId } = await store.wallet.send([{ cashaddr: walletAddr, value: 10000n }]);
       $q.notify({
         type: 'positive',
@@ -49,7 +44,7 @@
       // update wallet history as fire-and-forget promise
       void store.updateWalletHistory();
     } catch(error){
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -100,12 +95,7 @@
     try{
       const totalSupply = inputFungibleSupply.value;
       const opreturnData = await getOpreturnData();
-      $q.notify({
-        spinner: true,
-        message: t('createTokens.notifications.creatingTokens'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending(t('createTokens.notifications.creatingTokens'));
       const genesisResponse = await store.wallet.tokenGenesis(
         {
           cashaddr: store.wallet.getTokenDepositAddress(),
@@ -117,28 +107,13 @@
       const tokenId = genesisResponse?.categories?.[0];
       const { txId } = genesisResponse;
       const alertMessage = `Created ${totalSupply} fungible tokens of category ${tokenId}`;
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('createTokens.notifications.transactionSent')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       // reset input fields
       inputFungibleSupply.value = "";
       selectedTokenType.value  = "-select-";
-      // update utxo list
-      await store.updateWalletUtxos()
+      await showTransactionResult(alertMessage, txId, t('createTokens.notifications.transactionSent'));
       store.hasPreGenesis()
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
     } catch(error){
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -148,12 +123,7 @@
     activeAction.value = 'creatingMintingNFT';
     try{
       const opreturnData = await getOpreturnData();
-      $q.notify({
-        spinner: true,
-        message: t('createTokens.notifications.creatingMintingNft'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending(t('createTokens.notifications.creatingMintingNft'));
       const genesisResponse = await store.wallet.tokenGenesis(
         {
           cashaddr: store.wallet.getTokenDepositAddress(),
@@ -168,40 +138,15 @@
       const tokenId = genesisResponse?.categories?.[0];
       const { txId } = genesisResponse;
       const alertMessage = `Created minting NFT with category ${tokenId}`;
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('createTokens.notifications.transactionSent')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       // reset input fields
       selectedTokenType.value  = "-select-";
-      // update utxo list
-      await store.updateWalletUtxos()
+      await showTransactionResult(alertMessage, txId, t('createTokens.notifications.transactionSent'));
       store.hasPreGenesis()
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
     } catch(error){
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
-  }
-
-  function handleTransactionError(error: unknown){
-    const errorMessage = caughtErrorToString(error)
-    console.error(errorMessage)
-    $q.notify({
-      message: errorMessage,
-      icon: 'warning',
-      color: "red"
-    }) 
   }
 </script>
 

--- a/src/components/settings/createTokens.vue
+++ b/src/components/settings/createTokens.vue
@@ -4,7 +4,7 @@
   import { copyToClipboard } from 'src/utils/utils';
   import EmojiItem from '../general/emojiItem.vue';
   import { displayAndLogError } from 'src/utils/errorHandling';
-  import { notifySending, showTransactionResult } from 'src/utils/txHelpers';
+  import { notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers';
   import { useStore } from 'src/stores/store'
   import { useQuasar } from 'quasar'
   import { useSettingsStore } from 'src/stores/settingsStore';
@@ -110,7 +110,7 @@
       // reset input fields
       inputFungibleSupply.value = "";
       selectedTokenType.value  = "-select-";
-      await showTransactionResult(alertMessage, txId, t('createTokens.notifications.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('createTokens.notifications.transactionSent'));
       store.hasPreGenesis()
     } catch(error){
       displayAndLogError(error)
@@ -140,7 +140,7 @@
       const alertMessage = `Created minting NFT with category ${tokenId}`;
       // reset input fields
       selectedTokenType.value  = "-select-";
-      await showTransactionResult(alertMessage, txId, t('createTokens.notifications.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('createTokens.notifications.transactionSent'));
       store.hasPreGenesis()
     } catch(error){
       displayAndLogError(error)

--- a/src/components/settings/walletsOverview.vue
+++ b/src/components/settings/walletsOverview.vue
@@ -3,6 +3,7 @@
   import { useQuasar } from 'quasar'
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
+  import { confirmDialog } from 'src/utils/txHelpers'
   import { useI18n } from 'vue-i18n'
 
   const MAX_WALLETS = 20
@@ -77,16 +78,12 @@
       });
       return;
     }
-    const confirmed = await new Promise<boolean>((resolve) => {
-      $q.dialog({
-        title: t('walletsOverview.deleteWallet.title'),
-        message: t('walletsOverview.deleteWallet.message', { name: walletName }),
-        cancel: { flat: true, color: 'dark' },
-        ok: { label: t('walletsOverview.deleteWallet.title'), color: 'red', textColor: 'white' },
-        persistent: true
-      }).onOk(() => resolve(true))
-        .onCancel(() => resolve(false))
-    });
+    const confirmed = await confirmDialog(
+      t('walletsOverview.deleteWallet.title'),
+      t('walletsOverview.deleteWallet.message', { name: walletName }),
+      t('walletsOverview.deleteWallet.title'),
+      'red'
+    );
     if (confirmed) {
       try {
         await store.deleteWallet(walletName);

--- a/src/components/settingsMenu.vue
+++ b/src/components/settingsMenu.vue
@@ -4,7 +4,6 @@
   import walletsOverview from './settings/walletsOverview.vue'
   import LanguageSelector from './general/LanguageSelector.vue'
   import { computed, ref } from 'vue'
-  import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
   import { Connection, type ElectrumNetworkProvider, Config } from "mainnet-js"
   import { useStore } from '../stores/store'
@@ -12,11 +11,11 @@
   import { useWalletconnectStore } from '../stores/walletconnectStore'
   import { useCashconnectStore } from '../stores/cashconnectStore'
   import { getElectrumCacheSize, clearElectrumCache } from "src/utils/cacheUtils";
+  import { confirmDialog } from 'src/utils/txHelpers'
   const store = useStore()
   const settingsStore = useSettingsStore()
   const walletconnectStore = useWalletconnectStore()
   const cashconnectStore = useCashconnectStore()
-  const $q = useQuasar()
   const { t } = useI18n()
   import { useWindowSize } from 'src/utils/composables'
   const { width } = useWindowSize();
@@ -260,16 +259,12 @@
     if (isPwaMode) {
       text = t('settings.advanced.deleteAllWalletsPwaWarning', { platform: platformString });
     }
-    const confirmed = await new Promise<boolean>((resolve) => {
-      $q.dialog({
-        title: t('settings.advanced.deleteAllWalletsTitle'),
-        message: text,
-        cancel: { flat: true, color: 'dark' },
-        ok: { label: t('settings.advanced.deleteAllButton'), color: 'red', textColor: 'white' },
-        persistent: true
-      }).onOk(() => resolve(true))
-        .onCancel(() => resolve(false))
-    })
+    const confirmed = await confirmDialog(
+      t('settings.advanced.deleteAllWalletsTitle'),
+      text,
+      t('settings.advanced.deleteAllButton'),
+      'red'
+    )
     if (confirmed) {
       // TODO: see if we need 'resetWalletState' to cancel subscriptions, etc.
 

--- a/src/components/tokenItems/nftChild.vue
+++ b/src/components/tokenItems/nftChild.vue
@@ -1,22 +1,18 @@
 <script setup lang="ts">
   import dialogNftIcon from './dialogNftIcon.vue'
+  import nftMintForm from './nftMintForm.vue'
   import { ref, onMounted, toRefs, computed, watch, nextTick } from 'vue';
-  import { TokenSendRequest, TokenMintRequest, type TokenI } from "mainnet-js"
+  import { TokenSendRequest, type TokenI } from "mainnet-js"
   import { type Utxo } from "mainnet-js"
-  import { bigIntToVmNumber, binToHex, decodeCashAddress } from "@bitauth/libauth"
-  import alertDialog from 'src/components/general/alertDialog.vue'
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
   import type { BcmrTokenMetadata } from "src/interfaces/interfaces"
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import type { ParseResult } from 'src/parsing/nftParsing'
-  import { caughtErrorToString } from 'src/utils/errorHandling'
+  import { useTokenAddressInput, useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { displayAndLogError } from 'src/utils/errorHandling'
   import { appendBlockieIcon } from 'src/utils/blockieIcon'
-  import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
-  import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
-  import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
-  const $q = useQuasar()
   const store = useStore()
   const settingsStore = useSettingsStore()
   const { t } = useI18n()
@@ -39,27 +35,14 @@
   const displayNftInfo = ref(false);
   const displayMintNfts = ref(false);
   const displayBurnNft = ref(false);
-  const destinationAddr = ref("");
-  const mintMode = ref<"single" | "collection">("single");
-  const mintCapability = ref<"none" | "mutable" | "minting">("none");
-  const numberingUniqueNfts = ref<"vm-numbers" | "hex-numbers">("vm-numbers");
-  const mintCommitment = ref("");
-  const mintQuantity = ref(undefined as string | undefined);
-  const startingNumberNFTs = ref(undefined as string | undefined);
-  const showQrCodeDialog = ref(false);
-  const activeAction = ref<'sending' | 'minting' | 'burning' | null>(null);
-  const parseResult = ref(undefined as ParseResult | undefined);
-  const parsingNft = ref(false);
+  const activeAction = ref<TokenActionType | null>(null);
 
-  const hasParyonUsdExtension = computed(() => {
-    const category = nftData.value.token!.category;
-    const ext = store.bcmrRegistries?.[category]?.extensions;
-    return Boolean(ext?.paryonusd ?? ext?.pusd);
-  });
-  const isParsable = computed(() => {
-    const category = nftData.value.token!.category;
-    return store.bcmrRegistries?.[category]?.nft_type === 'parsable';
-  });
+  const category = computed(() => nftData.value.token!.category);
+
+  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
+    useTokenAddressInput(() => category.value);
+  const { parseResult, parsingNft, isParsable, hasParyonUsdExtension } =
+    useNftParsing(() => category.value, () => nftData.value);
 
   const nftMetadata = computed(() => {
     const commitment = nftData.value?.token?.nft?.commitment;
@@ -96,125 +79,39 @@
     return commitment;
   })
 
-  onMounted(async () => {
-    const category = nftData.value.token!.category;
-    appendBlockieIcon(category, `#${id.value}`);
-    // Parse NFT commitment if this is a parsable NFT
-    if (isParsable.value) {
-      parsingNft.value = true;
-      parseResult.value = await store.parseNftCommitment(category, nftData.value);
-      parsingNft.value = false;
-    }
-  })
-
-  // Watch for isParsable becoming true after mount (e.g. bcmrRegistries loads async)
-  watch(isParsable, async (nowParsable) => {
-    if (nowParsable && !parseResult.value) {
-      const category = nftData.value.token!.category;
-      parsingNft.value = true;
-      parseResult.value = await store.parseNftCommitment(category, nftData.value);
-      parsingNft.value = false;
-    }
+  onMounted(() => {
+    appendBlockieIcon(category.value, `#${id.value}`);
   })
 
   watch(imageLoadFailed, async (failedToLoad) => {
     if(failedToLoad) {
       // waits for next tick, so the DOM updates and renders the genericTokenIcon div
       await nextTick();
-      const category = nftData.value.token!.category;
-      appendBlockieIcon(category, `#${id.value}`);
+      appendBlockieIcon(category.value, `#${id.value}`);
     }
   })
 
-  const qrDecode = (content: string) => {
-    destinationAddr.value = content;
-    parseAddrParams();
-  }
-
-  function parseAddrParams(){
-    if(!isBip21Uri(destinationAddr.value) || !destinationAddr.value.includes("?")) return;
-
-    // Parse BIP21 URIs with query params
-    try {
-      const parsed = parseBip21Uri(destinationAddr.value);
-      const category = (nftData.value.token as TokenI)?.category;
-
-      const validationError = getBip21ValidationError(parsed);
-      if (validationError) {
-        $q.notify({ message: validationError, icon: 'warning', color: "red" });
-        return;
-      }
-
-      // Check if c= is for a different token
-      if(parsed.otherParams?.c && parsed.otherParams.c !== category){
-        $q.notify({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
-        return;
-      }
-
-      // Set the address (without query params)
-      destinationAddr.value = parsed.address;
-    } catch {
-      // If parsing fails, leave the input as-is
-    }
-  }
-
-  const qrFilter = (content: string) => {
-    // Extract address from BIP21 URI if needed
-    let addressToCheck = content;
-    if(isBip21Uri(content) && content.includes("?")){
-      try {
-        const parsed = parseBip21Uri(content);
-        addressToCheck = parsed.address;
-      } catch {
-        // If parsing fails, try with original content
-      }
-    }
-    const decoded = decodeCashAddress(addressToCheck);
-    if (typeof decoded === "string" || decoded.prefix !== `${store.wallet.networkPrefix}`) {
-      return t('tokenItem.errors.notCashaddress');
-    }
-    return true;
-  }
   async function sendNft(){
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'))
-      const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
-      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
-      if(!supportsTokens ) throw new Error(t('tokenItem.errors.notTokenAddress'));
+      validateDestination({ requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
+      const nftInfo = nftData.value.token as TokenI;
       // confirm payment if setting is enabled
       if (settingsStore.confirmBeforeSending) {
-        const nftInfo = nftData.value.token as TokenI;
         const tokenSymbol = tokenMetaData.value?.token?.symbol ?? nftInfo.category.slice(0, 8)
         const truncatedAddr = `${destinationAddr.value.slice(0, 24)}...${destinationAddr.value.slice(-8)}`
-        const confirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('tokenItem.dialogs.confirmNftSend.title'),
-            message: t('tokenItem.dialogs.confirmNftSend.message', { symbol: tokenSymbol, address: truncatedAddr }),
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('tokenItem.dialogs.confirmButton'), color: 'primary', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const confirmed = await confirmDialog(
+          t('tokenItem.dialogs.confirmNftSend.title'),
+          t('tokenItem.dialogs.confirmNftSend.message', { symbol: tokenSymbol, address: truncatedAddr }),
+          t('tokenItem.dialogs.confirmButton')
+        )
         if (!confirmed) return
       }
 
-      const nftInfo = nftData.value.token as TokenI;
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
-
+      notifySending();
       const { txId } = await store.wallet.send([
         new TokenSendRequest({
           cashaddr: destinationAddr.value,
@@ -230,123 +127,11 @@
       if (nftName) {
         alertMessage = t('tokenItem.alerts.sentNftNamed', { name: nftName, address: destinationAddr.value });
       }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-      $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.transactionSent')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       destinationAddr.value = "";
       displaySendNft.value = false;
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
-      handleTransactionError(error)
-    } finally {
-      activeAction.value = null;
-    }
-  }
-  const isHex = (str:string) => /^[A-F0-9]+$/i.test(str);
-
-  async function mintNfts() {
-    if (activeAction.value) return;
-    const nftInfo = nftData.value.token as TokenI;
-    const category = nftInfo.category;
-    const tokenAddr = store.wallet.getTokenDepositAddress();
-
-    activeAction.value = 'minting';
-    try {
-      let recipientAddr = tokenAddr;
-      if(destinationAddr.value) {
-        const { address } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-          invalidAddress: t('tokenItem.errors.invalidAddress'),
-          wrongNetwork: t('tokenItem.errors.notCashaddress'),
-        });
-        destinationAddr.value = address;
-        recipientAddr = address;
-      }
-      if(!nftInfo) return;
-      if(mintQuantity.value == undefined) throw new Error(t('tokenItem.errors.invalidAmountNfts'));
-      const mintAmount = parseInt(mintQuantity.value);
-
-      if(mintMode.value === "collection" && startingNumberNFTs.value == undefined) {
-        throw new Error(t('tokenItem.errors.invalidStartingNumber'));
-      }
-      // single mode: validate commitment is valid hex
-      let nftCommitment = mintMode.value === "collection" ? "" : mintCommitment.value;
-      const validCommitment = (isHex(nftCommitment) || nftCommitment == "")
-      if(!validCommitment) throw new Error(t('tokenItem.errors.commitmentMustBeHex', { commitment: nftCommitment }));
-
-      if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
-      // construct array of TokenMintRequest
-      const arraySendrequests = [];
-      for (let i = 0; i < mintAmount; i++){
-        if(mintMode.value === "collection" && startingNumberNFTs.value){
-          const startingNumber = parseInt(startingNumberNFTs.value);
-          const nftNumber = startingNumber + i;
-          if(numberingUniqueNfts.value == "vm-numbers"){
-            const vmNumber = bigIntToVmNumber(BigInt(nftNumber));
-            nftCommitment = binToHex(vmNumber)
-          } else if(numberingUniqueNfts.value == "hex-numbers"){
-            nftCommitment = nftNumber.toString(16);
-            if(nftCommitment.length % 2 != 0) nftCommitment = `0${nftCommitment}`;
-          }
-        }
-        const mintRequest = new TokenMintRequest({
-          cashaddr: recipientAddr,
-          nft: {
-            commitment: nftCommitment,
-            capability: mintCapability.value,
-          },
-          value: 1000n,
-        })
-        arraySendrequests.push(mintRequest);
-      }
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
-      const { txId } = await store.wallet.tokenMint(category, arraySendrequests);
-      const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
-      const commitmentText = nftCommitment ? `with commitment ${nftCommitment}` : "";
-      let alertMessage = t('tokenItem.alerts.mintedNfts', { amount: mintAmount, tokenId: displayId });
-      if (mintAmount == 1) {
-        alertMessage = t('tokenItem.alerts.mintedNft', { tokenId: displayId, commitmentText });
-      }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.mintSuccessful')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // reset input fields
-      displayMintNfts.value = false;
-      mintCapability.value = "none";
-      mintCommitment.value = "";
-      mintQuantity.value = undefined;
-      startingNumberNFTs.value = undefined;
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
-    } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -358,29 +143,19 @@
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       const nftInfo = nftData.value.token as TokenI;
-      const category = nftInfo.category;
       const nftTypeString = nftInfo?.nft?.capability == 'minting' ? t('tokenItem.dialogs.burnNft.nftTypeMinting') : t('tokenItem.dialogs.burnNft.nftTypeRegular')
-      const confirmed = await new Promise<boolean>((resolve) => {
-        $q.dialog({
-          title: t('tokenItem.dialogs.burnNft.title'),
-          message: t('tokenItem.dialogs.burnNft.message', { nftType: nftTypeString }),
-          cancel: { flat: true, color: 'dark' },
-          ok: { label: t('tokenItem.dialogs.burnNft.burnButton'), color: 'red', textColor: 'white' },
-          persistent: true
-        }).onOk(() => resolve(true))
-          .onCancel(() => resolve(false))
-      })
+      const confirmed = await confirmDialog(
+        t('tokenItem.dialogs.burnNft.title'),
+        t('tokenItem.dialogs.burnNft.message', { nftType: nftTypeString }),
+        t('tokenItem.dialogs.burnNft.burnButton'),
+        'red'
+      )
       if (!confirmed) return
 
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.tokenBurn(
         {
-          category: category,
+          category: category.value,
           nft: {
             capability: nftInfo.nft!.capability,
             commitment: nftInfo.nft!.commitment,
@@ -388,39 +163,14 @@
         },
         "burn", // optional OP_RETURN message
       );
-      const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
+      const displayId = `${category.value.slice(0, 20)}...${category.value.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.burnedNft', { nftType: nftTypeString, tokenId: displayId });
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.burnSuccessful')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
-  }
-
-  function handleTransactionError(error: unknown){
-    const errorMessage = caughtErrorToString(error)
-    console.error(errorMessage)
-    $q.notify({
-      message: errorMessage,
-      icon: 'warning',
-      color: "red"
-    }) 
   }
 </script>
 
@@ -509,41 +259,7 @@
             <input @click="sendNft()" type="button" class="primaryButton" :value="activeAction === 'sending' ? t('tokenItem.sendNft.sendingButton') : t('tokenItem.sendNft.sendButton')" :disabled="activeAction !== null">
           </div>
         </div>
-        <div v-if="displayMintNfts" class="tokenAction">
-          <b>{{ t('tokenItem.mint.modeSingle') }}</b>: {{ t('tokenItem.mint.titleSingle') }} <br>
-          <b>{{ t('tokenItem.mint.modeCollection') }}</b>: {{ t('tokenItem.mint.titleCollection') }}
-          <div style="display: flex; gap: 10px; align-items: center; margin: 5px 0;">
-            <label>{{ t('tokenItem.mint.modeLabel') }}</label>
-            <select v-model="mintMode" style="max-width: 260px; padding: 4px 8px;">
-              <option value="single">{{ t('tokenItem.mint.modeSingle') }}</option>
-              <option value="collection">{{ t('tokenItem.mint.modeCollection') }}</option>
-            </select>
-          </div>
-
-          <div v-if="mintMode === 'collection'" style="display: flex; gap: 10px; align-items: center; margin-bottom: 5px;">
-            <label for="numbering" style="width: 80px;">{{ t('tokenItem.mint.numberingLabel') }}</label>
-            <select id="numbering" v-model="numberingUniqueNfts" style="max-width: 260px; padding: 4px 8px;">
-              <option value="vm-numbers">{{ t('tokenItem.mint.vmNumbers') }}</option>
-              <option value="hex-numbers">{{ t('tokenItem.mint.hexNumbers') }}</option>
-            </select>
-          </div>
-
-          <span class="grouped" style="align-items: center; margin-bottom: 5px;">
-            <input v-if="mintMode === 'single'" v-model="mintCommitment" :placeholder="t('tokenItem.mint.commitmentPlaceholder')">
-            <input v-if="mintMode === 'collection'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.collectionSizePlaceholder')">
-            <input v-if="mintMode === 'collection'" v-model="startingNumberNFTs" type="number" :placeholder="t('tokenItem.mint.startingNumberPlaceholder')">
-            <select v-model="mintCapability" style="max-width: 130px;">
-              <option value="none">{{ t('tokenItem.mint.capabilityImmutable') }}</option>
-              <option value="mutable">{{ t('tokenItem.mint.capabilityMutable') }}</option>
-              <option value="minting">{{ t('tokenItem.mint.capabilityMinting') }}</option>
-            </select>
-            <input v-if="mintMode === 'single'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.quantityPlaceholder')" style="max-width: 122px;">
-          </span>
-          <span class="grouped">
-            <input v-model="destinationAddr" @input="parseAddrParams()" :placeholder="t('tokenItem.mint.destinationPlaceholder')">
-            <input @click="mintNfts()" type="button" :value="activeAction === 'minting' ? t('tokenItem.mint.mintingButton') : t('tokenItem.mint.mintButton')" class="primaryButton" :disabled="activeAction !== null">
-          </span>
-        </div>
+        <nftMintForm v-if="displayMintNfts" :category="category" v-model:active-action="activeAction" @minted="displayMintNfts = false"/>
         <div v-if="displayBurnNft" class="tokenAction">
           <span v-if="nftData?.token?.nft?.capability == 'minting'">{{ t('tokenItem.burn.burnMintingDescription') }}</span>
           <span v-else>{{ t('tokenItem.burn.burnNftDescription') }}</span>

--- a/src/components/tokenItems/nftChild.vue
+++ b/src/components/tokenItems/nftChild.vue
@@ -104,17 +104,11 @@
     parseAddrParams();
   }
   const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
-  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
-    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
-    destinationAddr.value = address;
-    return address;
-  }
-
   async function sendNft(){
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
-      validateDestination({ requireTokenSupport: true });
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, { requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       const nftInfo = nftData.value.token as TokenI;

--- a/src/components/tokenItems/nftChild.vue
+++ b/src/components/tokenItems/nftChild.vue
@@ -8,8 +8,9 @@
   import type { BcmrTokenMetadata } from "src/interfaces/interfaces"
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { useTokenAddressInput, useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
-  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
+  import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
   import { appendBlockieIcon } from 'src/utils/blockieIcon'
   import { useI18n } from 'vue-i18n'
@@ -35,12 +36,12 @@
   const displayNftInfo = ref(false);
   const displayMintNfts = ref(false);
   const displayBurnNft = ref(false);
+  const destinationAddr = ref("");
+  const showQrCodeDialog = ref(false);
   const activeAction = ref<TokenActionType | null>(null);
 
   const category = computed(() => nftData.value.token!.category);
 
-  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
-    useTokenAddressInput(() => category.value);
   const { parseResult, parsingNft, isParsable, hasParyonUsdExtension } =
     useNftParsing(() => category.value, () => nftData.value);
 
@@ -91,6 +92,22 @@
     }
   })
 
+  function parseAddrParams(){
+    const parsed = parseTokenRecipientRequest(destinationAddr.value, category.value);
+    if(!parsed) return;
+    destinationAddr.value = parsed.address;
+  }
+  const qrDecode = (content: string) => {
+    destinationAddr.value = content;
+    parseAddrParams();
+  }
+  const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
+  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
+    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
+    destinationAddr.value = address;
+    return address;
+  }
+
   async function sendNft(){
     if (activeAction.value) return;
     activeAction.value = 'sending';
@@ -129,7 +146,7 @@
       }
       destinationAddr.value = "";
       displaySendNft.value = false;
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
       displayAndLogError(error)
     } finally {
@@ -165,7 +182,7 @@
       );
       const displayId = `${category.value.slice(0, 20)}...${category.value.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.burnedNft', { nftType: nftTypeString, tokenId: displayId });
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
       displayAndLogError(error)
     } finally {

--- a/src/components/tokenItems/nftChild.vue
+++ b/src/components/tokenItems/nftChild.vue
@@ -5,10 +5,10 @@
   import { TokenSendRequest, type TokenI } from "mainnet-js"
   import { type Utxo } from "mainnet-js"
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
-  import type { BcmrTokenMetadata } from "src/interfaces/interfaces"
+  import type { BcmrTokenMetadata, TokenActionType } from "src/interfaces/interfaces"
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { useNftCommitmentParsing } from 'src/utils/nftCommitmentParsing'
   import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
   import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
@@ -42,8 +42,10 @@
 
   const category = computed(() => nftData.value.token!.category);
 
-  const { parseResult, parsingNft, isParsable, hasParyonUsdExtension } =
-    useNftParsing(() => category.value, () => nftData.value);
+  // Keeps parsing state and parses the commitment on mount/when metadata becomes available.
+  const { parseResult, parsingNft, isParsable, hasParyonUsdExtension } = useNftCommitmentParsing(
+    () => category.value, () => nftData.value
+  );
 
   const nftMetadata = computed(() => {
     const commitment = nftData.value?.token?.nft?.commitment;

--- a/src/components/tokenItems/nftMintForm.vue
+++ b/src/components/tokenItems/nftMintForm.vue
@@ -3,8 +3,9 @@
   import { TokenMintRequest } from "mainnet-js"
   import { bigIntToVmNumber, binToHex } from "@bitauth/libauth"
   import { useStore } from 'src/stores/store'
-  import { useTokenAddressInput, type TokenActionType } from 'src/utils/tokenComposables'
-  import { notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import type { TokenActionType } from 'src/utils/tokenComposables'
+  import { parseTokenRecipientRequest, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
+  import { notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
   import { useI18n } from 'vue-i18n'
   const store = useStore()
@@ -25,8 +26,18 @@
   const mintCommitment = ref("");
   const mintQuantity = ref(undefined as string | undefined);
   const startingNumberNFTs = ref(undefined as string | undefined);
+  const destinationAddr = ref("");
 
-  const { destinationAddr, parseAddrParams, validateDestination } = useTokenAddressInput(() => props.category);
+  function parseAddrParams(){
+    const parsed = parseTokenRecipientRequest(destinationAddr.value, props.category);
+    if(!parsed) return;
+    destinationAddr.value = parsed.address;
+  }
+  function validateDestination(): string {
+    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix);
+    destinationAddr.value = address;
+    return address;
+  }
 
   const isHex = (str:string) => /^[A-F0-9]+$/i.test(str);
 
@@ -86,7 +97,7 @@
       mintQuantity.value = undefined;
       startingNumberNFTs.value = undefined;
       emit('minted');
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.mintSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.mintSuccessful'));
     } catch (error) {
       displayAndLogError(error)
     } finally {

--- a/src/components/tokenItems/nftMintForm.vue
+++ b/src/components/tokenItems/nftMintForm.vue
@@ -33,12 +33,6 @@
     if(!parsed) return;
     destinationAddr.value = parsed.address;
   }
-  function validateDestination(): string {
-    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix);
-    destinationAddr.value = address;
-    return address;
-  }
-
   const isHex = (str:string) => /^[A-F0-9]+$/i.test(str);
 
   async function mintNfts() {
@@ -46,7 +40,10 @@
     activeAction.value = 'minting';
     try {
       let recipientAddr = store.wallet.getTokenDepositAddress();
-      if(destinationAddr.value) recipientAddr = validateDestination();
+      if(destinationAddr.value) {
+        recipientAddr = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix);
+        destinationAddr.value = recipientAddr;
+      }
       if(mintQuantity.value == undefined) throw new Error(t('tokenItem.errors.invalidAmountNfts'));
       const mintAmount = parseInt(mintQuantity.value);
 

--- a/src/components/tokenItems/nftMintForm.vue
+++ b/src/components/tokenItems/nftMintForm.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { TokenMintRequest } from "mainnet-js"
+  import { bigIntToVmNumber, binToHex } from "@bitauth/libauth"
+  import { useStore } from 'src/stores/store'
+  import { useTokenAddressInput, type TokenActionType } from 'src/utils/tokenComposables'
+  import { notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { displayAndLogError } from 'src/utils/errorHandling'
+  import { useI18n } from 'vue-i18n'
+  const store = useStore()
+  const { t } = useI18n()
+
+  const props = defineProps<{
+    category: string,
+  }>()
+  const emit = defineEmits<{
+    minted: []
+  }>();
+  // shared with the host component so send/mint/burn actions can't run concurrently
+  const activeAction = defineModel<TokenActionType | null>('activeAction', { required: true })
+
+  const mintMode = ref<"single" | "collection">("single");
+  const mintCapability = ref<"none" | "mutable" | "minting">("none");
+  const numberingUniqueNfts = ref<"vm-numbers" | "hex-numbers">("vm-numbers");
+  const mintCommitment = ref("");
+  const mintQuantity = ref(undefined as string | undefined);
+  const startingNumberNFTs = ref(undefined as string | undefined);
+
+  const { destinationAddr, parseAddrParams, validateDestination } = useTokenAddressInput(() => props.category);
+
+  const isHex = (str:string) => /^[A-F0-9]+$/i.test(str);
+
+  async function mintNfts() {
+    if (activeAction.value) return;
+    activeAction.value = 'minting';
+    try {
+      let recipientAddr = store.wallet.getTokenDepositAddress();
+      if(destinationAddr.value) recipientAddr = validateDestination();
+      if(mintQuantity.value == undefined) throw new Error(t('tokenItem.errors.invalidAmountNfts'));
+      const mintAmount = parseInt(mintQuantity.value);
+
+      if(mintMode.value === "collection" && startingNumberNFTs.value == undefined) {
+        throw new Error(t('tokenItem.errors.invalidStartingNumber'));
+      }
+      // single mode: validate commitment is valid hex
+      let nftCommitment = mintMode.value === "collection" ? "" : mintCommitment.value;
+      const validCommitment = (isHex(nftCommitment) || nftCommitment == "")
+      if(!validCommitment) throw new Error(t('tokenItem.errors.commitmentMustBeHex', { commitment: nftCommitment }));
+
+      if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
+      // construct array of TokenMintRequest
+      const arraySendrequests = [];
+      for (let i = 0; i < mintAmount; i++){
+        if(mintMode.value === "collection" && startingNumberNFTs.value){
+          const startingNumber = parseInt(startingNumberNFTs.value);
+          const nftNumber = startingNumber + i;
+          if(numberingUniqueNfts.value == "vm-numbers"){
+            const vmNumber = bigIntToVmNumber(BigInt(nftNumber));
+            nftCommitment = binToHex(vmNumber)
+          } else if(numberingUniqueNfts.value == "hex-numbers"){
+            nftCommitment = nftNumber.toString(16);
+            if(nftCommitment.length % 2 != 0) nftCommitment = `0${nftCommitment}`;
+          }
+        }
+        const mintRequest = new TokenMintRequest({
+          cashaddr: recipientAddr,
+          nft: {
+            commitment: nftCommitment,
+            capability: mintCapability.value,
+          },
+          value: 1000n,
+        })
+        arraySendrequests.push(mintRequest);
+      }
+      notifySending();
+      const { txId } = await store.wallet.tokenMint(props.category, arraySendrequests);
+      const displayId = `${props.category.slice(0, 20)}...${props.category.slice(-8)}`;
+      const commitmentText = nftCommitment ? `with commitment ${nftCommitment}` : "";
+      let alertMessage = t('tokenItem.alerts.mintedNfts', { amount: mintAmount, tokenId: displayId });
+      if (mintAmount == 1) {
+        alertMessage = t('tokenItem.alerts.mintedNft', { tokenId: displayId, commitmentText });
+      }
+      // reset input fields
+      mintCapability.value = "none";
+      mintCommitment.value = "";
+      mintQuantity.value = undefined;
+      startingNumberNFTs.value = undefined;
+      emit('minted');
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.mintSuccessful'));
+    } catch (error) {
+      displayAndLogError(error)
+    } finally {
+      activeAction.value = null;
+    }
+  }
+</script>
+
+<template>
+  <div class="tokenAction">
+    <b>{{ t('tokenItem.mint.modeSingle') }}</b>: {{ t('tokenItem.mint.titleSingle') }} <br>
+    <b>{{ t('tokenItem.mint.modeCollection') }}</b>: {{ t('tokenItem.mint.titleCollection') }}
+    <div style="display: flex; gap: 10px; align-items: center; margin: 5px 0;">
+      <label>{{ t('tokenItem.mint.modeLabel') }}</label>
+      <select v-model="mintMode" style="max-width: 260px; padding: 4px 8px;">
+        <option value="single">{{ t('tokenItem.mint.modeSingle') }}</option>
+        <option value="collection">{{ t('tokenItem.mint.modeCollection') }}</option>
+      </select>
+    </div>
+
+    <div v-if="mintMode === 'collection'" style="display: flex; gap: 10px; align-items: center; margin-bottom: 5px;">
+      <label for="numbering" style="width: 80px;">{{ t('tokenItem.mint.numberingLabel') }}</label>
+      <select id="numbering" v-model="numberingUniqueNfts" style="max-width: 260px; padding: 4px 8px;">
+        <option value="vm-numbers">{{ t('tokenItem.mint.vmNumbers') }}</option>
+        <option value="hex-numbers">{{ t('tokenItem.mint.hexNumbers') }}</option>
+      </select>
+    </div>
+
+    <span class="grouped" style="align-items: center; margin-bottom: 5px;">
+      <input v-if="mintMode === 'single'" v-model="mintCommitment" :placeholder="t('tokenItem.mint.commitmentPlaceholder')">
+      <input v-if="mintMode === 'collection'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.collectionSizePlaceholder')">
+      <input v-if="mintMode === 'collection'" v-model="startingNumberNFTs" type="number" :placeholder="t('tokenItem.mint.startingNumberPlaceholder')">
+      <select v-model="mintCapability" style="max-width: 130px;">
+        <option value="none">{{ t('tokenItem.mint.capabilityImmutable') }}</option>
+        <option value="mutable">{{ t('tokenItem.mint.capabilityMutable') }}</option>
+        <option value="minting">{{ t('tokenItem.mint.capabilityMinting') }}</option>
+      </select>
+      <input v-if="mintMode === 'single'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.quantityPlaceholder')" style="max-width: 122px;">
+    </span>
+    <span class="grouped">
+      <input v-model="destinationAddr" @input="parseAddrParams()" :placeholder="t('tokenItem.mint.destinationPlaceholder')">
+      <input @click="mintNfts()" type="button" :value="activeAction === 'minting' ? t('tokenItem.mint.mintingButton') : t('tokenItem.mint.mintButton')" class="primaryButton" :disabled="activeAction !== null">
+    </span>
+  </div>
+</template>

--- a/src/components/tokenItems/nftMintForm.vue
+++ b/src/components/tokenItems/nftMintForm.vue
@@ -2,8 +2,8 @@
   import { ref } from 'vue';
   import { TokenMintRequest } from "mainnet-js"
   import { bigIntToVmNumber, binToHex } from "@bitauth/libauth"
+  import type { TokenActionType } from "src/interfaces/interfaces"
   import { useStore } from 'src/stores/store'
-  import type { TokenActionType } from 'src/utils/tokenComposables'
   import { parseTokenRecipientRequest, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
   import { notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'

--- a/src/components/tokenItems/tokenItemFT.vue
+++ b/src/components/tokenItems/tokenItemFT.vue
@@ -108,17 +108,12 @@
     parseAddrParams();
   }
   const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
-  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
-    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
-    destinationAddr.value = address;
-    return address;
-  }
   async function sendTokens(){
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
-      validateDestination({ requireTokenSupport: true });
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, { requireTokenSupport: true });
       if(!tokenSendAmount?.value) throw new Error(t('tokenItem.errors.noValidAmount'));
       const decimals = tokenMetaData.value?.token?.decimals ?? 0;
       const amountTokensInt = parseTokenAmountToBigInt(tokenSendAmount.value, decimals);
@@ -222,7 +217,7 @@
       const reservedSupply = parseTokenAmountToBigInt(reservedSupplyInput.value, decimals);
       if(reservedSupply > tokenData.value.amount) throw new Error(t('tokenItem.errors.insufficientBalance'));
       const category = tokenData.value.category;
-      validateDestination();
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix);
       const authTransfer = !reservedSupply? {
         cashaddr: destinationAddr.value,
         value: 1000n,

--- a/src/components/tokenItems/tokenItemFT.vue
+++ b/src/components/tokenItems/tokenItemFT.vue
@@ -3,11 +3,10 @@
   import { TokenSendRequest, convert } from "mainnet-js"
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
   import TokenIcon from '../general/TokenIcon.vue';
-  import type { TokenDataFT, BcmrTokenMetadata } from "src/interfaces/interfaces"
+  import type { TokenDataFT, BcmrTokenMetadata, TokenActionType } from "src/interfaces/interfaces"
   import { copyToClipboard, formatFiatAmount, sanitizeUrl, parseTokenAmountToBigInt } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import type { TokenActionType } from 'src/utils/tokenComposables'
   import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
   import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'

--- a/src/components/tokenItems/tokenItemFT.vue
+++ b/src/components/tokenItems/tokenItemFT.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
   import { ref, toRefs, computed, watch } from 'vue';
   import { TokenSendRequest, convert } from "mainnet-js"
-  import { decodeCashAddress } from "@bitauth/libauth"
-  import alertDialog from 'src/components/general/alertDialog.vue'
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
   import TokenIcon from '../general/TokenIcon.vue';
   import type { TokenDataFT, BcmrTokenMetadata } from "src/interfaces/interfaces"
-  import { copyToClipboard, formatFiatAmount, sanitizeUrl } from 'src/utils/utils';
-  import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
-  import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
+  import { copyToClipboard, formatFiatAmount, sanitizeUrl, parseTokenAmountToBigInt } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { caughtErrorToString } from 'src/utils/errorHandling'
+  import { useTokenAddressInput, type TokenActionType } from 'src/utils/tokenComposables'
+  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { displayAndLogError } from 'src/utils/errorHandling'
   import { calculateTokenFiatValue } from 'src/utils/cauldronApi'
-  import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
-  const $q = useQuasar()
   const store = useStore()
   const settingsStore = useSettingsStore()
   const { t } = useI18n()
@@ -33,14 +29,30 @@
   const displayAuthTransfer = ref(false);
   const displayTokenInfo = ref(false);
   const tokenSendAmount = ref("");
-  const destinationAddr = ref("");
   const burnAmountFTs = ref("");
   const reservedSupplyInput = ref("")
   const tokenMetaData = ref(undefined as (BcmrTokenMetadata | undefined));
-  const showQrCodeDialog = ref(false);
-  const activeAction = ref<'sending' | 'burning' | 'transferAuth' | null>(null);
+  const activeAction = ref<TokenActionType | null>(null);
 
   tokenMetaData.value = store.bcmrRegistries?.[tokenData.value.category];
+
+  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
+    useTokenAddressInput(() => tokenData.value.category, (otherParams) => {
+      // Auto-fill fungible token amount if the category param (c=) matches this token
+      // Supports both ft= (spec proposal) and f= (Paytaca) as the fungible amount param - they are equivalent
+      // Amount is in base token units, so apply the decimals from token metadata
+      // e.g. ft=10000 with 2 decimals = 100 tokens displayed to user
+      const categoryParam = otherParams.c;
+      const fungibleAmountParam = otherParams.ft ?? otherParams.f;
+      if(categoryParam === tokenData.value.category && fungibleAmountParam){
+        const decimals = tokenMetaData.value?.token?.decimals ?? 0;
+        const amountBaseUnits = parseInt(fungibleAmountParam, 10);
+        if (!isNaN(amountBaseUnits) && amountBaseUnits >= 0) {
+          const humanReadableAmount = decimals ? amountBaseUnits / (10 ** decimals) : amountBaseUnits;
+          tokenSendAmount.value = String(humanReadableAmount);
+        }
+      }
+    });
 
   const numberFormatter = new Intl.NumberFormat('en-US', {maximumFractionDigits: 8});
 
@@ -77,82 +89,6 @@
     { immediate: true }
   );
 
-  function checkValidTokenInput(numberInput: string, decimals: number){
-    // Validate the input format (no separting commas allowed here)
-    if (!/^\d*\.?\d*$/.test(numberInput)) throw new Error(t('tokenItem.errors.invalidNumberFormat'));
-
-    // Validate if the input can be converted to a number
-    const number = parseFloat(numberInput);
-    if (isNaN(number) || number <= 0) throw new Error(t('tokenItem.errors.enterValidAmount'));
-
-    // check number of decimal places
-    const decimalPart = numberInput.split('.')[1];
-    const decimalPlaces = decimalPart ? decimalPart.length : 0;
-    const validInput = decimalPlaces <= decimals
-    if(!validInput && !decimals) throw new Error(t('tokenItem.errors.noDecimalsAllowed'));
-    if(!validInput) throw new Error(t('tokenItem.errors.maxDecimalsAllowed', { decimals }));
-  }
-  const qrDecode = (content: string) => {
-    destinationAddr.value = content;
-    parseAddrParams();
-  }
-  
-  function parseAddrParams(){
-    if(!isBip21Uri(destinationAddr.value) || !destinationAddr.value.includes("?")) return;
-
-    // Parse BIP21 URIs with query params
-    try {
-      const parsed = parseBip21Uri(destinationAddr.value);
-
-      const validationError = getBip21ValidationError(parsed);
-      if (validationError) {
-        $q.notify({ message: validationError, icon: 'warning', color: "red" });
-        return;
-      }
-
-      // Check if c= is for a different token
-      if(parsed.otherParams?.c && parsed.otherParams.c !== tokenData.value.category){
-        $q.notify({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
-        return;
-      }
-
-      // Set the address (without query params)
-      destinationAddr.value = parsed.address;
-
-      // Auto-fill fungible token amount if c= matches this token
-      // Supports both ft= (spec proposal) and f= (Paytaca) - they are equivalent
-      // Amount is in base token units, so apply the decimals from token metadata
-      // e.g. ft=10000 with 2 decimals = 100 tokens displayed to user
-      const ftParam = parsed.otherParams?.ft ?? parsed.otherParams?.f;
-      if(parsed.otherParams?.c === tokenData.value.category && ftParam){
-        const decimals = tokenMetaData.value?.token?.decimals ?? 0;
-        const ftBaseUnits = parseInt(ftParam, 10);
-        if (!isNaN(ftBaseUnits) && ftBaseUnits >= 0) {
-          const humanReadable = decimals ? ftBaseUnits / (10 ** decimals) : ftBaseUnits;
-          tokenSendAmount.value = String(humanReadable);
-        }
-      }
-    } catch {
-      // If parsing fails, leave the input as-is
-    }
-  }
-  const qrFilter = (content: string) => {
-    // Extract address from BIP21 URI if needed
-    let addressToCheck = content;
-    if(isBip21Uri(content) && content.includes("?")){
-      try {
-        const parsed = parseBip21Uri(content);
-        addressToCheck = parsed.address;
-      } catch {
-        // If parsing fails, try with original content
-      }
-    }
-    const decoded = decodeCashAddress(addressToCheck);
-    if (typeof decoded === "string" || decoded.prefix !== `${store.wallet.networkPrefix}`) {
-      return t('tokenItem.errors.notCashaddress');
-    }
-    return true;
-  }
   // Fungible token specific functionality
   function toAmountDecimals(amount:bigint){
     let tokenAmountDecimals: bigint|number = amount;
@@ -172,33 +108,19 @@
     activeAction.value = 'sending';
     try{
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'));
+      validateDestination({ requireTokenSupport: true });
       if(!tokenSendAmount?.value) throw new Error(t('tokenItem.errors.noValidAmount'));
-      const sanitizedInput = tokenSendAmount.value.replace(/,/g, '');
       const decimals = tokenMetaData.value?.token?.decimals ?? 0;
-      checkValidTokenInput(sanitizedInput, decimals)
-      const amountTokensNumber = decimals ? +sanitizedInput * (10 ** decimals) : sanitizedInput;
-      const amountTokensInt = typeof amountTokensNumber == "number" ? BigInt(Math.round(amountTokensNumber)): BigInt(amountTokensNumber)
+      const amountTokensInt = parseTokenAmountToBigInt(tokenSendAmount.value, decimals);
       const amountSentFormatted = numberFormatter.format(toAmountDecimals(amountTokensInt))
       if(amountTokensInt > tokenData.value.amount) throw new Error(t('tokenItem.errors.insufficientBalance'));
-      const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
-      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
-      if(!supportsTokens ) throw new Error(t('tokenItem.errors.notTokenAddress'));
       if(tokenData.value?.authUtxo){
-        const authConfirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('tokenItem.dialogs.authWarning.title'),
-            message: t('tokenItem.dialogs.authWarning.message'),
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('tokenItem.dialogs.authWarning.continueButton'), color: 'red', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const authConfirmed = await confirmDialog(
+          t('tokenItem.dialogs.authWarning.title'),
+          t('tokenItem.dialogs.authWarning.message'),
+          t('tokenItem.dialogs.authWarning.continueButton'),
+          'red'
+        )
         if (!authConfirmed) return
       }
 
@@ -206,26 +128,16 @@
       if (settingsStore.confirmBeforeSending) {
         const tokenSymbol = tokenMetaData.value?.token?.symbol ?? tokenData.value.category.slice(0, 8)
         const truncatedAddr = `${destinationAddr.value.slice(0, 24)}...${destinationAddr.value.slice(-8)}`
-        const confirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('tokenItem.dialogs.confirmTokenSend.title'),
-            message: t('tokenItem.dialogs.confirmTokenSend.message', { amount: amountSentFormatted, symbol: tokenSymbol, address: truncatedAddr }),
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('tokenItem.dialogs.confirmButton'), color: 'primary', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const confirmed = await confirmDialog(
+          t('tokenItem.dialogs.confirmTokenSend.title'),
+          t('tokenItem.dialogs.confirmTokenSend.message', { amount: amountSentFormatted, symbol: tokenSymbol, address: truncatedAddr }),
+          t('tokenItem.dialogs.confirmButton')
+        )
         if (!confirmed) return
       }
 
       const category = tokenData.value.category;
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.send([
         new TokenSendRequest({
           cashaddr: destinationAddr.value,
@@ -238,27 +150,12 @@
       if (tokenMetaData.value?.token?.symbol) {
         alertMessage = t('tokenItem.alerts.sentTokens', { amount: amountSentFormatted, symbol: tokenMetaData.value.token.symbol, address: destinationAddr.value });
       }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.transactionSent')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       tokenSendAmount.value = "";
       destinationAddr.value = "";
       displaySendTokens.value = false;
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -269,34 +166,22 @@
     try {
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
       if(!burnAmountFTs?.value) throw new Error(t('tokenItem.errors.amountMustBeInteger'));
-      const sanitizedInput = burnAmountFTs.value.replace(/,/g, '');
       const decimals = tokenMetaData.value?.token?.decimals ?? 0;
-      checkValidTokenInput(sanitizedInput, decimals)
-      const amountTokensNumber = decimals ? +sanitizedInput * (10 ** decimals) : sanitizedInput;
-      const amountTokensInt = typeof amountTokensNumber == "number" ? BigInt(Math.round(amountTokensNumber)): BigInt(amountTokensNumber)
+      const amountTokensInt = parseTokenAmountToBigInt(burnAmountFTs.value, decimals);
       if(amountTokensInt > tokenData.value.amount) throw new Error(t('tokenItem.errors.insufficientBalance'));
       const category = tokenData.value.category;
 
       const amountBurnFormatted = numberFormatter.format(toAmountDecimals(amountTokensInt))
       const tokenSymbol = tokenMetaData.value?.token?.symbol ?? t('tokenItem.tokens')
-      const confirmed = await new Promise<boolean>((resolve) => {
-        $q.dialog({
-          title: t('tokenItem.dialogs.burnTokens.title'),
-          message: t('tokenItem.dialogs.burnTokens.message', { amount: amountBurnFormatted, symbol: tokenSymbol }),
-          cancel: { flat: true, color: 'dark' },
-          ok: { label: t('tokenItem.dialogs.burnTokens.burnButton'), color: 'red', textColor: 'white' },
-          persistent: true
-        }).onOk(() => resolve(true))
-          .onCancel(() => resolve(false))
-      })
+      const confirmed = await confirmDialog(
+        t('tokenItem.dialogs.burnTokens.title'),
+        t('tokenItem.dialogs.burnTokens.message', { amount: amountBurnFormatted, symbol: tokenSymbol }),
+        t('tokenItem.dialogs.burnTokens.burnButton'),
+        'red'
+      )
       if (!confirmed) return
 
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.tokenBurn({
           category: category,
           amount: amountTokensInt,
@@ -304,29 +189,15 @@
         "burn", // optional OP_RETURN message
       );
       const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
-      const amountBurntFormatted = numberFormatter.format(toAmountDecimals(amountTokensInt))
-      let alertMessage = t('tokenItem.alerts.burnedTokensNoSymbol', { amount: amountBurntFormatted, category: displayId });
+      let alertMessage = t('tokenItem.alerts.burnedTokensNoSymbol', { amount: amountBurnFormatted, category: displayId });
       if (tokenMetaData.value?.token?.symbol) {
-        alertMessage = t('tokenItem.alerts.burnedTokens', { amount: amountBurntFormatted, symbol: tokenMetaData.value.token.symbol });
+        alertMessage = t('tokenItem.alerts.burnedTokens', { amount: amountBurnFormatted, symbol: tokenMetaData.value.token.symbol });
       }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.burnSuccessful')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       burnAmountFTs.value = "";
       displayBurnFungibles.value = false;
-      // update utxo list
-      await store.updateWalletUtxos();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -334,22 +205,14 @@
   async function transferAuth() {
     if (activeAction.value) return;
     if(!tokenData.value?.authUtxo) return;
-    if(!reservedSupplyInput?.value) throw new Error(t('tokenItem.errors.reservedSupplyInvalid'));
-    const decimals = tokenMetaData.value?.token?.decimals ?? 0;
-    const sanitizedInput = reservedSupplyInput.value.replace(/,/g, '');
-    checkValidTokenInput(sanitizedInput, decimals)
-    const reservedSupplyNumber = decimals ? +sanitizedInput * (10 ** decimals) : sanitizedInput;
-    const reservedSupply = typeof reservedSupplyNumber == "number" ? BigInt(Math.round(reservedSupplyNumber)): BigInt(reservedSupplyNumber)
-    if(reservedSupply > tokenData.value.amount) throw new Error(t('tokenItem.errors.insufficientBalance'));
-    const category = tokenData.value.category;
     activeAction.value = 'transferAuth';
     try {
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'));
-      const { address } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
+      if(!reservedSupplyInput?.value) throw new Error(t('tokenItem.errors.reservedSupplyInvalid'));
+      const decimals = tokenMetaData.value?.token?.decimals ?? 0;
+      const reservedSupply = parseTokenAmountToBigInt(reservedSupplyInput.value, decimals);
+      if(reservedSupply > tokenData.value.amount) throw new Error(t('tokenItem.errors.insufficientBalance'));
+      const category = tokenData.value.category;
+      validateDestination();
       const authTransfer = !reservedSupply? {
         cashaddr: destinationAddr.value,
         value: 1000n,
@@ -368,48 +231,18 @@
         });
         outputs.push(changeOutput)
       }
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.send(outputs, { ensureUtxos: [tokenData.value.authUtxo] });
       const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.transferredAuth', { category: displayId, address: destinationAddr.value });
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.authTransferSuccessful')
-      })
       displayAuthTransfer.value = false;
       destinationAddr.value = "";
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
     } catch (error) {
-      handleTransactionError(error);
+      displayAndLogError(error);
     } finally {
       activeAction.value = null;
     }
-  }
-
-  function handleTransactionError(error: unknown){
-    const errorMessage = caughtErrorToString(error);
-    console.error(errorMessage)
-    $q.notify({
-      message: errorMessage,
-      icon: 'warning',
-      color: "red"
-    }) 
   }
 </script>
 

--- a/src/components/tokenItems/tokenItemFT.vue
+++ b/src/components/tokenItems/tokenItemFT.vue
@@ -7,8 +7,9 @@
   import { copyToClipboard, formatFiatAmount, sanitizeUrl, parseTokenAmountToBigInt } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { useTokenAddressInput, type TokenActionType } from 'src/utils/tokenComposables'
-  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import type { TokenActionType } from 'src/utils/tokenComposables'
+  import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
+  import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
   import { calculateTokenFiatValue } from 'src/utils/cauldronApi'
   import { useI18n } from 'vue-i18n'
@@ -29,30 +30,14 @@
   const displayAuthTransfer = ref(false);
   const displayTokenInfo = ref(false);
   const tokenSendAmount = ref("");
+  const destinationAddr = ref("");
+  const showQrCodeDialog = ref(false);
   const burnAmountFTs = ref("");
   const reservedSupplyInput = ref("")
   const tokenMetaData = ref(undefined as (BcmrTokenMetadata | undefined));
   const activeAction = ref<TokenActionType | null>(null);
 
   tokenMetaData.value = store.bcmrRegistries?.[tokenData.value.category];
-
-  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
-    useTokenAddressInput(() => tokenData.value.category, (otherParams) => {
-      // Auto-fill fungible token amount if the category param (c=) matches this token
-      // Supports both ft= (spec proposal) and f= (Paytaca) as the fungible amount param - they are equivalent
-      // Amount is in base token units, so apply the decimals from token metadata
-      // e.g. ft=10000 with 2 decimals = 100 tokens displayed to user
-      const categoryParam = otherParams.c;
-      const fungibleAmountParam = otherParams.ft ?? otherParams.f;
-      if(categoryParam === tokenData.value.category && fungibleAmountParam){
-        const decimals = tokenMetaData.value?.token?.decimals ?? 0;
-        const amountBaseUnits = parseInt(fungibleAmountParam, 10);
-        if (!isNaN(amountBaseUnits) && amountBaseUnits >= 0) {
-          const humanReadableAmount = decimals ? amountBaseUnits / (10 ** decimals) : amountBaseUnits;
-          tokenSendAmount.value = String(humanReadableAmount);
-        }
-      }
-    });
 
   const numberFormatter = new Intl.NumberFormat('en-US', {maximumFractionDigits: 8});
 
@@ -102,6 +87,32 @@
     const amountTokens = decimals ? Number(tokenData.value.amount) / (10 ** decimals) : tokenData.value.amount;
     const targetState = tokenSend? tokenSendAmount : burnAmountFTs;
     targetState.value = numberFormatter.format(amountTokens);
+  }
+  function parseAddrParams(){
+    const parsed = parseTokenRecipientRequest(destinationAddr.value, tokenData.value.category);
+    if(!parsed) return;
+    destinationAddr.value = parsed.address;
+
+    // Auto-fill fungible token amount from token payment requests.
+    const fungibleAmountParam = parsed.otherParams?.ft ?? parsed.otherParams?.f;
+    if(parsed.otherParams?.c === tokenData.value.category && fungibleAmountParam){
+      const decimals = tokenMetaData.value?.token?.decimals ?? 0;
+      const amountBaseUnits = parseInt(fungibleAmountParam, 10);
+      if (!isNaN(amountBaseUnits) && amountBaseUnits >= 0) {
+        const humanReadableAmount = decimals ? amountBaseUnits / (10 ** decimals) : amountBaseUnits;
+        tokenSendAmount.value = String(humanReadableAmount);
+      }
+    }
+  }
+  const qrDecode = (content: string) => {
+    destinationAddr.value = content;
+    parseAddrParams();
+  }
+  const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
+  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
+    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
+    destinationAddr.value = address;
+    return address;
   }
   async function sendTokens(){
     if (activeAction.value) return;
@@ -153,7 +164,7 @@
       tokenSendAmount.value = "";
       destinationAddr.value = "";
       displaySendTokens.value = false;
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
       displayAndLogError(error)
     } finally {
@@ -195,7 +206,7 @@
       }
       burnAmountFTs.value = "";
       displayBurnFungibles.value = false;
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
       displayAndLogError(error)
     } finally {
@@ -237,7 +248,7 @@
       const alertMessage = t('tokenItem.alerts.transferredAuth', { category: displayId, address: destinationAddr.value });
       displayAuthTransfer.value = false;
       destinationAddr.value = "";
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
     } catch (error) {
       displayAndLogError(error);
     } finally {

--- a/src/components/tokenItems/tokenItemNFT.vue
+++ b/src/components/tokenItems/tokenItemNFT.vue
@@ -155,11 +155,6 @@
     parseAddrParams();
   }
   const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
-  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
-    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
-    destinationAddr.value = address;
-    return address;
-  }
   
   // NFT Group specific functionality
   async function sendBatchNfts(){
@@ -167,7 +162,7 @@
     activeAction.value = 'sending';
     try{
       if(selectedNftCount.value === 0) throw new Error(t('tokenItem.errors.noNftsSelected'))
-      validateDestination({ requireTokenSupport: true });
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, { requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       const category = tokenData.value.category;
@@ -229,7 +224,7 @@
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
-      validateDestination({ requireTokenSupport: true });
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, { requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       // confirm payment if setting is enabled
@@ -315,7 +310,7 @@
     const authNft = tokenData.value.authUtxo?.token;
     activeAction.value = 'transferAuth';
     try {
-      validateDestination();
+      destinationAddr.value = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix);
       const authTransfer: SendRequest = {
         cashaddr: destinationAddr.value,
         value: 1000n,

--- a/src/components/tokenItems/tokenItemNFT.vue
+++ b/src/components/tokenItems/tokenItemNFT.vue
@@ -9,8 +9,9 @@
   import { copyToClipboard, sanitizeUrl } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { useTokenAddressInput, useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
-  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
+  import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
   import { appendBlockieIcon } from 'src/utils/blockieIcon'
   import { useI18n } from 'vue-i18n'
@@ -35,6 +36,8 @@
   const displayTokenInfo = ref(false);
   const displayChildNfts = ref(false);
   const loadingChildNftMetadata = ref(false);
+  const destinationAddr = ref("");
+  const showQrCodeDialog = ref(false);
   const tokenMetaData = ref(undefined as (BcmrTokenMetadata | undefined));
   // Local state for batch NFT selection - keyed by "txid:vout"
   const selectedNfts = ref(new Set<string>());
@@ -47,8 +50,6 @@
 
   const isSingleNft = computed(() => tokenData.value.nfts?.length == 1);
 
-  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
-    useTokenAddressInput(() => tokenData.value.category);
   // Only parse the commitment when this category holds a single NFT (child NFTs parse their own)
   const { parseResult, parsingNft, hasParyonUsdExtension } =
     useNftParsing(() => tokenData.value.category, () => tokenData.value.nfts?.[0], () => isSingleNft.value);
@@ -139,6 +140,22 @@
     }
     displayChildNfts.value = !displayChildNfts.value;
   }
+
+  function parseAddrParams(){
+    const parsed = parseTokenRecipientRequest(destinationAddr.value, tokenData.value.category);
+    if(!parsed) return;
+    destinationAddr.value = parsed.address;
+  }
+  const qrDecode = (content: string) => {
+    destinationAddr.value = content;
+    parseAddrParams();
+  }
+  const qrFilter = (content: string) => getCashAddressScanError(content, store.wallet.networkPrefix) ?? true;
+  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
+    const address = validateTokenRecipientAddress(destinationAddr.value, store.wallet.networkPrefix, opts);
+    destinationAddr.value = address;
+    return address;
+  }
   
   // NFT Group specific functionality
   async function sendBatchNfts(){
@@ -196,7 +213,7 @@
       destinationAddr.value = "";
       displayBatchTransfer.value = false;
       clearSelection();
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
       displayAndLogError(error)
     } finally {
@@ -243,7 +260,7 @@
       }
       destinationAddr.value = "";
       displaySendNft.value = false;
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
       displayAndLogError(error)
     } finally {
@@ -280,7 +297,7 @@
       );
       const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.burnedNft', { nftType: nftTypeString, tokenId: displayId });
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
       displayAndLogError(error)
     } finally {
@@ -313,7 +330,7 @@
       const alertMessage = t('tokenItem.alerts.transferredAuth', { category: displayId, address: destinationAddr.value });
       displayAuthTransfer.value = false;
       destinationAddr.value = "";
-      await showTransactionResult(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
+      await handleTransactionBroadcastSuccess(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
     } catch (error) {
       displayAndLogError(error)
     } finally {

--- a/src/components/tokenItems/tokenItemNFT.vue
+++ b/src/components/tokenItems/tokenItemNFT.vue
@@ -5,11 +5,11 @@
   import nftMintForm from './nftMintForm.vue'
   import { TokenSendRequest, type SendRequest, type TokenI } from "mainnet-js"
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
-  import type { TokenDataNFT, BcmrTokenMetadata } from "src/interfaces/interfaces"
+  import type { TokenDataNFT, BcmrTokenMetadata, TokenActionType } from "src/interfaces/interfaces"
   import { copyToClipboard, sanitizeUrl } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import { useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { useNftCommitmentParsing } from 'src/utils/nftCommitmentParsing'
   import { parseTokenRecipientRequest, getCashAddressScanError, validateTokenRecipientAddress } from 'src/utils/tokenRecipientUtils'
   import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import { displayAndLogError } from 'src/utils/errorHandling'
@@ -49,10 +49,14 @@
   tokenMetaData.value = store.bcmrRegistries?.[tokenData.value.category] ?? undefined;
 
   const isSingleNft = computed(() => tokenData.value.nfts?.length == 1);
-
+  
   // Only parse the commitment when this category holds a single NFT (child NFTs parse their own)
-  const { parseResult, parsingNft, hasParyonUsdExtension } =
-    useNftParsing(() => tokenData.value.category, () => tokenData.value.nfts?.[0], () => isSingleNft.value);
+  const shouldParseNftCommitment = () => isSingleNft.value;
+  // Keeps parsing state and parses the commitment on mount/when metadata becomes available.
+  const { parseResult, parsingNft, hasParyonUsdExtension } = useNftCommitmentParsing(
+    () => tokenData.value.category, () => tokenData.value.nfts?.[0], shouldParseNftCommitment
+  );
+  
   const nftMetadata = computed(() => {
     if(!isSingleNft.value) return
     const nftData = tokenData.value.nfts?.[0];

--- a/src/components/tokenItems/tokenItemNFT.vue
+++ b/src/components/tokenItems/tokenItemNFT.vue
@@ -2,22 +2,18 @@
   import { ref, onMounted, toRefs, computed, watch, nextTick } from 'vue';
   import dialogNftIcon from './dialogNftIcon.vue'
   import nftChild from './nftChild.vue'
-  import { TokenSendRequest, TokenMintRequest, type SendRequest, type TokenI } from "mainnet-js"
-  import { bigIntToVmNumber, binToHex, decodeCashAddress } from "@bitauth/libauth"
-  import alertDialog from 'src/components/general/alertDialog.vue'
+  import nftMintForm from './nftMintForm.vue'
+  import { TokenSendRequest, type SendRequest, type TokenI } from "mainnet-js"
   import QrCodeDialog from '../qr/qrCodeScanDialog.vue';
   import type { TokenDataNFT, BcmrTokenMetadata } from "src/interfaces/interfaces"
   import { copyToClipboard, sanitizeUrl } from 'src/utils/utils';
-  import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
-  import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
-  import type { ParseResult } from 'src/parsing/nftParsing'
-  import { caughtErrorToString } from 'src/utils/errorHandling'
+  import { useTokenAddressInput, useNftParsing, type TokenActionType } from 'src/utils/tokenComposables'
+  import { confirmDialog, notifySending, showTransactionResult } from 'src/utils/txHelpers'
+  import { displayAndLogError } from 'src/utils/errorHandling'
   import { appendBlockieIcon } from 'src/utils/blockieIcon'
-  import { useQuasar } from 'quasar'
   import { useI18n } from 'vue-i18n'
-  const $q = useQuasar()
   const store = useStore()
   const settingsStore = useSettingsStore()
   const { t } = useI18n()
@@ -39,35 +35,23 @@
   const displayTokenInfo = ref(false);
   const displayChildNfts = ref(false);
   const loadingChildNftMetadata = ref(false);
-  const destinationAddr = ref("");
   const tokenMetaData = ref(undefined as (BcmrTokenMetadata | undefined));
-  const mintMode = ref<"single" | "collection">("single");
-  const mintCapability = ref<"none" | "mutable" | "minting">("none");
-  const numberingUniqueNfts = ref<"vm-numbers" | "hex-numbers">("vm-numbers");
-  const mintCommitment = ref("");
-  const mintQuantity = ref(undefined as string | undefined);
-  const startingNumberNFTs = ref(undefined as string | undefined);
-  const showQrCodeDialog = ref(false);
   // Local state for batch NFT selection - keyed by "txid:vout"
   const selectedNfts = ref(new Set<string>());
-  const activeAction = ref<'sending' | 'minting' | 'burning' | 'transferAuth' | null>(null);
+  const activeAction = ref<TokenActionType | null>(null);
   const imageLoadFailed = ref(false);
-  const parseResult = ref(undefined as ParseResult | undefined);
-  const parsingNft = ref(false);
-
-  const hasParyonUsdExtension = computed(() => {
-    const ext = store.bcmrRegistries?.[tokenData.value.category]?.extensions;
-    return Boolean(ext?.paryonusd ?? ext?.pusd);
-  });
-  const isParsable = computed(() =>
-    store.bcmrRegistries?.[tokenData.value.category]?.nft_type === 'parsable'
-  );
 
   let fetchedMetadataChildren = false
 
   tokenMetaData.value = store.bcmrRegistries?.[tokenData.value.category] ?? undefined;
 
   const isSingleNft = computed(() => tokenData.value.nfts?.length == 1);
+
+  const { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination } =
+    useTokenAddressInput(() => tokenData.value.category);
+  // Only parse the commitment when this category holds a single NFT (child NFTs parse their own)
+  const { parseResult, parsingNft, hasParyonUsdExtension } =
+    useNftParsing(() => tokenData.value.category, () => tokenData.value.nfts?.[0], () => isSingleNft.value);
   const nftMetadata = computed(() => {
     if(!isSingleNft.value) return
     const nftData = tokenData.value.nfts?.[0];
@@ -133,29 +117,8 @@
     selectedNfts.value = new Set(allKeys);
   }
 
-  onMounted(async () => {
+  onMounted(() => {
     appendBlockieIcon(tokenData.value.category, `#id${tokenData.value.category.slice(0, 10)}nft`);
-    // Parse NFT commitment if this is a parsable single NFT
-    if (isSingleNft.value && isParsable.value) {
-      const nftUtxo = tokenData.value.nfts?.[0];
-      if (nftUtxo) {
-        parsingNft.value = true;
-        parseResult.value = await store.parseNftCommitment(tokenData.value.category, nftUtxo);
-        parsingNft.value = false;
-      }
-    }
-  })
-
-  // Watch for isParsable becoming true after mount (e.g. bcmrRegistries loads async)
-  watch(isParsable, async (nowParsable) => {
-    if (nowParsable && isSingleNft.value && !parseResult.value) {
-      const nftUtxo = tokenData.value.nfts?.[0];
-      if (nftUtxo) {
-        parsingNft.value = true;
-        parseResult.value = await store.parseNftCommitment(tokenData.value.category, nftUtxo);
-        parsingNft.value = false;
-      }
-    }
   })
 
   watch(imageLoadFailed, async (failedToLoad) => {
@@ -177,67 +140,13 @@
     displayChildNfts.value = !displayChildNfts.value;
   }
   
-  const qrDecode = (content: string) => {
-    destinationAddr.value = content;
-    parseAddrParams();
-  }
-  
-  function parseAddrParams(){
-    if(!isBip21Uri(destinationAddr.value) || !destinationAddr.value.includes("?")) return;
-
-    // Parse BIP21 URIs with query params
-    try {
-      const parsed = parseBip21Uri(destinationAddr.value);
-
-      const validationError = getBip21ValidationError(parsed);
-      if (validationError) {
-        $q.notify({ message: validationError, icon: 'warning', color: "red" });
-        return;
-      }
-
-      // Check if c= is for a different token
-      if(parsed.otherParams?.c && parsed.otherParams.c !== tokenData.value.category){
-        $q.notify({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
-        return;
-      }
-
-      // Set the address (without query params)
-      destinationAddr.value = parsed.address;
-    } catch {
-      // If parsing fails, leave the input as-is
-    }
-  }
-  const qrFilter = (content: string) => {
-    // Extract address from BIP21 URI if needed
-    let addressToCheck = content;
-    if(isBip21Uri(content) && content.includes("?")){
-      try {
-        const parsed = parseBip21Uri(content);
-        addressToCheck = parsed.address;
-      } catch {
-        // If parsing fails, try with original content
-      }
-    }
-    const decoded = decodeCashAddress(addressToCheck);
-    if (typeof decoded === "string" || decoded.prefix !== `${store.wallet.networkPrefix}`) {
-      return t('tokenItem.errors.notCashaddress');
-    }
-    return true;
-  }
   // NFT Group specific functionality
   async function sendBatchNfts(){
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
       if(selectedNftCount.value === 0) throw new Error(t('tokenItem.errors.noNftsSelected'))
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'))
-      const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
-      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
-      if(!supportsTokens ) throw new Error(t('tokenItem.errors.notTokenAddress'));
+      validateDestination({ requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       const category = tokenData.value.category;
@@ -248,16 +157,11 @@
       if (settingsStore.confirmBeforeSending) {
         const tokenSymbol = tokenMetaData.value?.token?.symbol ?? category.slice(0, 8)
         const truncatedAddr = `${destinationAddr.value.slice(0, 24)}...${destinationAddr.value.slice(-8)}`
-        const confirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('tokenItem.dialogs.confirmNftTransfer.title'),
-            message: t('tokenItem.dialogs.confirmNftTransfer.message', { prefix: isAllSelected ? 'all ' : '', count: nftCount, symbol: tokenSymbol, address: truncatedAddr }),
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('tokenItem.dialogs.confirmButton'), color: 'primary', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const confirmed = await confirmDialog(
+          t('tokenItem.dialogs.confirmNftTransfer.title'),
+          t('tokenItem.dialogs.confirmNftTransfer.message', { prefix: isAllSelected ? 'all ' : '', count: nftCount, symbol: tokenSymbol, address: truncatedAddr }),
+          t('tokenItem.dialogs.confirmButton')
+        )
         if (!confirmed) return
       }
 
@@ -278,12 +182,7 @@
           },
         }))
       })
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.send(outputArray);
       const nftName = tokenName.value;
       let alertMessage = t('tokenItem.alerts.sentNfts', { count: nftCount, tokenId: category, address: destinationAddr.value });
@@ -294,27 +193,12 @@
       } else if (nftName) {
         alertMessage = t('tokenItem.alerts.sentNftsNamed', { count: nftCount, name: nftName, address: destinationAddr.value });
       }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-      $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.transactionSent')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
       destinationAddr.value = "";
       displayBatchTransfer.value = false;
       clearSelection();
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -324,41 +208,24 @@
     if (activeAction.value) return;
     activeAction.value = 'sending';
     try{
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'))
-      const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
-      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
-      if(!supportsTokens) throw new Error(t('tokenItem.errors.notTokenAddress'));
+      validateDestination({ requireTokenSupport: true });
       if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
 
       // confirm payment if setting is enabled
       if (settingsStore.confirmBeforeSending) {
         const tokenSymbol = tokenMetaData.value?.token?.symbol ?? tokenData.value.category.slice(0, 8)
         const truncatedAddr = `${destinationAddr.value.slice(0, 24)}...${destinationAddr.value.slice(-8)}`
-        const confirmed = await new Promise<boolean>((resolve) => {
-          $q.dialog({
-            title: t('tokenItem.dialogs.confirmNftSend.title'),
-            message: t('tokenItem.dialogs.confirmNftSend.message', { symbol: tokenSymbol, address: truncatedAddr }),
-            cancel: { flat: true, color: 'dark' },
-            ok: { label: t('tokenItem.dialogs.confirmButton'), color: 'primary', textColor: 'white' },
-            persistent: true
-          }).onOk(() => resolve(true))
-            .onCancel(() => resolve(false))
-        })
+        const confirmed = await confirmDialog(
+          t('tokenItem.dialogs.confirmNftSend.title'),
+          t('tokenItem.dialogs.confirmNftSend.message', { symbol: tokenSymbol, address: truncatedAddr }),
+          t('tokenItem.dialogs.confirmButton')
+        )
         if (!confirmed) return
       }
 
       const category = tokenData.value.category;
       const nftInfo = tokenData.value.nfts?.[0]?.token as TokenI;
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.send([
         new TokenSendRequest({
           cashaddr: destinationAddr.value,
@@ -374,123 +241,11 @@
       if (nftName) {
         alertMessage = t('tokenItem.alerts.sentNftNamed', { name: nftName, address: destinationAddr.value });
       }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-      $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.transactionSent')
-      })
-      console.log(alertMessage)
-      console.log(`${store.explorerUrl}/${txId}`);
       destinationAddr.value = "";
       displaySendNft.value = false;
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.transactionSent'));
     }catch(error){
-      handleTransactionError(error)
-    } finally {
-      activeAction.value = null;
-    }
-  }
-  const isHex = (str:string) => /^[A-F0-9]+$/i.test(str);
-
-  async function mintNfts() {
-    if (activeAction.value) return;
-    const category = tokenData.value.category;
-    const nftInfo = tokenData.value.nfts?.[0]?.token as TokenI;
-    const tokenAddr = store.wallet.getTokenDepositAddress();
-
-    activeAction.value = 'minting';
-    try {
-      let recipientAddr = tokenAddr;
-      if(destinationAddr.value) {
-        const { address } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-          invalidAddress: t('tokenItem.errors.invalidAddress'),
-          wrongNetwork: t('tokenItem.errors.notCashaddress'),
-        });
-        destinationAddr.value = address;
-        recipientAddr = address;
-      }
-      if(!nftInfo) return;
-      if(mintQuantity.value == undefined) throw new Error(t('tokenItem.errors.invalidAmountNfts'));
-      const mintAmount = parseInt(mintQuantity.value);
-
-      if(mintMode.value === "collection" && startingNumberNFTs.value == undefined) {
-        throw new Error(t('tokenItem.errors.invalidStartingNumber'));
-      }
-      // single mode: validate commitment is valid hex
-      let nftCommitment = mintMode.value === "collection" ? "" : mintCommitment.value;
-      const validCommitment = (isHex(nftCommitment) || nftCommitment == "")
-      if(!validCommitment) throw new Error(t('tokenItem.errors.commitmentMustBeHex', { commitment: nftCommitment }));
-
-      if((store.balance ?? 0n) < 550n) throw new Error(t('tokenItem.errors.needBchForFee'));
-      // construct array of TokenMintRequest
-      const arraySendrequests = [];
-      for (let i = 0; i < mintAmount; i++){
-        if(mintMode.value === "collection" && startingNumberNFTs.value){
-          const startingNumber = parseInt(startingNumberNFTs.value);
-          const nftNumber = startingNumber + i;
-          if(numberingUniqueNfts.value == "vm-numbers"){
-            const vmNumber = bigIntToVmNumber(BigInt(nftNumber));
-            nftCommitment = binToHex(vmNumber)
-          } else if(numberingUniqueNfts.value == "hex-numbers"){
-            nftCommitment = nftNumber.toString(16);
-            if(nftCommitment.length % 2 != 0) nftCommitment = `0${nftCommitment}`;
-          }
-        }
-        const mintRequest = new TokenMintRequest({
-          cashaddr: recipientAddr,
-          nft: {
-            commitment: nftCommitment,
-            capability: mintCapability.value,
-          },
-          value: 1000n,
-        })
-        arraySendrequests.push(mintRequest);
-      }
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
-      const { txId } = await store.wallet.tokenMint(category, arraySendrequests);
-      const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
-      const commitmentText = nftCommitment ? `with commitment ${nftCommitment}` : "";
-      let alertMessage = t('tokenItem.alerts.mintedNfts', { amount: mintAmount, tokenId: displayId });
-      if (mintAmount == 1) {
-        alertMessage = t('tokenItem.alerts.mintedNft', { tokenId: displayId, commitmentText });
-      }
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.mintSuccessful')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // reset input fields
-      displayMintNfts.value = false;
-      mintCapability.value = "none";
-      mintCommitment.value = "";
-      mintQuantity.value = undefined;
-      startingNumberNFTs.value = undefined;
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
-    } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -504,24 +259,15 @@
       const category = tokenData.value.category;
       const nftInfo = tokenData.value.nfts[0]?.token as TokenI;
       const nftTypeString = nftInfo?.nft?.capability == 'minting' ? t('tokenItem.dialogs.burnNft.nftTypeMinting') : t('tokenItem.dialogs.burnNft.nftTypeRegular')
-      const confirmed = await new Promise<boolean>((resolve) => {
-        $q.dialog({
-          title: t('tokenItem.dialogs.burnNft.title'),
-          message: t('tokenItem.dialogs.burnNft.message', { nftType: nftTypeString }),
-          cancel: { flat: true, color: 'dark' },
-          ok: { label: t('tokenItem.dialogs.burnNft.burnButton'), color: 'red', textColor: 'white' },
-          persistent: true
-        }).onOk(() => resolve(true))
-          .onCancel(() => resolve(false))
-      })
+      const confirmed = await confirmDialog(
+        t('tokenItem.dialogs.burnNft.title'),
+        t('tokenItem.dialogs.burnNft.message', { nftType: nftTypeString }),
+        t('tokenItem.dialogs.burnNft.burnButton'),
+        'red'
+      )
       if (!confirmed) return
 
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.tokenBurn(
         {
           category: category,
@@ -534,24 +280,9 @@
       );
       const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.burnedNft', { nftType: nftTypeString, tokenId: displayId });
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.burnSuccessful')
-      })
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.burnSuccessful'));
     } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
@@ -563,12 +294,7 @@
     const authNft = tokenData.value.authUtxo?.token;
     activeAction.value = 'transferAuth';
     try {
-      if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'));
-      const { address } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-        invalidAddress: t('tokenItem.errors.invalidAddress'),
-        wrongNetwork: t('tokenItem.errors.notCashaddress'),
-      });
-      destinationAddr.value = address;
+      validateDestination();
       const authTransfer: SendRequest = {
         cashaddr: destinationAddr.value,
         value: 1000n,
@@ -581,48 +307,18 @@
           capability: authNft!.nft!.capability
         },
       });
-      $q.notify({
-        spinner: true,
-        message: t('common.status.sending'),
-        color: 'grey-5',
-        timeout: 1000
-      })
+      notifySending();
       const { txId } = await store.wallet.send([authTransfer,changeOutputNft], { ensureUtxos: [tokenData.value.authUtxo] });
       const displayId = `${category.slice(0, 20)}...${category.slice(-8)}`;
       const alertMessage = t('tokenItem.alerts.transferredAuth', { category: displayId, address: destinationAddr.value });
-      $q.dialog({
-        component: alertDialog,
-        componentProps: {
-          alertInfo: { message: alertMessage, txid: txId }
-        }
-      })
-       $q.notify({
-        type: 'positive',
-        message: t('tokenItem.success.authTransferSuccessful')
-      })
       displayAuthTransfer.value = false;
       destinationAddr.value = "";
-      console.log(alertMessage);
-      console.log(`${store.explorerUrl}/${txId}`);
-      // update utxo list
-      await store.updateWalletUtxos();
-      // update wallet history as fire-and-forget promise
-      void store.updateWalletHistory();
+      await showTransactionResult(alertMessage, txId, t('tokenItem.success.authTransferSuccessful'));
     } catch (error) {
-      handleTransactionError(error)
+      displayAndLogError(error)
     } finally {
       activeAction.value = null;
     }
-  }
-
-  function handleTransactionError(error: unknown){
-    const errorMessage = caughtErrorToString(error)
-    console.error(errorMessage)
-    $q.notify({
-      message: errorMessage,
-      icon: 'warning',
-      color: "red"
-    }) 
   }
 </script>
 
@@ -787,41 +483,7 @@
             <input @click="sendBatchNfts()" type="button" class="primaryButton" :value="activeAction === 'sending' ? t('tokenItem.batchTransfer.transferringButton') : t('tokenItem.batchTransfer.transferButton')" :disabled="activeAction !== null">
           </div>
         </div>
-        <div v-if="displayMintNfts" class="tokenAction">
-          <b>{{ t('tokenItem.mint.modeSingle') }}</b>: {{ t('tokenItem.mint.titleSingle') }} <br>
-          <b>{{ t('tokenItem.mint.modeCollection') }}</b>: {{ t('tokenItem.mint.titleCollection') }}
-          <div style="display: flex; gap: 10px; align-items: center; margin: 5px 0;">
-            <label>{{ t('tokenItem.mint.modeLabel') }}</label>
-            <select v-model="mintMode" style="max-width: 260px; padding: 4px 8px;">
-              <option value="single">{{ t('tokenItem.mint.modeSingle') }}</option>
-              <option value="collection">{{ t('tokenItem.mint.modeCollection') }}</option>
-            </select>
-          </div>
-
-          <div v-if="mintMode === 'collection'" style="display: flex; gap: 10px; align-items: center; margin-bottom: 5px;">
-            <label for="numbering" style="width: 80px;">{{ t('tokenItem.mint.numberingLabel') }}</label>
-            <select id="numbering" v-model="numberingUniqueNfts" style="max-width: 260px; padding: 4px 8px;">
-              <option value="vm-numbers">{{ t('tokenItem.mint.vmNumbers') }}</option>
-              <option value="hex-numbers">{{ t('tokenItem.mint.hexNumbers') }}</option>
-            </select>
-          </div>
-
-          <span class="grouped" style="align-items: center; margin-bottom: 5px;">
-            <input v-if="mintMode === 'single'" v-model="mintCommitment" :placeholder="t('tokenItem.mint.commitmentPlaceholder')">
-            <input v-if="mintMode === 'collection'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.collectionSizePlaceholder')">
-            <input v-if="mintMode === 'collection'" v-model="startingNumberNFTs" type="number" :placeholder="t('tokenItem.mint.startingNumberPlaceholder')">
-            <select v-model="mintCapability" style="max-width: 130px;">
-              <option value="none">{{ t('tokenItem.mint.capabilityImmutable') }}</option>
-              <option value="mutable">{{ t('tokenItem.mint.capabilityMutable') }}</option>
-              <option value="minting">{{ t('tokenItem.mint.capabilityMinting') }}</option>
-            </select>
-            <input v-if="mintMode === 'single'" v-model="mintQuantity" type="number" :placeholder="t('tokenItem.mint.quantityPlaceholder')" style="max-width: 122px;">
-          </span>
-          <span class="grouped">
-            <input v-model="destinationAddr" @input="parseAddrParams()" :placeholder="t('tokenItem.mint.destinationPlaceholder')">
-            <input @click="mintNfts()" type="button" :value="activeAction === 'minting' ? t('tokenItem.mint.mintingButton') : t('tokenItem.mint.mintButton')" class="primaryButton" :disabled="activeAction !== null">
-          </span>
-        </div>
+        <nftMintForm v-if="displayMintNfts" :category="tokenData.category" v-model:active-action="activeAction" @minted="displayMintNfts = false"/>
         <div v-if="displayBurnNft" class="tokenAction">
           <span v-if="isSingleNft && tokenData?.nfts?.[0]?.token?.nft?.capability == 'minting'">{{ t('tokenItem.burn.burnMintingDescription') }}</span>
           <span v-else>{{ t('tokenItem.burn.burnNftDescription') }}</span>

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -39,6 +39,8 @@ export interface QrCodeElement extends HTMLElement {
   animateQRCode: (animationName: QRCodeAnimationName) => void;
 }
 
+export type TokenActionType = 'sending' | 'minting' | 'burning' | 'transferAuth';
+
 export type TokenList = (TokenDataNFT | TokenDataFT)[]
 
 export interface TokenDataNFT {

--- a/src/utils/nftCommitmentParsing.ts
+++ b/src/utils/nftCommitmentParsing.ts
@@ -3,8 +3,10 @@ import type { Utxo } from "mainnet-js"
 import type { ParseResult } from 'src/parsing/nftParsing'
 import { useStore } from 'src/stores/store'
 
-// Parsable-NFT state: runs the BCMR parsing bytecode on the NFT commitment.
+// Vue composable for Parsable-NFT state.
+// Keeps parsing state and parses the NFT commitment on mount/when metadata becomes available.
 // isEnabled gates parsing (e.g. tokenItemNFT only parses when it holds a single NFT).
+// Callback arguments read the latest reactive values when parsing runs.
 export function useNftCommitmentParsing(getCategory: () => string, getNftUtxo: () => Utxo | undefined, isEnabled: () => boolean = () => true) {
   const store = useStore();
   const parseResult = ref(undefined as ParseResult | undefined);

--- a/src/utils/nftCommitmentParsing.ts
+++ b/src/utils/nftCommitmentParsing.ts
@@ -3,11 +3,9 @@ import type { Utxo } from "mainnet-js"
 import type { ParseResult } from 'src/parsing/nftParsing'
 import { useStore } from 'src/stores/store'
 
-export type TokenActionType = 'sending' | 'minting' | 'burning' | 'transferAuth';
-
 // Parsable-NFT state: runs the BCMR parsing bytecode on the NFT commitment.
 // isEnabled gates parsing (e.g. tokenItemNFT only parses when it holds a single NFT).
-export function useNftParsing(getCategory: () => string, getNftUtxo: () => Utxo | undefined, isEnabled: () => boolean = () => true) {
+export function useNftCommitmentParsing(getCategory: () => string, getNftUtxo: () => Utxo | undefined, isEnabled: () => boolean = () => true) {
   const store = useStore();
   const parseResult = ref(undefined as ParseResult | undefined);
   const parsingNft = ref(false);

--- a/src/utils/tokenComposables.ts
+++ b/src/utils/tokenComposables.ts
@@ -1,93 +1,9 @@
-// Composables shared by the tokenItems components (tokenItemFT, tokenItemNFT, nftChild, nftMintForm)
 import { ref, computed, watch, onMounted } from 'vue'
-import { Notify } from "quasar";
-import { decodeCashAddress } from "@bitauth/libauth"
 import type { Utxo } from "mainnet-js"
-import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
-import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
 import type { ParseResult } from 'src/parsing/nftParsing'
 import { useStore } from 'src/stores/store'
-import { i18n } from 'src/boot/i18n'
-const { t } = i18n.global
 
 export type TokenActionType = 'sending' | 'minting' | 'burning' | 'transferAuth';
-
-// Destination address input for token sends: BIP21 URI parsing, QR scanning and validation.
-// onOtherParams receives the non-standard BIP21 params (c, ft, ...) after a URI was accepted.
-export function useTokenAddressInput(getCategory: () => string, onOtherParams?: (otherParams: Record<string, string>) => void) {
-  const store = useStore();
-  const destinationAddr = ref("");
-  const showQrCodeDialog = ref(false);
-
-  function parseAddrParams(){
-    if(!isBip21Uri(destinationAddr.value) || !destinationAddr.value.includes("?")) return;
-
-    // Parse BIP21 URIs with query params
-    try {
-      const parsed = parseBip21Uri(destinationAddr.value);
-
-      const validationError = getBip21ValidationError(parsed);
-      if (validationError) {
-        Notify.create({ message: validationError, icon: 'warning', color: "red" });
-        return;
-      }
-
-      // Check if c= is for a different token
-      if(parsed.otherParams?.c && parsed.otherParams.c !== getCategory()){
-        Notify.create({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
-        return;
-      }
-
-      // Set the address (without query params)
-      destinationAddr.value = parsed.address;
-
-      if(parsed.otherParams) onOtherParams?.(parsed.otherParams);
-    } catch {
-      // If parsing fails, leave the input as-is
-    }
-  }
-
-  const qrDecode = (content: string) => {
-    destinationAddr.value = content;
-    parseAddrParams();
-  }
-
-  const qrFilter = (content: string) => {
-    // Extract address from BIP21 URI if needed
-    let addressToCheck = content;
-    if(isBip21Uri(content) && content.includes("?")){
-      try {
-        const parsed = parseBip21Uri(content);
-        addressToCheck = parsed.address;
-      } catch {
-        // If parsing fails, try with original content
-      }
-    }
-    const decoded = decodeCashAddress(addressToCheck);
-    if (typeof decoded === "string" || decoded.prefix !== `${store.wallet.networkPrefix}`) {
-      return t('tokenItem.errors.notCashaddress');
-    }
-    return true;
-  }
-
-  // Validates destinationAddr, normalizes it to a prefixed cashaddress (also in the input field)
-  // and returns it. Throws a localized error on empty/invalid/wrong-network/non-token address.
-  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
-    if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'));
-    const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
-      invalidAddress: t('tokenItem.errors.invalidAddress'),
-      wrongNetwork: t('tokenItem.errors.notCashaddress'),
-    });
-    destinationAddr.value = address;
-    if(opts?.requireTokenSupport){
-      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
-      if(!supportsTokens) throw new Error(t('tokenItem.errors.notTokenAddress'));
-    }
-    return address;
-  }
-
-  return { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination };
-}
 
 // Parsable-NFT state: runs the BCMR parsing bytecode on the NFT commitment.
 // isEnabled gates parsing (e.g. tokenItemNFT only parses when it holds a single NFT).

--- a/src/utils/tokenComposables.ts
+++ b/src/utils/tokenComposables.ts
@@ -1,0 +1,125 @@
+// Composables shared by the tokenItems components (tokenItemFT, tokenItemNFT, nftChild, nftMintForm)
+import { ref, computed, watch, onMounted } from 'vue'
+import { Notify } from "quasar";
+import { decodeCashAddress } from "@bitauth/libauth"
+import type { Utxo } from "mainnet-js"
+import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
+import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
+import type { ParseResult } from 'src/parsing/nftParsing'
+import { useStore } from 'src/stores/store'
+import { i18n } from 'src/boot/i18n'
+const { t } = i18n.global
+
+export type TokenActionType = 'sending' | 'minting' | 'burning' | 'transferAuth';
+
+// Destination address input for token sends: BIP21 URI parsing, QR scanning and validation.
+// onOtherParams receives the non-standard BIP21 params (c, ft, ...) after a URI was accepted.
+export function useTokenAddressInput(getCategory: () => string, onOtherParams?: (otherParams: Record<string, string>) => void) {
+  const store = useStore();
+  const destinationAddr = ref("");
+  const showQrCodeDialog = ref(false);
+
+  function parseAddrParams(){
+    if(!isBip21Uri(destinationAddr.value) || !destinationAddr.value.includes("?")) return;
+
+    // Parse BIP21 URIs with query params
+    try {
+      const parsed = parseBip21Uri(destinationAddr.value);
+
+      const validationError = getBip21ValidationError(parsed);
+      if (validationError) {
+        Notify.create({ message: validationError, icon: 'warning', color: "red" });
+        return;
+      }
+
+      // Check if c= is for a different token
+      if(parsed.otherParams?.c && parsed.otherParams.c !== getCategory()){
+        Notify.create({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
+        return;
+      }
+
+      // Set the address (without query params)
+      destinationAddr.value = parsed.address;
+
+      if(parsed.otherParams) onOtherParams?.(parsed.otherParams);
+    } catch {
+      // If parsing fails, leave the input as-is
+    }
+  }
+
+  const qrDecode = (content: string) => {
+    destinationAddr.value = content;
+    parseAddrParams();
+  }
+
+  const qrFilter = (content: string) => {
+    // Extract address from BIP21 URI if needed
+    let addressToCheck = content;
+    if(isBip21Uri(content) && content.includes("?")){
+      try {
+        const parsed = parseBip21Uri(content);
+        addressToCheck = parsed.address;
+      } catch {
+        // If parsing fails, try with original content
+      }
+    }
+    const decoded = decodeCashAddress(addressToCheck);
+    if (typeof decoded === "string" || decoded.prefix !== `${store.wallet.networkPrefix}`) {
+      return t('tokenItem.errors.notCashaddress');
+    }
+    return true;
+  }
+
+  // Validates destinationAddr, normalizes it to a prefixed cashaddress (also in the input field)
+  // and returns it. Throws a localized error on empty/invalid/wrong-network/non-token address.
+  function validateDestination(opts?: { requireTokenSupport?: boolean }): string {
+    if(!destinationAddr.value) throw new Error(t('tokenItem.errors.noDestination'));
+    const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr.value, store.wallet.networkPrefix, {
+      invalidAddress: t('tokenItem.errors.invalidAddress'),
+      wrongNetwork: t('tokenItem.errors.notCashaddress'),
+    });
+    destinationAddr.value = address;
+    if(opts?.requireTokenSupport){
+      const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
+      if(!supportsTokens) throw new Error(t('tokenItem.errors.notTokenAddress'));
+    }
+    return address;
+  }
+
+  return { destinationAddr, showQrCodeDialog, qrDecode, parseAddrParams, qrFilter, validateDestination };
+}
+
+// Parsable-NFT state: runs the BCMR parsing bytecode on the NFT commitment.
+// isEnabled gates parsing (e.g. tokenItemNFT only parses when it holds a single NFT).
+export function useNftParsing(getCategory: () => string, getNftUtxo: () => Utxo | undefined, isEnabled: () => boolean = () => true) {
+  const store = useStore();
+  const parseResult = ref(undefined as ParseResult | undefined);
+  const parsingNft = ref(false);
+
+  const hasParyonUsdExtension = computed(() => {
+    const ext = store.bcmrRegistries?.[getCategory()]?.extensions;
+    return Boolean(ext?.paryonusd ?? ext?.pusd);
+  });
+  const isParsable = computed(() =>
+    store.bcmrRegistries?.[getCategory()]?.nft_type === 'parsable'
+  );
+
+  async function parseNft() {
+    const nftUtxo = getNftUtxo();
+    if (!nftUtxo) return;
+    parsingNft.value = true;
+    parseResult.value = await store.parseNftCommitment(getCategory(), nftUtxo);
+    parsingNft.value = false;
+  }
+
+  onMounted(async () => {
+    if (isEnabled() && isParsable.value) await parseNft();
+  })
+
+  // Watch for isParsable becoming true after mount (e.g. bcmrRegistries loads async)
+  watch(isParsable, async (nowParsable) => {
+    if (nowParsable && isEnabled() && !parseResult.value) await parseNft();
+  })
+
+  return { parseResult, parsingNft, isParsable, hasParyonUsdExtension };
+}

--- a/src/utils/tokenRecipientUtils.ts
+++ b/src/utils/tokenRecipientUtils.ts
@@ -1,0 +1,61 @@
+import { Notify } from "quasar";
+import { decodeCashAddress } from "@bitauth/libauth"
+import { parseBip21Uri, isBip21Uri, getBip21ValidationError } from 'src/utils/bip21';
+import { normalizeCashAddressForNetwork } from 'src/utils/addressValidation';
+import { i18n } from 'src/boot/i18n'
+const { t } = i18n.global
+
+export function parseTokenRecipientRequest(addressInput: string, expectedCategory: string) {
+  if(!isBip21Uri(addressInput) || !addressInput.includes("?")) return;
+
+  try {
+    const parsed = parseBip21Uri(addressInput);
+    const validationError = getBip21ValidationError(parsed);
+    if (validationError) {
+      Notify.create({ message: validationError, icon: 'warning', color: "red" });
+      return;
+    }
+
+    if(parsed.otherParams?.c && parsed.otherParams.c !== expectedCategory){
+      Notify.create({ message: t('tokenItem.errors.differentTokenRequest'), icon: 'warning', color: "grey-7" });
+      return;
+    }
+
+    return { address: parsed.address, otherParams: parsed.otherParams };
+  } catch {
+    // If parsing fails, leave the input as-is.
+  }
+}
+
+export function getCashAddressScanError(content: string, networkPrefix: string): string | undefined {
+  let addressToCheck = content;
+  if(isBip21Uri(content) && content.includes("?")){
+    try {
+      const parsed = parseBip21Uri(content);
+      addressToCheck = parsed.address;
+    } catch {
+      // If parsing fails, try with original content.
+    }
+  }
+  const decoded = decodeCashAddress(addressToCheck);
+  if (typeof decoded === "string" || decoded.prefix !== networkPrefix) {
+    return t('tokenItem.errors.notCashaddress');
+  }
+}
+
+export function validateTokenRecipientAddress(
+  destinationAddr: string,
+  networkPrefix: string,
+  opts?: { requireTokenSupport?: boolean }
+): string {
+  if(!destinationAddr) throw new Error(t('tokenItem.errors.noDestination'));
+  const { address, decodedAddress } = normalizeCashAddressForNetwork(destinationAddr, networkPrefix, {
+    invalidAddress: t('tokenItem.errors.invalidAddress'),
+    wrongNetwork: t('tokenItem.errors.notCashaddress'),
+  });
+  if(opts?.requireTokenSupport){
+    const supportsTokens = (decodedAddress.type === 'p2pkhWithTokens' || decodedAddress.type === 'p2shWithTokens');
+    if(!supportsTokens) throw new Error(t('tokenItem.errors.notTokenAddress'));
+  }
+  return address;
+}

--- a/src/utils/txHelpers.ts
+++ b/src/utils/txHelpers.ts
@@ -1,0 +1,55 @@
+// Shared helpers for the transaction lifecycle in components:
+// user confirmation, progress notification and success reporting.
+// For error display, use displayAndLogError from errorHandling.ts.
+import { Dialog, Notify } from "quasar";
+import alertDialog from 'src/components/general/alertDialog.vue'
+import { useStore } from 'src/stores/store'
+import { i18n } from 'src/boot/i18n'
+const { t } = i18n.global
+
+// Promisified Quasar confirmation dialog, resolves to false on cancel
+export function confirmDialog(
+  title: string, message: string, okLabel: string, okColor: 'primary' | 'red' = 'primary'
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    Dialog.create({
+      title,
+      message,
+      cancel: { flat: true, color: 'dark' },
+      ok: { label: okLabel, color: okColor, textColor: 'white' },
+      persistent: true
+    }).onOk(() => resolve(true))
+      .onCancel(() => resolve(false))
+  })
+}
+
+export function notifySending(message?: string){
+  Notify.create({
+    spinner: true,
+    message: message ?? t('common.status.sending'),
+    color: 'grey-5',
+    timeout: 1000
+  })
+}
+
+// Shows the success dialog + toast, logs the tx and refreshes the wallet state
+// txId can be undefined because mainnet-js send() types its txId as optional
+export async function showTransactionResult(alertMessage: string, txId: string | undefined, successMessage: string){
+  const store = useStore()
+  Dialog.create({
+    component: alertDialog,
+    componentProps: {
+      alertInfo: { message: alertMessage, txid: txId }
+    }
+  })
+  Notify.create({
+    type: 'positive',
+    message: successMessage
+  })
+  console.log(alertMessage);
+  console.log(`${store.explorerUrl}/${txId}`);
+  // update utxo list
+  await store.updateWalletUtxos();
+  // update wallet history as fire-and-forget promise
+  void store.updateWalletHistory();
+}

--- a/src/utils/txHelpers.ts
+++ b/src/utils/txHelpers.ts
@@ -32,9 +32,9 @@ export function notifySending(message?: string){
   })
 }
 
-// Shows the success dialog + toast, logs the tx and refreshes the wallet state
+// Handles a successful transaction broadcast: shows feedback, logs the tx and refreshes wallet state.
 // txId can be undefined because mainnet-js send() types its txId as optional
-export async function showTransactionResult(alertMessage: string, txId: string | undefined, successMessage: string){
+export async function handleTransactionBroadcastSuccess(alertMessage: string, txId: string | undefined, successMessage: string){
   const store = useStore()
   Dialog.create({
     component: alertDialog,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,16 +101,16 @@ export function formatTimestamp(timestamp: number | undefined, dateFormat: DateF
   return short ? dateStr : `${dateStr} ${time}`;
 }
 
-function checkValidTokenInput(numberInput: string, decimals: number){
-  // Validate the input format (no separting commas allowed here)
-  if (!/^\d*\.?\d*$/.test(numberInput)) throw new Error(t('tokenItem.errors.invalidNumberFormat'));
+function validateTokenAmountString(tokenAmount: string, decimals: number){
+  // Validate the amount format (no separating commas allowed here).
+  if (!/^\d*\.?\d*$/.test(tokenAmount)) throw new Error(t('tokenItem.errors.invalidNumberFormat'));
 
   // Validate if the input can be converted to a number
-  const number = parseFloat(numberInput);
+  const number = parseFloat(tokenAmount);
   if (isNaN(number) || number <= 0) throw new Error(t('tokenItem.errors.enterValidAmount'));
 
   // check number of decimal places
-  const decimalPart = numberInput.split('.')[1];
+  const decimalPart = tokenAmount.split('.')[1];
   const decimalPlaces = decimalPart ? decimalPart.length : 0;
   const validInput = decimalPlaces <= decimals
   if(!validInput && !decimals) throw new Error(t('tokenItem.errors.noDecimalsAllowed'));
@@ -122,7 +122,7 @@ function checkValidTokenInput(numberInput: string, decimals: number){
 // float multiplication so large amounts don't lose precision.
 export function parseTokenAmountToBigInt(input: string, decimals: number): bigint {
   const sanitizedInput = input.replace(/,/g, '');
-  checkValidTokenInput(sanitizedInput, decimals);
+  validateTokenAmountString(sanitizedInput, decimals);
   const [integerPart = '', fractionalPart = ''] = sanitizedInput.split('.');
   return BigInt(integerPart + fractionalPart.padEnd(decimals, '0'));
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,6 +101,32 @@ export function formatTimestamp(timestamp: number | undefined, dateFormat: DateF
   return short ? dateStr : `${dateStr} ${time}`;
 }
 
+function checkValidTokenInput(numberInput: string, decimals: number){
+  // Validate the input format (no separting commas allowed here)
+  if (!/^\d*\.?\d*$/.test(numberInput)) throw new Error(t('tokenItem.errors.invalidNumberFormat'));
+
+  // Validate if the input can be converted to a number
+  const number = parseFloat(numberInput);
+  if (isNaN(number) || number <= 0) throw new Error(t('tokenItem.errors.enterValidAmount'));
+
+  // check number of decimal places
+  const decimalPart = numberInput.split('.')[1];
+  const decimalPlaces = decimalPart ? decimalPart.length : 0;
+  const validInput = decimalPlaces <= decimals
+  if(!validInput && !decimals) throw new Error(t('tokenItem.errors.noDecimalsAllowed'));
+  if(!validInput) throw new Error(t('tokenItem.errors.maxDecimalsAllowed', { decimals }));
+}
+
+// Parses a user-entered token amount into base units.
+// Throws a localized error on invalid input; uses string math instead of
+// float multiplication so large amounts don't lose precision.
+export function parseTokenAmountToBigInt(input: string, decimals: number): bigint {
+  const sanitizedInput = input.replace(/,/g, '');
+  checkValidTokenInput(sanitizedInput, decimals);
+  const [integerPart = '', fractionalPart = ''] = sanitizedInput.split('.');
+  return BigInt(integerPart + fractionalPart.padEnd(decimals, '0'));
+}
+
 export function convertToCurrency(satAmount: bigint, exchangeRate:number) {
   const newFiatValue =  Number(satAmount) * exchangeRate / 100_000_000
   return Number(newFiatValue.toFixed(2));


### PR DESCRIPTION
Extracts the verbatim-duplicated code identified in code review issue 18:

- utils/txHelpers.ts: confirmDialog, notifySending, showTransactionResult (replaces 12 dialog promise wrappers and 8 tx-success tails)
- utils/tokenComposables.ts: useTokenAddressInput incl. validateDestination, and useNftParsing for parsable-NFT state
- tokenItems/nftMintForm.vue: mint form previously duplicated in tokenItemNFT.vue and nftChild.vue, sharing the host action lock
- utils.ts parseTokenAmountToBigInt: replaces the 3x pasted amount pipeline in tokenItemFT.vue using string math, fixing the float-precision finding
- local handleTransactionError copies replaced by existing displayAndLogError

Behavior changes: FT burn now updates wallet history like other tx flows, FT auth-transfer validation errors now display as toasts instead of unhandled rejections, and the mint form has its own destination field.