### PR TITLE
Guard all wallet loading against silent fresh-seed creation

### DIFF
--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -88,6 +88,8 @@
     void store.walletUtxos;
     const hdWallet = store.wallet;
     // wallet can briefly be non-HD mid wallet-switch
+    // KeepAlive preserves this HD-only view, so its watchEffect can rerun after setWallet()
+    // swaps in a single-address wallet but before changeView(1) navigates away.
     if (!(hdWallet instanceof HDWallet)) return;
     receivingAddresses.value = buildAddressRows(hdWallet, hdWallet.depositIndex, false);
     changeAddresses.value = buildAddressRows(hdWallet, hdWallet.changeIndex, true);

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -4,7 +4,7 @@
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useI18n } from 'vue-i18n'
-  import { type HDWallet, type TestNetHDWallet, GAP_SIZE } from 'mainnet-js';
+  import { HDWallet, type TestNetHDWallet, GAP_SIZE } from 'mainnet-js';
   import { useWindowSize } from 'src/utils/composables'
 
   const store = useStore()
@@ -86,7 +86,9 @@
   watchEffect(() => {
     // Access walletUtxos to establish reactive dependency
     void store.walletUtxos;
-    const hdWallet = store.wallet as HDWallet | TestNetHDWallet;
+    const hdWallet = store.wallet;
+    // wallet can briefly be non-HD mid wallet-switch
+    if (!(hdWallet instanceof HDWallet)) return;
     receivingAddresses.value = buildAddressRows(hdWallet, hdWallet.depositIndex, false);
     changeAddresses.value = buildAddressRows(hdWallet, hdWallet.changeIndex, true);
   });

--- a/src/components/walletconnect/hdAddressSelect.vue
+++ b/src/components/walletconnect/hdAddressSelect.vue
@@ -95,6 +95,8 @@
     void store.walletUtxos;
     const hdWallet = store.wallet;
     // wallet can briefly be non-HD mid wallet-switch
+    // KeepAlive preserves this HD-only view, so its watchEffect can rerun after setWallet()
+    // swaps in a single-address wallet but before changeView(1) navigates away.
     if (!(hdWallet instanceof HDWallet)) return;
     receivingAddresses.value = buildAddressRows(hdWallet, hdWallet.depositIndex, false);
     changeAddresses.value = buildAddressRows(hdWallet, hdWallet.changeIndex, true);

--- a/src/components/walletconnect/hdAddressSelect.vue
+++ b/src/components/walletconnect/hdAddressSelect.vue
@@ -4,7 +4,7 @@
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useI18n } from 'vue-i18n'
-  import { type HDWallet, type TestNetHDWallet, GAP_SIZE } from 'mainnet-js';
+  import { HDWallet, type TestNetHDWallet, GAP_SIZE } from 'mainnet-js';
   import { useWindowSize } from 'src/utils/composables'
 
   const store = useStore()
@@ -93,7 +93,9 @@
   watchEffect(() => {
     // Access walletUtxos to establish reactive dependency
     void store.walletUtxos;
-    const hdWallet = store.wallet as HDWallet | TestNetHDWallet;
+    const hdWallet = store.wallet;
+    // wallet can briefly be non-HD mid wallet-switch
+    if (!(hdWallet instanceof HDWallet)) return;
     receivingAddresses.value = buildAddressRows(hdWallet, hdWallet.depositIndex, false);
     changeAddresses.value = buildAddressRows(hdWallet, hdWallet.changeIndex, true);
   });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -60,6 +60,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Das aktive Wallet kann nicht gelöscht werden",
+      "walletNotFoundOnNetwork": "Wallet \"{name}\" existiert nicht auf {network}",
       "errorInitializingWalletConnect": "Fehler beim Initialisieren von WalletConnect",
       "errorInitializingCashConnect": "Fehler beim Initialisieren von CashConnect",
       "errorFetchingUtxos": "Fehler beim Abrufen der Wallet-UTXOs",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -60,6 +60,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Cannot delete the currently active wallet",
+      "walletNotFoundOnNetwork": "Wallet \"{name}\" does not exist on {network}",
       "errorInitializingWalletConnect": "Error initializing WalletConnect",
       "errorInitializingCashConnect": "Error initializing CashConnect",
       "errorFetchingUtxos": "Error in fetching wallet UTXOs",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -60,6 +60,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "No se puede eliminar la billetera actualmente activa",
+      "walletNotFoundOnNetwork": "La billetera \"{name}\" no existe en {network}",
       "errorInitializingWalletConnect": "Error al inicializar WalletConnect",
       "errorInitializingCashConnect": "Error al inicializar CashConnect",
       "errorFetchingUtxos": "Error al obtener los UTXOs de la billetera",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -60,6 +60,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Impossible de supprimer le portefeuille actuellement actif",
+      "walletNotFoundOnNetwork": "Le portefeuille \"{name}\" n'existe pas sur {network}",
       "errorInitializingWalletConnect": "Erreur lors de l'initialisation de WalletConnect",
       "errorInitializingCashConnect": "Erreur lors de l'initialisation de CashConnect",
       "errorFetchingUtxos": "Erreur lors de la récupération des UTXOs du portefeuille",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -60,6 +60,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Não é possível excluir a carteira ativa",
+      "walletNotFoundOnNetwork": "A carteira \"{name}\" não existe em {network}",
       "errorInitializingWalletConnect": "Erro ao inicializar WalletConnect",
       "errorInitializingCashConnect": "Erro ao inicializar CashConnect",
       "errorFetchingUtxos": "Erro ao buscar UTXOs da carteira",

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -69,9 +69,9 @@
   // check if named wallet already exists in indexedDB
   // we use a dbUtil and avoid 'WalletClass.namedExists' which instantiates a wallet + provider
   let walletToLoad = store.activeWalletName;
-  const mainnetWalletExists = await namedWalletExistsInDb(walletToLoad, "bitcoincash");
-  const testnetWalletExists = await namedWalletExistsInDb(walletToLoad, "bchtest");
-  let walletExists = mainnetWalletExists || testnetWalletExists;
+  let walletHasMainnet = await namedWalletExistsInDb(walletToLoad, "bitcoincash");
+  let walletHasChipnet = await namedWalletExistsInDb(walletToLoad, "bchtest");
+  let walletExists = walletHasMainnet || walletHasChipnet;
 
   // If active wallet doesn't exist somehow, try to fall back to any existing wallet
   if (!walletExists) {
@@ -79,6 +79,8 @@
     const fallbackWallet = allWallets[0];
     if (fallbackWallet) {
       walletToLoad = fallbackWallet.name;
+      walletHasMainnet = fallbackWallet.hasMainnet;
+      walletHasChipnet = fallbackWallet.hasChipnet;
       walletExists = true;
       // Update stored active wallet name
       store.activeWalletName = walletToLoad;
@@ -88,9 +90,15 @@
 
   if(walletExists){
     // initialise wallet on configured network
-    const readNetwork = localStorage.getItem('network') ?? 'mainnet';
-    const walletClass = await store.getWalletClass(walletToLoad, readNetwork);
-    const initWallet = await walletClass.named(walletToLoad);
+    let readNetwork = (localStorage.getItem('network') ?? 'mainnet') as 'mainnet' | 'chipnet';
+    // if the wallet only exists on the other network (legacy single-network wallet or
+    // fallback wallet), correct the configured network instead of loading a missing wallet
+    const walletExistsOnNetwork = readNetwork === 'mainnet' ? walletHasMainnet : walletHasChipnet;
+    if (!walletExistsOnNetwork) {
+      readNetwork = walletHasMainnet ? 'mainnet' : 'chipnet';
+      localStorage.setItem('network', readNetwork);
+    }
+    const initWallet = await store.loadExistingWallet(walletToLoad, readNetwork);
     store.setWallet(initWallet);
     store.changeView(1);
     // fire-and-forget promise does not wait on full wallet initialization

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,8 +1,6 @@
 import { defineStore } from "pinia"
 import { ref, reactive, computed, watch } from 'vue'
 import {
-  Wallet,
-  TestNetWallet,
   HDWallet,
   TestNetHDWallet,
   BaseWallet,
@@ -27,7 +25,9 @@ import {
 import {
   getBalanceFromUtxos,
   getTokenUtxos,
-  runAsyncVoid
+  loadWalletFromId,
+  runAsyncVoid,
+  walletTypeFromWalletId
 } from "src/utils/utils"
 import {
   fetchTokenMetadata as fetchTokenMetadataFromIndexer,
@@ -44,7 +44,7 @@ import { useCashconnectStore } from "./cashconnectStore"
 import { displayAndLogError } from "src/utils/errorHandling"
 import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
-import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getWalletTypeFromDb, namedWalletExistsInDb, type WalletInfo } from "src/utils/dbUtils"
+import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/dbUtils"
 import { fetchCauldronPrices, type CauldronPriceData } from "src/utils/cauldronApi"
 import { defaultWalletName } from './constants';
 import { i18n } from 'src/boot/i18n'
@@ -500,32 +500,22 @@ export const useStore = defineStore('store', () => {
     isHistoryPartial.value = false;
   }
 
-  async function getWalletClass(walletName: string, network: string) {
-    // Ensure wallet type metadata exists, detect from IndexedDB if missing
-    const metadata = settingsStore.getWalletMetadata(walletName);
-    if (!metadata?.walletType) {
-      const dbName = network === 'mainnet' ? 'bitcoincash' : 'bchtest';
-      const detectedType = await getWalletTypeFromDb(walletName, dbName);
-      settingsStore.setWalletType(walletName, detectedType);
-    }
-
-    const isHD = settingsStore.getWalletType(walletName) === 'hd';
-    if (network === 'mainnet') return isHD ? HDWallet : Wallet;
-    return isHD ? TestNetHDWallet : TestNetWallet;
-  }
-
-  // WalletClass.named() silently creates a new wallet (with a fresh random seed) when the
-  // name is not in the network's IndexedDB, so all wallet loading must go through this
-  // existence check to make sure a missing wallet is never replaced by a new random seed.
-  // Only the wallet creation flows in walletUtils.ts should use .named() directly.
+  // Avoid WalletClass.named() here: it creates a fresh random wallet if the name is missing.
+  // Loading must reconstruct from the saved walletId; .named() is only for creation flows.
   async function loadExistingWallet(walletName: string, network: 'mainnet' | 'chipnet'): Promise<WalletType> {
     const dbName = network === 'mainnet' ? 'bitcoincash' : 'bchtest';
-    const walletExistsInDb = await namedWalletExistsInDb(walletName, dbName);
-    if (!walletExistsInDb) {
+    const walletId = await getNamedWalletIdFromDb(walletName, dbName);
+    if (!walletId) {
       throw new Error(t('store.errors.walletNotFoundOnNetwork', { name: walletName, network }));
     }
-    const walletClass = await getWalletClass(walletName, network);
-    return await walletClass.named(walletName);
+    const metadata = settingsStore.getWalletMetadata(walletName);
+    if (!metadata?.walletType) {
+      const walletType = walletTypeFromWalletId(walletId);
+      settingsStore.setWalletType(walletName, walletType);
+    }
+    const loadedWallet = await loadWalletFromId(walletId, network);
+    loadedWallet.name = walletName;
+    return loadedWallet;
   }
 
   // Resets all wallet state and makes the given (already loaded) wallet the active one

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -44,7 +44,7 @@ import { useCashconnectStore } from "./cashconnectStore"
 import { displayAndLogError } from "src/utils/errorHandling"
 import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
-import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getWalletTypeFromDb, type WalletInfo } from "src/utils/dbUtils"
+import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getWalletTypeFromDb, namedWalletExistsInDb, type WalletInfo } from "src/utils/dbUtils"
 import { fetchCauldronPrices, type CauldronPriceData } from "src/utils/cauldronApi"
 import { defaultWalletName } from './constants';
 import { i18n } from 'src/boot/i18n'
@@ -514,15 +514,27 @@ export const useStore = defineStore('store', () => {
     return isHD ? TestNetHDWallet : TestNetWallet;
   }
 
-  // Switching networks resets all wallet state and reinitializes the wallet on the new network
-  async function changeNetwork(
-    newNetwork: 'mainnet' | 'chipnet',
+  // WalletClass.named() silently creates a new wallet (with a fresh random seed) when the
+  // name is not in the network's IndexedDB, so all wallet loading must go through this
+  // existence check to make sure a missing wallet is never replaced by a new random seed.
+  // Only the wallet creation flows in walletUtils.ts should use .named() directly.
+  async function loadExistingWallet(walletName: string, network: 'mainnet' | 'chipnet'): Promise<WalletType> {
+    const dbName = network === 'mainnet' ? 'bitcoincash' : 'bchtest';
+    const walletExistsInDb = await namedWalletExistsInDb(walletName, dbName);
+    if (!walletExistsInDb) {
+      throw new Error(t('store.errors.walletNotFoundOnNetwork', { name: walletName, network }));
+    }
+    const walletClass = await getWalletClass(walletName, network);
+    return await walletClass.named(walletName);
+  }
+
+  // Resets all wallet state and makes the given (already loaded) wallet the active one
+  async function activateWallet(
+    newWallet: WalletType,
+    network: 'mainnet' | 'chipnet',
     awaitWalletInitialization: boolean = false
   ){
-    await resetWalletState()
-    // set new wallet
-    const walletClass = await getWalletClass(activeWalletName.value, newNetwork);
-    const newWallet = await walletClass.named(activeWalletName.value);
+    await resetWalletState();
     setWallet(newWallet);
     if (awaitWalletInitialization) {
       await initializeWallet();
@@ -530,8 +542,25 @@ export const useStore = defineStore('store', () => {
       // fire-and-forget promise does not wait on full wallet initialization
       void initializeWallet();
     }
-    localStorage.setItem('network', newNetwork);
+    localStorage.setItem('network', network);
     changeView(1);
+  }
+
+  // Switching networks resets all wallet state and reinitializes the wallet on the new network
+  async function changeNetwork(
+    newNetwork: 'mainnet' | 'chipnet',
+    awaitWalletInitialization: boolean = false
+  ){
+    // Load the wallet on the new network first: if it does not exist there,
+    // this throws and the current wallet state is left untouched
+    let newWallet: WalletType;
+    try {
+      newWallet = await loadExistingWallet(activeWalletName.value, newNetwork);
+    } catch (error) {
+      displayAndLogError(error);
+      return;
+    }
+    await activateWallet(newWallet, newNetwork, awaitWalletInitialization);
   }
 
   interface SwitchWalletResult {
@@ -543,34 +572,25 @@ export const useStore = defineStore('store', () => {
     // Get the current network from localStorage (default to mainnet)
     const currentNetwork = (localStorage.getItem('network') ?? 'mainnet') as 'mainnet' | 'chipnet';
 
-    // Check if wallet exists on current network (if we have wallet info available)
+    // If the wallet doesn't exist on the current network, target a network where it does
+    // (availableWallets may be stale, loadExistingWallet below re-checks IndexedDB)
+    let targetNetwork = currentNetwork;
     const walletInfo = availableWallets.value.find(w => w.name === walletName);
     if (walletInfo) {
       const networkSelector = currentNetwork === 'mainnet' ? 'hasMainnet' : 'hasChipnet';
-      const walletExistsOnCurrentNetwork = walletInfo[networkSelector];
-
-      // If wallet doesn't exist on current network, switch to a network where it does
-      if (!walletExistsOnCurrentNetwork) {
-        const targetNetwork = walletInfo.hasMainnet ? 'mainnet' : 'chipnet';
-        activeWalletName.value = walletName;
-        localStorage.setItem('activeWalletName', walletName);
-        // changeNetwork will reset state and initialize the wallet
-        void changeNetwork(targetNetwork);
-        return { success: true, networkChanged: targetNetwork };
+      if (!walletInfo[networkSelector]) {
+        targetNetwork = walletInfo.hasMainnet ? 'mainnet' : 'chipnet';
       }
     }
 
-    // Load wallet on current network
-    const walletClass = await getWalletClass(walletName, currentNetwork);
-    const newWallet = await walletClass.named(walletName);
+    const newWallet = await loadExistingWallet(walletName, targetNetwork);
     // Only update state after successful wallet load
     activeWalletName.value = walletName;
     localStorage.setItem('activeWalletName', walletName);
-    await resetWalletState();
-    setWallet(newWallet);
-    changeView(1);
-    // fire-and-forget - don't await so UI is responsive
-    void initializeWallet();
+    await activateWallet(newWallet, targetNetwork);
+    if (targetNetwork !== currentNetwork) {
+      return { success: true, networkChanged: targetNetwork };
+    }
     return { success: true };
   }
 
@@ -929,6 +949,6 @@ export const useStore = defineStore('store', () => {
     toggleFavorite,
     toggleHidden,
     tokenIconUrl,
-    getWalletClass
+    loadExistingWallet
   }
 })

--- a/src/utils/dbUtils.ts
+++ b/src/utils/dbUtils.ts
@@ -55,25 +55,19 @@ export async function getAllWalletsWithNetworkInfo(): Promise<WalletInfo[]> {
   }
 }
 
-/**
- * Detects wallet type from the walletId stored in IndexedDB.
- * Returns 'hd' if the walletId starts with 'hd:', 'single' otherwise.
- * This is a fallback for when localStorage metadata is missing.
- */
-export async function getWalletTypeFromDb(
+// Mirrors the IndexedDB lookup inside mainnet-js BaseWallet.named(), but stops after
+// reading the saved walletId. Calling .named() directly would create a new wallet if missing.
+export async function getNamedWalletIdFromDb(
   name: string,
   dbName: "bitcoincash" | "bchtest"
-): Promise<'single' | 'hd'> {
+): Promise<string | undefined> {
   if (!name) throw new Error("Named wallets must have a non-empty name");
 
   const db = new IndexedDBProvider(dbName);
   await db.init();
   try {
     const walletEntry = await db.getWallet(name);
-    if (!walletEntry) return 'single';
-    // walletEntry.wallet contains the walletId string (e.g., 'hd:mainnet:...' or 'seed:mainnet:...')
-    const walletId = (walletEntry as { wallet?: string }).wallet ?? '';
-    return walletId.startsWith('hd:') ? 'hd' : 'single';
+    return walletEntry?.wallet || undefined;
   } finally {
     await db.close();
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { decodeBip39Mnemonic, hexToBin } from "@bitauth/libauth"
 import { Notify } from "quasar";
-import type { Utxo } from "mainnet-js"
-import type { ElectrumTokenData, TokenDataFT, TokenDataNFT, CurrencyShortNames, DateFormat } from "../interfaces/interfaces"
+import { Wallet, TestNetWallet, HDWallet, TestNetHDWallet, type Utxo } from "mainnet-js"
+import type { ElectrumTokenData, TokenDataFT, TokenDataNFT, CurrencyShortNames, DateFormat, WalletType } from "../interfaces/interfaces"
 import { type Ref, watch, type WatchStopHandle } from "vue";
 import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
@@ -19,6 +19,20 @@ export function copyToClipboard(copyText:string|undefined){
 
 export function runAsyncVoid(fn: () => Promise<void>) {
   void fn();
+}
+
+export function walletTypeFromWalletId(walletId: string): 'single' | 'hd' {
+  return walletId.startsWith('hd:') ? 'hd' : 'single';
+}
+
+export async function loadWalletFromId(walletId: string, network: 'mainnet' | 'chipnet'): Promise<WalletType> {
+  const isHD = walletTypeFromWalletId(walletId) === 'hd';
+  if (network === 'mainnet') {
+    const wallet = isHD ? await HDWallet.fromId(walletId) : await Wallet.fromId(walletId);
+    return wallet;
+  }
+  const wallet = isHD ? await TestNetHDWallet.fromId(walletId) : await TestNetWallet.fromId(walletId);
+  return wallet;
 }
 
 // Sanitize untrusted URLs (e.g. from dApp metadata) to prevent protocol abuse.

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -80,6 +80,8 @@ export async function createNewWallet(name: string): Promise<WalletOperationResu
 
     // mainnet-js defaults to m/44'/0'/0' (bitcoindotcom), override to use BCH standard
     Config.DefaultParentDerivationPath = DERIVATION_PATHS.standard.parent;
+    // .named() deliberately creates the new wallet here (non-existence checked above),
+    // elsewhere wallets should be loaded through store.loadExistingWallet
     const mainnetWallet = await Wallet.named(trimmedName);
     const walletId = mainnetWallet.toDbString().replace("mainnet", "testnet");
     await TestNetWallet.replaceNamed(trimmedName, walletId);
@@ -215,6 +217,8 @@ export async function createNewHDWallet(name: string): Promise<WalletOperationRe
     const settingsStore = useSettingsStore();
 
     Config.DefaultParentDerivationPath = DERIVATION_PATHS.standard.parent;
+    // .named() deliberately creates the new wallet here (non-existence checked above),
+    // elsewhere wallets should be loaded through store.loadExistingWallet
     const mainnetWallet = await HDWallet.named(trimmedName);
     const walletId = mainnetWallet.toDbString().replace("mainnet", "testnet");
     await TestNetHDWallet.replaceNamed(trimmedName, walletId);

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -35,6 +35,10 @@ export const mockWalletNamed = vi.fn()
 export const mockTestNetWalletNamed = vi.fn()
 export const mockHDWalletNamed = vi.fn()
 export const mockTestNetHDWalletNamed = vi.fn()
+export const mockWalletFromId = vi.fn().mockResolvedValue(mockMainnetWallet)
+export const mockTestNetWalletFromId = vi.fn().mockResolvedValue(mockChipnetWallet)
+export const mockHDWalletFromId = vi.fn().mockResolvedValue(mockMainnetWallet)
+export const mockTestNetHDWalletFromId = vi.fn().mockResolvedValue(mockChipnetWallet)
 
 // Mock localStorage
 export const localStorageMock = {
@@ -58,10 +62,10 @@ class MockConnection {
 }
 
 // Mock wallet classes (must be real classes so instanceof checks work)
-class MockWallet { static named = mockWalletNamed }
-class MockTestNetWallet { static named = mockTestNetWalletNamed }
-class MockHDWallet { static named = mockHDWalletNamed }
-class MockTestNetHDWallet { static named = mockTestNetHDWalletNamed }
+class MockWallet { static named = mockWalletNamed; static fromId = mockWalletFromId }
+class MockTestNetWallet { static named = mockTestNetWalletNamed; static fromId = mockTestNetWalletFromId }
+class MockHDWallet { static named = mockHDWalletNamed; static fromId = mockHDWalletFromId }
+class MockTestNetHDWallet { static named = mockTestNetHDWalletNamed; static fromId = mockTestNetHDWalletFromId }
 
 // Mock mainnet-js
 vi.mock('mainnet-js', () => ({
@@ -98,15 +102,24 @@ vi.mock('@mainnet-cash/indexeddb-storage', () => ({
 export const mockGetAllWalletsWithNetworkInfo = vi.fn()
 export const mockDeleteWalletFromDb = vi.fn()
 
-export const mockGetWalletTypeFromDb = vi.fn().mockResolvedValue('single')
 // Wallets exist in IndexedDB by default, override per-test to exercise the missing-wallet guard
 export const mockNamedWalletExistsInDb = vi.fn().mockResolvedValue(true)
+function defaultGetNamedWalletIdFromDb(
+  _name: string,
+  dbName: 'bitcoincash' | 'bchtest'
+): Promise<string | undefined> {
+  const walletId = dbName === 'bitcoincash'
+    ? 'seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0'
+    : 'seed:testnet:test mnemonic:m/44\'/145\'/0\'/0/0'
+  return Promise.resolve(walletId)
+}
+export const mockGetNamedWalletIdFromDb = vi.fn(defaultGetNamedWalletIdFromDb)
 
 vi.mock('src/utils/dbUtils', () => ({
   getAllWalletsWithNetworkInfo: mockGetAllWalletsWithNetworkInfo,
   deleteWalletFromDb: mockDeleteWalletFromDb,
-  getWalletTypeFromDb: mockGetWalletTypeFromDb,
   namedWalletExistsInDb: mockNamedWalletExistsInDb,
+  getNamedWalletIdFromDb: mockGetNamedWalletIdFromDb,
 }))
 
 // Mock settingsStore
@@ -172,6 +185,12 @@ vi.mock('src/stores/storeUtils', () => ({
 vi.mock('src/utils/utils', () => ({
   getBalanceFromUtxos: vi.fn().mockReturnValue(0),
   getTokenUtxos: vi.fn().mockReturnValue([]),
+  walletTypeFromWalletId: vi.fn((walletId: string) => walletId.startsWith('hd:') ? 'hd' : 'single'),
+  loadWalletFromId: vi.fn((walletId: string, network: 'mainnet' | 'chipnet') => {
+    const isHD = walletId.startsWith('hd:')
+    if (network === 'mainnet') return isHD ? mockHDWalletFromId(walletId) : mockWalletFromId(walletId)
+    return isHD ? mockTestNetHDWalletFromId(walletId) : mockTestNetWalletFromId(walletId)
+  }),
   runAsyncVoid: vi.fn((fn) => fn()),
   convertElectrumTokenData: vi.fn(),
 }))

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -99,11 +99,14 @@ export const mockGetAllWalletsWithNetworkInfo = vi.fn()
 export const mockDeleteWalletFromDb = vi.fn()
 
 export const mockGetWalletTypeFromDb = vi.fn().mockResolvedValue('single')
+// Wallets exist in IndexedDB by default, override per-test to exercise the missing-wallet guard
+export const mockNamedWalletExistsInDb = vi.fn().mockResolvedValue(true)
 
 vi.mock('src/utils/dbUtils', () => ({
   getAllWalletsWithNetworkInfo: mockGetAllWalletsWithNetworkInfo,
   deleteWalletFromDb: mockDeleteWalletFromDb,
   getWalletTypeFromDb: mockGetWalletTypeFromDb,
+  namedWalletExistsInDb: mockNamedWalletExistsInDb,
 }))
 
 // Mock settingsStore

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -8,12 +8,14 @@ import { setActivePinia, createPinia } from 'pinia'
 import {
   mockWalletNamed,
   mockTestNetWalletNamed,
+  mockWalletFromId,
+  mockTestNetWalletFromId,
   mockMainnetWallet,
   mockChipnetWallet,
   localStorageMock,
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
-  mockNamedWalletExistsInDb,
+  mockGetNamedWalletIdFromDb,
 } from './mocks/store.mocks'
 
 // Import store after mocks
@@ -30,7 +32,6 @@ describe('switchWallet', () => {
   describe('wallet loading', () => {
     it('loads mainnet wallet when network is mainnet', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
 
       const store = useStore()
       // Set initial wallet to avoid "No wallet set" error
@@ -38,40 +39,42 @@ describe('switchWallet', () => {
 
       await store.switchWallet('newWallet')
 
-      expect(mockWalletNamed).toHaveBeenCalledWith('newWallet')
+      expect(mockGetNamedWalletIdFromDb).toHaveBeenCalledWith('newWallet', 'bitcoincash')
+      expect(mockWalletFromId).toHaveBeenCalledWith('seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockWalletNamed).not.toHaveBeenCalled()
       expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
     })
 
     it('loads chipnet wallet when network is chipnet', async () => {
       localStorageMock.setItem('network', 'chipnet')
-      mockTestNetWalletNamed.mockResolvedValue(mockChipnetWallet)
 
       const store = useStore()
       store.setWallet(mockChipnetWallet as never)
 
       await store.switchWallet('newWallet')
 
-      expect(mockTestNetWalletNamed).toHaveBeenCalledWith('newWallet')
+      expect(mockGetNamedWalletIdFromDb).toHaveBeenCalledWith('newWallet', 'bchtest')
+      expect(mockTestNetWalletFromId).toHaveBeenCalledWith('seed:testnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
       expect(mockWalletNamed).not.toHaveBeenCalled()
     })
 
     it('defaults to mainnet when no network in localStorage', async () => {
       // No network set in localStorage
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
 
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
 
       await store.switchWallet('newWallet')
 
-      expect(mockWalletNamed).toHaveBeenCalledWith('newWallet')
+      expect(mockWalletFromId).toHaveBeenCalledWith('seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockWalletNamed).not.toHaveBeenCalled()
     })
   })
 
   describe('state updates', () => {
     beforeEach(() => {
       localStorageMock.setItem('network', 'mainnet')
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
     })
 
     it('updates activeWalletName in store', async () => {
@@ -105,7 +108,6 @@ describe('switchWallet', () => {
 
     it('sets _wallet to chipnet wallet instance', async () => {
       localStorageMock.setItem('network', 'chipnet')
-      mockTestNetWalletNamed.mockResolvedValue(mockChipnetWallet)
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
 
@@ -120,7 +122,6 @@ describe('switchWallet', () => {
   describe('network fallback for network-specific wallets', () => {
     it('switches to mainnet when wallet only exists on mainnet and current network is chipnet', async () => {
       localStorageMock.setItem('network', 'chipnet')
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
       const store = useStore()
       store.setWallet(mockChipnetWallet as never)
       // Set up availableWallets with a mainnet-only wallet
@@ -138,12 +139,12 @@ describe('switchWallet', () => {
       expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
       // Verify network was changed and correct wallet loader was called
       expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'mainnet')
-      expect(mockWalletNamed).toHaveBeenCalledWith('mainnetOnlyWallet')
+      expect(mockWalletFromId).toHaveBeenCalledWith('seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockWalletNamed).not.toHaveBeenCalled()
     })
 
     it('switches to chipnet when wallet only exists on chipnet and current network is mainnet', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockTestNetWalletNamed.mockResolvedValue(mockChipnetWallet)
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
       // Set up availableWallets with a chipnet-only wallet
@@ -161,12 +162,12 @@ describe('switchWallet', () => {
       expect(mockWalletNamed).not.toHaveBeenCalled()
       // Verify network was changed and correct wallet loader was called
       expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'chipnet')
-      expect(mockTestNetWalletNamed).toHaveBeenCalledWith('chipnetOnlyWallet')
+      expect(mockTestNetWalletFromId).toHaveBeenCalledWith('seed:testnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
     })
 
     it('does not change network when wallet exists on current network', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
       // Wallet exists on both networks
@@ -178,12 +179,12 @@ describe('switchWallet', () => {
 
       expect(result.success).toBe(true)
       expect(result.networkChanged).toBeUndefined()
-      expect(mockWalletNamed).toHaveBeenCalledWith('bothNetworks')
+      expect(mockWalletFromId).toHaveBeenCalledWith('seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockWalletNamed).not.toHaveBeenCalled()
     })
 
     it('loads wallet normally when not in availableWallets but present in IndexedDB', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockWalletNamed.mockResolvedValue(mockMainnetWallet)
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
       store.availableWallets = [] // Empty list
@@ -192,14 +193,16 @@ describe('switchWallet', () => {
 
       expect(result.success).toBe(true)
       expect(result.networkChanged).toBeUndefined()
-      expect(mockWalletNamed).toHaveBeenCalledWith('unknownWallet')
+      expect(mockGetNamedWalletIdFromDb).toHaveBeenCalledWith('unknownWallet', 'bitcoincash')
+      expect(mockWalletFromId).toHaveBeenCalledWith('seed:mainnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+      expect(mockWalletNamed).not.toHaveBeenCalled()
     })
   })
 
   describe('error handling', () => {
     it('throws without calling .named() when wallet does not exist in IndexedDB', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+      mockGetNamedWalletIdFromDb.mockResolvedValueOnce(undefined)
 
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
@@ -213,7 +216,7 @@ describe('switchWallet', () => {
     it('does not mutate state when a stale availableWallets entry points to a missing wallet', async () => {
       localStorageMock.setItem('network', 'mainnet')
       localStorageMock.setItem.mockClear()
-      mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+      mockGetNamedWalletIdFromDb.mockResolvedValueOnce(undefined)
 
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
@@ -233,7 +236,7 @@ describe('switchWallet', () => {
 
     it('throws when wallet loading fails', async () => {
       localStorageMock.setItem('network', 'mainnet')
-      mockWalletNamed.mockRejectedValue(new Error('Wallet not found'))
+      mockWalletFromId.mockRejectedValueOnce(new Error('Wallet not found'))
 
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
@@ -245,7 +248,7 @@ describe('switchWallet', () => {
       localStorageMock.setItem('network', 'mainnet')
       localStorageMock.setItem('activeWalletName', 'originalWallet')
       localStorageMock.setItem.mockClear()
-      mockWalletNamed.mockRejectedValue(new Error('Wallet not found'))
+      mockWalletFromId.mockRejectedValueOnce(new Error('Wallet not found'))
 
       const store = useStore()
       store.setWallet(mockMainnetWallet as never)
@@ -277,7 +280,6 @@ describe('changeNetwork', () => {
 
   it('loads the wallet on the new network when it exists there', async () => {
     localStorageMock.setItem('network', 'mainnet')
-    mockTestNetWalletNamed.mockResolvedValue(mockChipnetWallet)
 
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)
@@ -285,13 +287,14 @@ describe('changeNetwork', () => {
 
     await store.changeNetwork('chipnet')
 
-    expect(mockTestNetWalletNamed).toHaveBeenCalledWith('myWallet')
+    expect(mockTestNetWalletFromId).toHaveBeenCalledWith('seed:testnet:test mnemonic:m/44\'/145\'/0\'/0/0')
+    expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
     expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'chipnet')
   })
 
   it('does not create a new wallet when it does not exist on the target network', async () => {
     localStorageMock.setItem('network', 'mainnet')
-    mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+    mockGetNamedWalletIdFromDb.mockResolvedValueOnce(undefined)
 
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -13,6 +13,7 @@ import {
   localStorageMock,
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
+  mockNamedWalletExistsInDb,
 } from './mocks/store.mocks'
 
 // Import store after mocks
@@ -135,8 +136,6 @@ describe('switchWallet', () => {
       expect(localStorageMock.setItem).toHaveBeenCalledWith('activeWalletName', 'mainnetOnlyWallet')
       // Should NOT have called TestNetWallet.named (we're switching away from chipnet)
       expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
-      // changeNetwork is fire-and-forget, wait a tick for its effects
-      await new Promise(r => setTimeout(r, 0))
       // Verify network was changed and correct wallet loader was called
       expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'mainnet')
       expect(mockWalletNamed).toHaveBeenCalledWith('mainnetOnlyWallet')
@@ -160,8 +159,6 @@ describe('switchWallet', () => {
       expect(localStorageMock.setItem).toHaveBeenCalledWith('activeWalletName', 'chipnetOnlyWallet')
       // Should NOT have called Wallet.named (we're switching away from mainnet)
       expect(mockWalletNamed).not.toHaveBeenCalled()
-      // changeNetwork is fire-and-forget, wait a tick for its effects
-      await new Promise(r => setTimeout(r, 0))
       // Verify network was changed and correct wallet loader was called
       expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'chipnet')
       expect(mockTestNetWalletNamed).toHaveBeenCalledWith('chipnetOnlyWallet')
@@ -184,7 +181,7 @@ describe('switchWallet', () => {
       expect(mockWalletNamed).toHaveBeenCalledWith('bothNetworks')
     })
 
-    it('loads wallet normally when not in availableWallets (fresh wallet)', async () => {
+    it('loads wallet normally when not in availableWallets but present in IndexedDB', async () => {
       localStorageMock.setItem('network', 'mainnet')
       mockWalletNamed.mockResolvedValue(mockMainnetWallet)
       const store = useStore()
@@ -200,6 +197,40 @@ describe('switchWallet', () => {
   })
 
   describe('error handling', () => {
+    it('throws without calling .named() when wallet does not exist in IndexedDB', async () => {
+      localStorageMock.setItem('network', 'mainnet')
+      mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+
+      const store = useStore()
+      store.setWallet(mockMainnetWallet as never)
+
+      await expect(store.switchWallet('ghostWallet')).rejects.toThrowError()
+      // .named() would silently create a new wallet with a fresh seed
+      expect(mockWalletNamed).not.toHaveBeenCalled()
+      expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
+    })
+
+    it('does not mutate state when a stale availableWallets entry points to a missing wallet', async () => {
+      localStorageMock.setItem('network', 'mainnet')
+      localStorageMock.setItem.mockClear()
+      mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+
+      const store = useStore()
+      store.setWallet(mockMainnetWallet as never)
+      store.activeWalletName = 'originalWallet'
+      // Stale list claims the wallet exists on chipnet, but IndexedDB disagrees
+      store.availableWallets = [
+        { name: 'staleWallet', hasMainnet: false, hasChipnet: true }
+      ]
+
+      await expect(store.switchWallet('staleWallet')).rejects.toThrowError()
+
+      expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
+      expect(store.activeWalletName).toBe('originalWallet')
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith('activeWalletName', 'staleWallet')
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith('network', 'chipnet')
+    })
+
     it('throws when wallet loading fails', async () => {
       localStorageMock.setItem('network', 'mainnet')
       mockWalletNamed.mockRejectedValue(new Error('Wallet not found'))
@@ -234,6 +265,46 @@ describe('switchWallet', () => {
       expect(store.displayView).toBe(5)
       expect(localStorageMock.setItem).not.toHaveBeenCalledWith('activeWalletName', 'failedWallet')
     })
+  })
+})
+
+describe('changeNetwork', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('loads the wallet on the new network when it exists there', async () => {
+    localStorageMock.setItem('network', 'mainnet')
+    mockTestNetWalletNamed.mockResolvedValue(mockChipnetWallet)
+
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+    store.activeWalletName = 'myWallet'
+
+    await store.changeNetwork('chipnet')
+
+    expect(mockTestNetWalletNamed).toHaveBeenCalledWith('myWallet')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('network', 'chipnet')
+  })
+
+  it('does not create a new wallet when it does not exist on the target network', async () => {
+    localStorageMock.setItem('network', 'mainnet')
+    mockNamedWalletExistsInDb.mockResolvedValueOnce(false)
+
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+    const originalWalletRef = store._wallet
+
+    await store.changeNetwork('chipnet')
+
+    // .named() would silently create a new wallet with a fresh seed
+    expect(mockTestNetWalletNamed).not.toHaveBeenCalled()
+    expect(mockWalletNamed).not.toHaveBeenCalled()
+    // current wallet state and configured network are left untouched
+    expect(store._wallet).toBe(originalWalletRef)
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('network', 'chipnet')
   })
 })
 


### PR DESCRIPTION
WalletClass.named() silently creates a new wallet with a fresh random seed when the name is missing from the network's IndexedDB. A wallet that existed on only one network could therefore be replaced by a new random-seed wallet on network toggle (inheriting the old name's backup status), and the boot path could do the same for legacy single-network wallets.

- Add store.loadExistingWallet(): checks IndexedDB existence and throws before .named() can create anything; all loading (changeNetwork, switchWallet, boot) now goes through it. Only the creation flows in walletUtils.ts use .named() directly, now with explanatory comments.
- changeNetwork loads the wallet on the target network first and leaves current state untouched when it doesn't exist there (new walletNotFoundOnNetwork error in all 5 locales).
- Boot path corrects the configured network when the wallet only exists on the other network, instead of loading a missing wallet.
- Extract shared activateWallet() from changeNetwork/switchWallet.
- Guard the two HD address views with instanceof, since the wallet can briefly be non-HD mid wallet-switch.
- Regression tests: missing-wallet guard for switchWallet and changeNetwork, stale availableWallets entry, no-mutation invariants.