### PR TITLE
add date range filter and CSV export to transaction history

### DIFF
--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -7,12 +7,16 @@
   import TransactionDialog from './transactionDialog.vue';
   import EmojiItem from '../general/emojiItem.vue';
   import { formatTimestamp, formatTime, formatFiatAmount } from 'src/utils/utils';
+  import { historyToCsv } from 'src/utils/csvUtils';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
+  import { exportFile, useQuasar } from 'quasar'
 
   const store = useStore()
   const settingsStore = useSettingsStore()
   const { t } = useI18n()
+  const $q = useQuasar()
+  const isCapacitor = import.meta.env.QUASAR_CAPACITOR_MODE;
   const itemsPerPage = 100
   const { width } = useWindowSize();
   const isMobile = computed(() => width.value <= 600)
@@ -23,6 +27,8 @@
   const showFiatValue = ref(settingsStore.showFiatValueHistory)
   const hideBalance = ref(settingsStore.hideBalanceColumn)
   const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions");
+  const dateFrom = ref("");
+  const dateTo = ref("");
 
   const currentPage = ref(1)
   const selectedTransaction = ref(undefined as TransactionHistoryItem | undefined);
@@ -36,11 +42,31 @@
     return store.network === "mainnet" ? "BCH" : "tBCH";
   });
 
+  // Date inputs hold local calendar dates (YYYY-MM-DD); compare in local time to match the displayed dates
+  function localDayStart(isoDate: string, dayOffset = 0): number {
+    const [year = 0, month = 1, day = 1] = isoDate.split('-').map(Number);
+    return new Date(year, month - 1, day + dayOffset).getTime() / 1000;
+  }
+
   const selectedHistory = computed(() => {
-    if (selectedFilter.value === "bchTransactions") return store.walletHistory?.filter(tx => !tx.tokenAmountChanges.length);
-    if (selectedFilter.value === "tokenTransactions") return store.walletHistory?.filter(tx => tx.tokenAmountChanges.length);
-    return store.walletHistory;
+    let history = store.walletHistory;
+    if (selectedFilter.value === "bchTransactions") history = history?.filter(tx => !tx.tokenAmountChanges.length);
+    if (selectedFilter.value === "tokenTransactions") history = history?.filter(tx => tx.tokenAmountChanges.length);
+    const fromTimestamp = dateFrom.value ? localDayStart(dateFrom.value) : undefined;
+    const untilTimestamp = dateTo.value ? localDayStart(dateTo.value, 1) : undefined;
+    if (fromTimestamp !== undefined || untilTimestamp !== undefined) {
+      // Pending transactions have no timestamp yet, treat them as happening now
+      history = history?.filter(tx => {
+        const txTimestamp = tx.timestamp ?? Date.now() / 1000;
+        if (fromTimestamp !== undefined && txTimestamp < fromTimestamp) return false;
+        if (untilTimestamp !== undefined && txTimestamp >= untilTimestamp) return false;
+        return true;
+      });
+    }
+    return history;
   });
+
+  watch([selectedFilter, dateFrom, dateTo], () => { currentPage.value = 1 });
 
   const transactionCount = computed(() => selectedHistory.value?.length);
 
@@ -62,6 +88,12 @@
   function toggleHideBalance() {
     localStorage.setItem("hideBalanceColumn", hideBalance.value ? "true" : "false");
     settingsStore.hideBalanceColumn = hideBalance.value;
+  }
+
+  function exportCsv() {
+    const csvContent = historyToCsv(selectedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value);
+    const status = exportFile("cashonize-tx-history.csv", csvContent, { mimeType: "text/csv" });
+    if (status !== true) $q.notify({ message: t('history.exportFailed'), icon: 'warning', color: "red" });
   }
 </script>
 
@@ -96,10 +128,19 @@
           </select>
         </div>
         <div class="option-item">
+          <label for="dateFrom">{{ t('history.filter.dateRange') }}</label>
+          <input type="date" id="dateFrom" v-model="dateFrom" :max="dateTo || undefined">
+          <span>–</span>
+          <input type="date" id="dateTo" v-model="dateTo" :min="dateFrom || undefined">
+        </div>
+        <div class="option-item">
           {{ t('history.showFiatValue') }} <q-toggle v-model="showFiatValue" @update:model-value="toggleShowFiatValue" dense />
         </div>
         <div class="option-item">
           {{ t('history.hideBalanceColumn') }} <q-toggle v-model="hideBalance" @update:model-value="toggleHideBalance" dense />
+        </div>
+        <div class="option-item" v-if="!isCapacitor">
+          <button @click="exportCsv">{{ t('history.exportCsv') }}</button>
         </div>
       </div>
 
@@ -252,6 +293,18 @@
 .option-item select {
   width: 100px;
   padding: 2px 8px;
+}
+
+.option-item input[type="date"] {
+  width: auto;
+  padding: 2px 8px;
+  font-size: 0.9em;
+  font-family: inherit;
+}
+
+.option-item button {
+  padding: 6px 14px;
+  font-size: 0.9em;
 }
 
 .tx-table {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -383,6 +383,13 @@
       "balance": "Guthaben",
       "tokens": "Tokens"
     },
+    "csv": {
+      "date": "Datum (UTC)",
+      "transactionId": "Transaktions-ID",
+      "amount": "Betrag ({unit})",
+      "balance": "Guthaben ({unit})",
+      "tokenChanges": "Token-Änderungen"
+    },
     "pending": "ausstehend",
     "transactionCountPartial": "{count}+ Transaktionen",
     "loadingFullHistory": "Lade vollständige Historie..."

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -370,10 +370,13 @@
       "label": "Anzeigen:",
       "all": "Alle",
       "bchTxs": "BCH-Txs",
-      "tokenTxs": "Token-Txs"
+      "tokenTxs": "Token-Txs",
+      "dateRange": "Zeitraum:"
     },
     "showFiatValue": "Fiat-Wert anzeigen",
-    "hideBalanceColumn": "Guthaben-Spalte ausblenden",
+    "hideBalanceColumn": "Guthaben ausblenden",
+    "exportCsv": "CSV exportieren",
+    "exportFailed": "CSV-Export fehlgeschlagen",
     "columns": {
       "date": "Datum",
       "amount": "Betrag",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -370,10 +370,13 @@
       "label": "Show:",
       "all": "All",
       "bchTxs": "BCH txs",
-      "tokenTxs": "Token txs"
+      "tokenTxs": "Token txs",
+      "dateRange": "Filter range:"
     },
     "showFiatValue": "Show fiat value",
-    "hideBalanceColumn": "Hide balance column",
+    "hideBalanceColumn": "Hide balance",
+    "exportCsv": "Export CSV",
+    "exportFailed": "CSV export failed",
     "columns": {
       "date": "Date",
       "amount": "Amount",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -383,6 +383,13 @@
       "balance": "Balance",
       "tokens": "Tokens"
     },
+    "csv": {
+      "date": "Date (UTC)",
+      "transactionId": "Transaction Id",
+      "amount": "Amount ({unit})",
+      "balance": "Balance ({unit})",
+      "tokenChanges": "Token Changes"
+    },
     "pending": "pending",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Loading full history..."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -370,10 +370,13 @@
       "label": "Mostrar:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
-      "tokenTxs": "Txs de tokens"
+      "tokenTxs": "Txs de tokens",
+      "dateRange": "Rango de fechas:"
     },
     "showFiatValue": "Mostrar valor en fiat",
-    "hideBalanceColumn": "Ocultar columna de saldo",
+    "hideBalanceColumn": "Ocultar saldo",
+    "exportCsv": "Exportar CSV",
+    "exportFailed": "Error al exportar CSV",
     "columns": {
       "date": "Fecha",
       "amount": "Cantidad",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -383,6 +383,13 @@
       "balance": "Saldo",
       "tokens": "Tokens"
     },
+    "csv": {
+      "date": "Fecha (UTC)",
+      "transactionId": "ID de transacción",
+      "amount": "Cantidad ({unit})",
+      "balance": "Saldo ({unit})",
+      "tokenChanges": "Cambios de tokens"
+    },
     "pending": "pendiente",
     "transactionCountPartial": "{count}+ Transacciones",
     "loadingFullHistory": "Cargando historial completo..."

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -383,6 +383,13 @@
       "balance": "Solde",
       "tokens": "Tokens"
     },
+    "csv": {
+      "date": "Date (UTC)",
+      "transactionId": "ID de transaction",
+      "amount": "Montant ({unit})",
+      "balance": "Solde ({unit})",
+      "tokenChanges": "Variations de tokens"
+    },
     "pending": "en attente",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Chargement de l'historique complet..."

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -370,10 +370,13 @@
       "label": "Afficher :",
       "all": "Toutes",
       "bchTxs": "Txs BCH",
-      "tokenTxs": "Txs tokens"
+      "tokenTxs": "Txs tokens",
+      "dateRange": "Plage de dates :"
     },
     "showFiatValue": "Afficher la valeur en devise",
-    "hideBalanceColumn": "Masquer la colonne solde",
+    "hideBalanceColumn": "Masquer le solde",
+    "exportCsv": "Exporter en CSV",
+    "exportFailed": "Échec de l'export CSV",
     "columns": {
       "date": "Date",
       "amount": "Montant",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -370,10 +370,13 @@
       "label": "Exibir:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
-      "tokenTxs": "Txs de tokens"
+      "tokenTxs": "Txs de tokens",
+      "dateRange": "Intervalo de datas:"
     },
     "showFiatValue": "Mostrar valor em fiat",
-    "hideBalanceColumn": "Ocultar coluna de saldo",
+    "hideBalanceColumn": "Ocultar saldo",
+    "exportCsv": "Exportar CSV",
+    "exportFailed": "Falha ao exportar CSV",
     "columns": {
       "date": "Data",
       "amount": "Valor",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -383,6 +383,13 @@
       "balance": "Saldo",
       "tokens": "Tokens"
     },
+    "csv": {
+      "date": "Data (UTC)",
+      "transactionId": "ID da transação",
+      "amount": "Valor ({unit})",
+      "balance": "Saldo ({unit})",
+      "tokenChanges": "Alterações de tokens"
+    },
     "pending": "pendente",
     "transactionCountPartial": "{count}+ Transações",
     "loadingFullHistory": "Carregando histórico completo..."

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -1,29 +1,51 @@
 import type { TransactionHistoryItem } from "mainnet-js";
 import type { BcmrTokenMetadata } from "src/interfaces/interfaces";
+import { i18n } from "src/boot/i18n";
 
+const { t } = i18n.global;
+
+const SATS_PER_BCH = 100_000_000;
+
+type TokenAmountChange = TransactionHistoryItem["tokenAmountChanges"][number];
+
+// Quote a field (and double any embedded quotes) when it contains a comma, quote or
+// newline, so it survives as a single cell. Follows RFC 4180.
 export function csvEscape(field: string): string {
   return /[",\n]/.test(field) ? `"${field.replaceAll('"', '""')}"` : field;
 }
 
-function tokenChangesText(
-  tokenAmountChanges: TransactionHistoryItem["tokenAmountChanges"],
+// Token symbols come from attacker-controlled metadata. A cell starting with = + - @ is
+// treated as a formula by spreadsheet apps, so restrict symbols to plainly safe characters.
+function sanitizeSymbol(symbol: string): string {
+  return symbol.replace(/[^a-zA-Z0-9._-]/g, "");
+}
+
+// Prefix positive amounts with "+" so the direction of every change is explicit.
+function withSign(amount: number | bigint): string {
+  return amount > 0 ? `+${amount}` : `${amount}`;
+}
+
+// Render one token's fungible and/or NFT change as e.g. "+123.45 FURU; -1 FURU NFT".
+function formatTokenChange(
+  tokenChange: TokenAmountChange,
   bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined
 ): string {
-  return tokenAmountChanges.map(tokenChange => {
-    // strip formula-injection characters from attacker-controlled token symbols (CSV cells starting with = + - @ can execute in spreadsheet apps)
-    const rawSymbol = bcmrRegistries?.[tokenChange.category]?.token?.symbol ?? tokenChange.category.slice(0, 8);
-    const symbol = rawSymbol.replace(/[^a-zA-Z0-9._-]/g, "") || tokenChange.category.slice(0, 8);
-    const decimals = bcmrRegistries?.[tokenChange.category]?.token.decimals ?? 0;
-    const changes: string[] = [];
-    if (tokenChange.amount !== 0n || tokenChange.nftAmount == 0n) {
-      const amount = Number(tokenChange.amount) / 10 ** decimals;
-      changes.push(`${amount > 0 ? '+' : ''}${amount} ${symbol}`);
-    }
-    if (tokenChange.nftAmount) {
-      changes.push(`${tokenChange.nftAmount > 0n ? '+' : ''}${tokenChange.nftAmount} ${symbol} NFT`);
-    }
-    return changes.join("; ");
-  }).join("; ");
+  const tokenMetadata = bcmrRegistries?.[tokenChange.category]?.token;
+  const categoryPrefix = tokenChange.category.slice(0, 8);
+  const symbol = sanitizeSymbol(tokenMetadata?.symbol ?? categoryPrefix) || categoryPrefix;
+  const decimals = tokenMetadata?.decimals ?? 0;
+
+  const parts: string[] = [];
+  // Show the fungible change for any nonzero amount. When there is no NFT change either,
+  // still show it (as "0 SYMBOL") so an entry never renders as an empty cell.
+  if (tokenChange.amount !== 0n || tokenChange.nftAmount === 0n) {
+    const amount = Number(tokenChange.amount) / 10 ** decimals;
+    parts.push(`${withSign(amount)} ${symbol}`);
+  }
+  if (tokenChange.nftAmount !== 0n) {
+    parts.push(`${withSign(tokenChange.nftAmount)} ${symbol} NFT`);
+  }
+  return parts.join("; ");
 }
 
 export function historyToCsv(
@@ -31,13 +53,21 @@ export function historyToCsv(
   bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined,
   bchUnit: string
 ): string {
-  const header = ["Date (UTC)", "Transaction Id", `Amount (${bchUnit})`, `Balance (${bchUnit})`, "Token Changes"];
+  const header = [
+    t("history.csv.date"),
+    t("history.csv.transactionId"),
+    t("history.csv.amount", { unit: bchUnit }),
+    t("history.csv.balance", { unit: bchUnit }),
+    t("history.csv.tokenChanges"),
+  ];
   const rows = history.map(tx => [
-    tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : "pending",
+    tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : t("history.pending"),
     tx.hash,
-    (tx.valueChange / 100_000_000).toFixed(8),
-    (tx.balance / 100_000_000).toFixed(8),
-    tokenChangesText(tx.tokenAmountChanges, bcmrRegistries)
+    (tx.valueChange / SATS_PER_BCH).toFixed(8),
+    (tx.balance / SATS_PER_BCH).toFixed(8),
+    tx.tokenAmountChanges.map(change => formatTokenChange(change, bcmrRegistries)).join("; "),
   ]);
-  return [header, ...rows].map(row => row.map(csvEscape).join(",")).join("\r\n");
+  return [header, ...rows]
+    .map(row => row.map(csvEscape).join(","))
+    .join("\r\n");
 }

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -1,0 +1,43 @@
+import type { TransactionHistoryItem } from "mainnet-js";
+import type { BcmrTokenMetadata } from "src/interfaces/interfaces";
+
+export function csvEscape(field: string): string {
+  return /[",\n]/.test(field) ? `"${field.replaceAll('"', '""')}"` : field;
+}
+
+function tokenChangesText(
+  tokenAmountChanges: TransactionHistoryItem["tokenAmountChanges"],
+  bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined
+): string {
+  return tokenAmountChanges.map(tokenChange => {
+    // strip formula-injection characters from attacker-controlled token symbols (CSV cells starting with = + - @ can execute in spreadsheet apps)
+    const rawSymbol = bcmrRegistries?.[tokenChange.category]?.token?.symbol ?? tokenChange.category.slice(0, 8);
+    const symbol = rawSymbol.replace(/[^a-zA-Z0-9._-]/g, "") || tokenChange.category.slice(0, 8);
+    const decimals = bcmrRegistries?.[tokenChange.category]?.token.decimals ?? 0;
+    const changes: string[] = [];
+    if (tokenChange.amount !== 0n || tokenChange.nftAmount == 0n) {
+      const amount = Number(tokenChange.amount) / 10 ** decimals;
+      changes.push(`${amount > 0 ? '+' : ''}${amount} ${symbol}`);
+    }
+    if (tokenChange.nftAmount) {
+      changes.push(`${tokenChange.nftAmount > 0n ? '+' : ''}${tokenChange.nftAmount} ${symbol} NFT`);
+    }
+    return changes.join("; ");
+  }).join("; ");
+}
+
+export function historyToCsv(
+  history: TransactionHistoryItem[],
+  bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined,
+  bchUnit: string
+): string {
+  const header = ["Date (UTC)", "Transaction Id", `Amount (${bchUnit})`, `Balance (${bchUnit})`, "Token Changes"];
+  const rows = history.map(tx => [
+    tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : "pending",
+    tx.hash,
+    (tx.valueChange / 100_000_000).toFixed(8),
+    (tx.balance / 100_000_000).toFixed(8),
+    tokenChangesText(tx.tokenAmountChanges, bcmrRegistries)
+  ]);
+  return [header, ...rows].map(row => row.map(csvEscape).join(",")).join("\r\n");
+}

--- a/test/csvUtils.test.ts
+++ b/test/csvUtils.test.ts
@@ -1,0 +1,69 @@
+import { csvEscape, historyToCsv } from "../src/utils/csvUtils";
+import type { TransactionHistoryItem } from "mainnet-js";
+import type { BcmrTokenMetadata } from "../src/interfaces/interfaces";
+
+const categoryA = "aabbccdd".repeat(8);
+const categoryB = "11223344".repeat(8);
+
+const makeTx = (overrides: Partial<TransactionHistoryItem>): TransactionHistoryItem => ({
+  hash: "txhash123",
+  blockHeight: 800000,
+  timestamp: 1700000000, // 2023-11-14T22:13:20.000Z
+  size: 250,
+  fee: 300,
+  balance: 150_000_000,
+  valueChange: -50_000_000,
+  inputs: [],
+  outputs: [],
+  tokenAmountChanges: [],
+  ...overrides,
+});
+
+const registries = {
+  [categoryA]: { token: { symbol: "FURU", decimals: 2 } },
+  [categoryB]: { token: { symbol: "=cmd|' /C calc'!A0", decimals: 0 } },
+} as unknown as Record<string, BcmrTokenMetadata>;
+
+describe('csvEscape', () => {
+  it('should leave plain fields unchanged', () => {
+    expect(csvEscape("plain text")).toBe("plain text");
+  })
+  it('should quote fields containing commas and escape embedded quotes', () => {
+    expect(csvEscape("a,b")).toBe('"a,b"');
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+  })
+})
+
+describe('historyToCsv', () => {
+  it('should write the header with the given BCH unit', () => {
+    expect(historyToCsv([], undefined, "tBCH"))
+      .toBe("Date (UTC),Transaction Id,Amount (tBCH),Balance (tBCH),Token Changes");
+  })
+  it('should format the date as ISO UTC and amounts with 8 decimals', () => {
+    const csv = historyToCsv([makeTx({})], undefined, "BCH");
+    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,");
+  })
+  it('should mark unconfirmed transactions as pending', () => {
+    const pendingTx = makeTx({});
+    delete pendingTx.timestamp;
+    const csv = historyToCsv([pendingTx], undefined, "BCH");
+    expect(csv).toContain("pending,txhash123");
+  })
+  it('should apply token symbol and decimals from the registry', () => {
+    const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: 12345n, nftAmount: -1n }] });
+    const csv = historyToCsv([tx], registries, "BCH");
+    expect(csv).toContain("+123.45 FURU; -1 FURU NFT");
+  })
+  it('should fall back to the category prefix for unknown tokens', () => {
+    const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: -5n, nftAmount: 0n }] });
+    const csv = historyToCsv([tx], undefined, "BCH");
+    expect(csv).toContain("-5 aabbccdd");
+  })
+  it('should strip formula-injection characters from token symbols', () => {
+    const tx = makeTx({ tokenAmountChanges: [{ category: categoryB, amount: 1n, nftAmount: 0n }] });
+    const csv = historyToCsv([tx], registries, "BCH");
+    expect(csv).not.toContain("=cmd");
+    expect(csv).not.toContain("|");
+    expect(csv).toContain("+1 cmdCcalcA0");
+  })
+})


### PR DESCRIPTION
- filter history by a local-time date range with native date inputs
- export the filtered history as CSV via Quasar's exportFile (hidden on Capacitor where blob downloads don't work)
- sanitize attacker-controlled token symbols against CSV formula injection
- shorten "Hide balance column" label to "Hide balance"
- reset pagination when filters change

closes #102 