### PR TITLE
add WizardConnect dapp connection protocol support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ v3 introduced breaking changes including HD wallet support with new classes (`HD
 - **@electrum-cash/network**: Electrum client used under mainnet-js (https://gitlab.com/electrum-cash/network)
 - **@reown/walletkit**: WalletConnect integration (wraps @walletconnect/* packages). Uses BCH-specific payloads per the WC2-BCH spec: https://github.com/mainnet-pat/wc2-bch-bcr
 - **@cashconnect-js/core** & **@cashconnect-js/nostr**: CashConnect protocol for BCH-native dApp connections. Docs: https://cashconnect.developers.cash/ — Repo: https://gitlab.com/cashconnect-js/cashconnect-js
-- **@wizardconnect/core** & **@wizardconnect/wallet**: WizardConnect protocol for BCH HD-wallet dApp connections over Nostr relays (`wiz:` URIs). The wallet shares chain-level xpubs (receive/change/defi) so dapps derive addresses locally; the only interactive request is transaction signing, which MUST use `SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID` (see `wizSigning.ts`). Nostr transport is fully encapsulated in @wizardconnect/core — no separate nostr deps. HD wallets only; single-address wallets get a clear error on pairing. Repo: https://gitlab.com/riftenlabs/lib/wizardconnect
+- **@wizardconnect/core** & **@wizardconnect/wallet**: WizardConnect protocol for BCH HD-wallet dApp connections. Repo: https://gitlab.com/riftenlabs/lib/wizardconnect
 
 ### Electrum Connections
 mainnet-js configures `@electrum-cash/web-socket` to keep connections alive across visibility changes (tab switches, app backgrounding, window minimizing) rather than disconnecting/reconnecting. This matters because wallet subscriptions (balance watches, token monitors) are fire-and-forget callbacks via `runAsyncVoid`, so forcibly rejected electrum requests would surface as uncaught promise errors.
@@ -68,6 +68,9 @@ mainnet-js configures `@electrum-cash/web-socket` to keep connections alive acro
 
 ### CashConnect Transport
 CashConnect communicates over a Nostr relay (default `wss://nostr.infra.cash`). The relay is store-and-forward with per-message TTLs, so dApp and wallet don't need to be online at the same time — a session survives either side going offline (short-lived messages like balance pushes simply expire rather than being replayed). Sessions persist in localStorage, namespaced per wallet identity key, and are restored by the library's `start()`; the app's `cashconnectStore.stop()` stops the service without un-pairing.
+
+### WizardConnect
+WizardConnect connects HD wallets to dApps over Nostr relays (`wiz:` URIs); the transport is fully encapsulated in @wizardconnect/core, so no separate nostr dependencies are needed. The wallet shares chain-level xpubs (receive/change/defi) so dapps derive addresses locally; the only interactive request is transaction signing, which MUST use `SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID` (see `wizSigning.ts`). HD wallets only; single-address wallets get a clear error on pairing.
 
 ### Token Metadata (BCMR)
 BCMR (Bitcoin Cash Metadata Registries) is the metadata standard for CashTokens on BCH. Spec: https://github.com/bitjson/chip-bcmr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ Single-route SPA — views are switched via `store.displayView` in `WalletPage.v
 ### Platform Concurrency
 Only the web (SPA) target can run multiple live app instances at once: several browser tabs (or a PWA window plus a tab) share the same localStorage and IndexedDB, but each has its own in-memory Pinia state, electrum connections, and WalletKit instance. There is no cross-tab sync (no `storage` listener or `BroadcastChannel`), so code that persists mutable state must assume another tab can read or write the same keys concurrently and that in-memory state may be stale relative to storage. Electron is single-window by construction (one `createWindow`, all `window.open` denied in `electron-main.ts`) and the Android activity is `launchMode="singleTask"`, so desktop and mobile always have exactly one live instance.
 
+### Wallet Concurrency
+Regardless of app instances, the same wallet can be live elsewhere: the user may run Cashonize on several devices at once, or share the seed with other wallet software. On-chain wallet state can therefore change at any moment from outside the running app: in-memory UTXOs, balance and history are a cache kept fresh by electrum subscriptions, not a source of truth, and flows that hold UTXO state across user interaction (coin selection, sign dialogs) must tolerate it going stale.
+
 ### mainnet-js (Core Wallet Library)
 
 The wallet functionality is powered by `mainnet-js` v3, built on `@bitauth/libauth` for cryptographic primitives and transaction building, and `@electrum-cash/network` for blockchain data fetching from Electrum servers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Cashonize is a Bitcoin Cash (BCH) wallet supporting CashTokens, WalletConnect, and CashConnect. Built with Quasar Framework and TypeScript. Uses Vue 3 Composition API (`<script setup>`) and Pinia for state management. Targets multiple platforms: web (SPA), desktop (Electron), and mobile (Capacitor).
+Cashonize is a Bitcoin Cash (BCH) wallet supporting CashTokens, WalletConnect, CashConnect and WizardConnect. Built with Quasar Framework and TypeScript. Uses Vue 3 Composition API (`<script setup>`) and Pinia for state management. Targets multiple platforms: web (SPA), desktop (Electron), and mobile (Capacitor).
 
 ## Commands
 
@@ -56,6 +56,7 @@ v3 introduced breaking changes including HD wallet support with new classes (`HD
 - **@electrum-cash/network**: Electrum client used under mainnet-js (https://gitlab.com/electrum-cash/network)
 - **@reown/walletkit**: WalletConnect integration (wraps @walletconnect/* packages). Uses BCH-specific payloads per the WC2-BCH spec: https://github.com/mainnet-pat/wc2-bch-bcr
 - **@cashconnect-js/core** & **@cashconnect-js/wallet**: CashConnect protocol for BCH-native dApp connections. Docs: https://cashconnect.developers.cash/ — Repo: https://gitlab.com/cashconnect-js/cashconnect-js
+- **@wizardconnect/core** & **@wizardconnect/wallet**: WizardConnect protocol for BCH HD-wallet dApp connections over Nostr relays (`wiz:` URIs). The wallet shares chain-level xpubs (receive/change/defi) so dapps derive addresses locally; the only interactive request is transaction signing, which MUST use `SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID` (see `wizSigning.ts`). Nostr transport is fully encapsulated in @wizardconnect/core — no separate nostr deps. HD wallets only; single-address wallets get a clear error on pairing. Repo: https://gitlab.com/riftenlabs/lib/wizardconnect
 
 ### Electrum Connections
 mainnet-js configures `@electrum-cash/web-socket` to keep connections alive across visibility changes (tab switches, app backgrounding, window minimizing) rather than disconnecting/reconnecting. This matters because wallet subscriptions (balance watches, token monitors) are fire-and-forget callbacks via `runAsyncVoid`, so forcibly rejected electrum requests would surface as uncaught promise errors.
@@ -83,8 +84,9 @@ src/components/
 ├── bchWallet.vue, myTokens.vue, connectDapp.vue, settingsMenu.vue  # Main tab views
 ├── walletOnboarding.vue                                             # Initial setup
 ├── settings/          # Components accessed from settings menu
-├── walletconnect/     # WC2 session and dialog components
+├── walletconnect/     # WC2 session and dialog components (WC2TransactionRequest is shared with wizardconnect)
 ├── cashconnect/       # CC session and dialog components
+├── wizardconnect/     # WizardConnect session components (sign dialogs are opened from wizardconnectStore)
 ├── history/           # Transaction history components
 ├── tokenItems/        # Token display components (FT, NFT)
 ├── qr/                # QR scanning components
@@ -114,7 +116,7 @@ Unit tests (`/test`, vitest) and E2E tests (`/test/e2e`, Playwright). See `devel
 
 ## Dependency Pinning
 
-Security-critical dependencies (key material, signing, dApp communication: mainnet-js, libauth, walletkit, @walletconnect/core, indexeddb-storage, cashconnect) use exact versions in `package.json`; the ones that also appear as transitive deps are pinned graph-wide in the pnpm `overrides` block. Upgrades to these must be deliberate and reviewed — bump both places together.
+Security-critical dependencies (key material, signing, dApp communication: mainnet-js, libauth, walletkit, @walletconnect/core, indexeddb-storage, cashconnect, wizardconnect) use exact versions in `package.json`; the ones that also appear as transitive deps are pinned graph-wide in the pnpm `overrides` block. Upgrades to these must be deliberate and reviewed — bump both places together. `@wizardconnect/wallet` additionally carries a pnpm patch (`patches/`) fixing a disconnect race — re-check whether it's still needed on upgrades.
 
 ## Code Style Preferences
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because of its minimalist design, Cashonize is a user-friendly wallet, even for 
 Cashonize has an easy-to-understand transaction preview screen for WalletConnect and CashConnect, empowering users before signing DeFi transactions.
 Further, Cashonize nicely groups and displays your NFTs, making it ideal for NFT collectors.
 
-Cashonize has multi-wallet support with both single-address and HD wallet options. HD wallets use a new address for each transaction, providing basic privacy for everyday payments.
+Cashonize lets you create and switch between multiple wallets. There are two wallet types supported: single-address wallet and HD wallet. HD wallets use a new address for each transaction, providing basic privacy for everyday payments.
 
 Cashonize does not currently support password or pin locked wallets and encrypted seed phrases.
 
@@ -22,6 +22,7 @@ Cashonize does not currently support password or pin locked wallets and encrypte
 
 - **Send & receive BCH and CashTokens** - Full support for fungible tokens and NFTs
 - **Connect to dApps via WalletConnect** - Easy-to-understand transaction preview screen
+- **WizardConnect support** - Connect HD wallets to dApps through the Nostr-based WizardConnect protocol
 - **Open-source and non-custodial** - You control your keys
 - **Multi-wallet support** - Create and manage multiple wallets (single-address or HD)
 - **Minimalist design** - Easy to use with a clean, simple interface

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Cashonize: a Bitcoin Cash Wallet
 
 **Cashonize is an easy-to-use, multi-platform Bitcoin Cash wallet** <br>
-Cashonize supports CashTokens and WalletConnect which makes it an ideal wallet for using dapps on BCH. <br>
+Cashonize supports CashTokens and the WalletConnect, CashConnect and WizardConnect connection methods, which makes it an ideal wallet for using dapps on BCH. <br>
 Currently Cashonize is available as a webwallet, a desktop application (for Windows & Linux), an Android APK and an Installable web app. <br>
 
 Cashonize is available in English, Spanish, French, German, and Portuguese.
@@ -11,7 +11,7 @@ Cashonize is available in English, Spanish, French, German, and Portuguese.
 ### The wallet for you?
 
 Because of its minimalist design, Cashonize is a user-friendly wallet, even for inexperienced users.
-Cashonize has an easy-to-understand transaction preview screen for WalletConnect and CashConnect, empowering users before signing DeFi transactions.
+Cashonize has an easy-to-understand transaction preview screen for WalletConnect, CashConnect and WizardConnect, empowering users before signing DeFi transactions.
 Further, Cashonize nicely groups and displays your NFTs, making it ideal for NFT collectors.
 
 Cashonize lets you create and switch between multiple wallets. There are two wallet types supported: single-address wallet and HD wallet. HD wallets use a new address for each transaction, providing basic privacy for everyday payments.
@@ -35,7 +35,7 @@ Cashonize does not currently support password or pin locked wallets and encrypte
 ### Exclusive Features
 
 - **CashConnect support** - Connect to BCH-native dApps through the CashConnect protocol
-- **Detailed WC/CC transaction preview** - Shows your balance changes for BCH and tokens before signing
+- **Detailed dApp transaction preview** - Shows your balance changes for BCH and tokens before signing
 - **Token management** - Favorite, hide, and search tokens
 - **Cauldron price display** - View live Cauldron DEX prices for fungible tokens
 - **Parsable NFTs** - Decode NFT commitments and display their data as human-readable attributes (parsable BCMR support)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cashonize-wallet",
   "version": "0.8.2",
-  "description": "Cashonize is a Bitcoin Cash (BCH) Wallet which supports CashTokens, WalletConnect and CashConnect.",
+  "description": "Cashonize is a Bitcoin Cash (BCH) Wallet which supports CashTokens, WalletConnect, CashConnect and WizardConnect.",
   "productName": "Cashonize",
   "author": "Mathieu Geukens",
   "repository": {
@@ -27,6 +27,8 @@
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",
     "@walletconnect/core": "2.23.9",
+    "@wizardconnect/core": "0.2.4",
+    "@wizardconnect/wallet": "0.2.2",
     "mainnet-js": "3.1.7",
     "pinia": "^3.0.4",
     "qr-scanner": "^1.4.2",

--- a/patches/@wizardconnect__wallet@0.2.2.patch
+++ b/patches/@wizardconnect__wallet@0.2.2.patch
@@ -1,0 +1,43 @@
+diff --git a/dist/wallet-connection-manager.js b/dist/wallet-connection-manager.js
+index 65729ae935beef17654516ca81113c94cf6d0a69..e26e8334f6fb20f8e992168fc3eb3d9b5fe51e26 100644
+--- a/dist/wallet-connection-manager.js
++++ b/dist/wallet-connection-manager.js
+@@ -113,21 +113,31 @@ export class WalletConnectionManager extends EventEmitter {
+         const conn = this.connections.get(connectionId);
+         if (!conn)
+             return;
++        // Cleanup must wait for the courtesy disconnect message to be relayed:
++        // running it synchronously tears down the relay connection while the
++        // message is still in flight, so the dapp never learns of the disconnect.
++        const clean = () => {
++            for (const seq of conn.signSequences) {
++                this.activeSignSequences.delete(seq);
++            }
++            clearInterval(conn.notificationProcessor ?? undefined);
++            conn.cleanup();
++            this.connections.delete(connectionId);
++            this.emit("connectionsChanged");
++        };
+         if (sendMessage && conn.client) {
+             const disconnectMsg = {
+                 action: RelayMsgAction.Disconnect,
+                 reason: DisconnectReason.UserDisconnect,
+                 time: Math.floor(Date.now() / 1000),
+             };
+-            conn.client.relay(disconnectMsg).catch(() => { });
++            conn.client.relay(disconnectMsg)
++                .then(() => { clean(); })
++                .catch(() => { clean(); });
+         }
+-        for (const seq of conn.signSequences) {
+-            this.activeSignSequences.delete(seq);
++        else {
++            clean();
+         }
+-        clearInterval(conn.notificationProcessor ?? undefined);
+-        conn.cleanup();
+-        this.connections.delete(connectionId);
+-        this.emit("connectionsChanged");
+     }
+     /**
+      * Get all connection states (for UI/Redux).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@bitauth/libauth': 3.1.0-next.8
   '@reown/walletkit': 1.5.6
   '@walletconnect/core': 2.23.9
+  '@wizardconnect/core': 0.2.4
   mainnet-js: 3.1.7
   tar: 7.5.16
   vite: 8.0.16
@@ -17,6 +18,9 @@ overrides:
   picomatch: 4.0.4
 
 packageExtensionsChecksum: sha256-oM9k2Xy6771yG3++ENfeHlUom6t6HU6jhzCLVMzv5Sc=
+
+patchedDependencies:
+  '@wizardconnect/wallet@0.2.2': dbd94ee240729f29e1e5ed7279ece1d070c96710019a92ef3431aca531dba895
 
 importers:
 
@@ -46,6 +50,12 @@ importers:
       '@walletconnect/core':
         specifier: 2.23.9
         version: 2.23.9(typescript@6.0.3)(zod@4.4.3)
+      '@wizardconnect/core':
+        specifier: 0.2.4
+        version: 0.2.4(typescript@6.0.3)
+      '@wizardconnect/wallet':
+        specifier: 0.2.2
+        version: 0.2.2(patch_hash=dbd94ee240729f29e1e5ed7279ece1d070c96710019a92ef3431aca531dba895)(typescript@6.0.3)
       mainnet-js:
         specifier: 3.1.7
         version: 3.1.7
@@ -157,6 +167,11 @@ packages:
 
   '@bch-wc2/interfaces@0.0.16':
     resolution: {integrity: sha512-Rz7ygOnuJHrf3jEOfbB6hdkatbYEKCSHGqccFmJ+HtYcwZM3ZenPKWqWkFFgPncuQpGAbZVpegclMXJImjaAkA==}
+    peerDependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+
+  '@bch-wc2/interfaces@0.0.8':
+    resolution: {integrity: sha512-gRt95azHVqoViGI4X3F1ObgTpYBh3//KaCHRBWSMJbAKNM09T+TA/h9kx9u9SZmE8otMtpFSy4awSHWHUQZmbg==}
     peerDependencies:
       '@bitauth/libauth': 3.1.0-next.8
 
@@ -332,6 +347,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.8.0':
     resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
     engines: {node: ^14.21.3 || >=16}
@@ -344,6 +363,10 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -355,6 +378,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -757,11 +784,20 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
+  '@scure/bip32@2.0.1':
+    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1036,6 +1072,12 @@ packages:
 
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
+
+  '@wizardconnect/core@0.2.4':
+    resolution: {integrity: sha512-CHcm3YWEdZHGSH6+Ml2H8LE4HCe2DWKX6PbzvGIaExYg1LGbiTXABPoBWMhCOibcQFz3BIgjfcewP29M0JFrUw==}
+
+  '@wizardconnect/wallet@0.2.2':
+    resolution: {integrity: sha512-mP8xBSnzEDc2VKPQ2tWQfqXBCiyxL244VNhOYLAm3fXewPvs0mW18aPkfjjt9Cqca25/VeKLRtP37TzpG/t12A==}
 
   abitype@1.2.4:
     resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
@@ -1585,6 +1627,11 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -1777,6 +1824,17 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nostr-tools@2.23.9:
+    resolution: {integrity: sha512-PBN3TpGh+EszlTZWpQdvcqEMqhcKcY1vTw0Xkkccg+TyP7y/icu9/iXJw72aFZ/ETm35ehU0hneGTXLaTSkImw==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
 
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
@@ -2689,6 +2747,10 @@ snapshots:
     dependencies:
       '@bitauth/libauth': 3.1.0-next.8
 
+  '@bch-wc2/interfaces@0.0.8(@bitauth/libauth@3.1.0-next.8)':
+    dependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+
   '@bitauth/libauth@3.1.0-next.8': {}
 
   '@bitjson/qr-code@1.0.2': {}
@@ -2959,6 +3021,8 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.1.1': {}
+
   '@noble/curves@1.8.0':
     dependencies:
       '@noble/hashes': 1.7.0
@@ -2971,11 +3035,17 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.7.0': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.0.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3360,16 +3430,29 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/base@2.0.0': {}
+
   '@scure/bip32@1.7.0':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/bip32@2.0.1':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3988,6 +4071,30 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
+  '@wizardconnect/core@0.2.4(typescript@6.0.3)':
+    dependencies:
+      '@bch-wc2/interfaces': 0.0.8(@bitauth/libauth@3.1.0-next.8)
+      '@bitauth/libauth': 3.1.0-next.8
+      eventemitter3: 5.0.4
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      lossless-json: 4.3.0
+      nostr-tools: 2.23.9(typescript@6.0.3)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@wizardconnect/wallet@0.2.2(patch_hash=dbd94ee240729f29e1e5ed7279ece1d070c96710019a92ef3431aca531dba895)(typescript@6.0.3)':
+    dependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+      '@wizardconnect/core': 0.2.4(typescript@6.0.3)
+      eventemitter3: 5.0.4
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   abitype@1.2.4(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 6.0.3
@@ -4467,6 +4574,10 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  isomorphic-ws@5.0.0(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
+
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
@@ -4625,6 +4736,20 @@ snapshots:
   node-releases@2.0.50: {}
 
   normalize-path@3.0.0: {}
+
+  nostr-tools@2.23.9(typescript@6.0.3):
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 6.0.3
+
+  nostr-wasm@0.1.0: {}
 
   npm-run-path@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ overrides:
   '@bitauth/libauth': 3.1.0-next.8
   '@reown/walletkit': 1.5.6
   '@walletconnect/core': 2.23.9
+  '@wizardconnect/core': 0.2.4
   mainnet-js: 3.1.7
 
   # Dependabot security bumps for indirect dependencies.
@@ -69,3 +70,10 @@ packageExtensions:
 # (src-electron has its own allowBuilds for electron's binary download.)
 allowBuilds:
   '@parcel/watcher': true
+
+# Fix a disconnect race in @wizardconnect/wallet: doDisconnect tore down the relay
+# connection synchronously while the courtesy disconnect message was still in flight,
+# so the dapp never learned of the disconnect. The patch defers cleanup until the
+# relay promise settles. Remove once fixed upstream.
+patchedDependencies:
+  '@wizardconnect/wallet@0.2.2': patches/@wizardconnect__wallet@0.2.2.patch

--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
                 <data android:scheme="bch-wif" />
                 <data android:scheme="wc" />
                 <data android:scheme="cc" />
+                <data android:scheme="wiz" />
             </intent-filter>
 
         </activity>

--- a/src/components/cashconnect/CCSessions.vue
+++ b/src/components/cashconnect/CCSessions.vue
@@ -35,10 +35,9 @@
 </script>
 
 <template>
-    <!-- Sessions -->
-    <fieldset class="item">
-      <legend>{{ t('cashConnect.sessions.title') }}</legend>
-      <!-- Sessions -->
+    <!-- Section inside the shared 'dApp Sessions' fieldset (connectDapp.vue); hidden when empty -->
+    <div v-if="Object.keys(cashconnectStore.sessions).length">
+      <div class="sessions-section-heading">{{ t('cashConnect.sessions.title') }}</div>
       <div class="cc-session-items-container">
         <!-- Iterate over active sessions -->
         <template v-for="(session, topic) of cashconnectStore.sessions" :key="topic">
@@ -59,12 +58,8 @@
             </div>
           </div>
         </template>
-        <!-- Show Empty Message if no Sessions are active -->
-        <template v-if="!Object.keys(cashconnectStore.sessions).length">
-          <div class="q-pa-md">{{ t('cashConnect.sessions.noActiveSessions') }}</div>
-        </template>
       </div>
-    </fieldset>
+    </div>
 </template>
 
 <style>

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -175,7 +175,6 @@
       <CCSessions ref="cashconnectRef" />
       <WizSessions ref="wizardconnectRef" />
       <div v-if="hasNoSessions" class="q-pa-md">{{ t('dapp.noActiveSessions') }}</div>
-      <div v-if="!isHdWallet" class="q-pa-md wiz-unavailable-note">{{ t('wizardConnect.sessions.notAvailableForWalletType') }}</div>
     </fieldset>
 
     <div v-if="showQrCodeDialog">
@@ -188,12 +187,5 @@
   .sessions-section-heading {
     font-weight: 600;
     margin: 8px 0 2px;
-  }
-</style>
-
-<style scoped>
-  .wiz-unavailable-note {
-    font-size: smaller;
-    color: var(--color-grey);
   }
 </style>

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -6,12 +6,14 @@
   import { useStore } from 'src/stores/store'
   import { useWalletconnectStore } from 'src/stores/walletconnectStore'
   import { useCashconnectStore } from 'src/stores/cashconnectStore';
+  import { useWizardconnectStore } from 'src/stores/wizardconnectStore';
   import { waitForInitialized } from 'src/utils/utils'
   import QrCodeDialog from './qr/qrCodeScanDialog.vue';
 
   // Components.
   import WCSessions from 'src/components/walletconnect/WCSessions.vue'
   import CCSessions from 'src/components/cashconnect/CCSessions.vue'
+  import WizSessions from 'src/components/wizardconnect/WizSessions.vue'
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { caughtErrorToString } from 'src/utils/errorHandling';
 
@@ -23,6 +25,7 @@
   const walletconnectStore = useWalletconnectStore()
   const web3wallet = walletconnectStore.web3wallet
   const cashconnectStore = useCashconnectStore();
+  const wizardconnectStore = useWizardconnectStore();
 
   // Props.
   const props = defineProps<{
@@ -32,6 +35,7 @@
   // Component references.
   const walletconnectRef = ref<InstanceType<typeof WCSessions> | null>(null);
   const cashconnectRef = ref<InstanceType<typeof CCSessions> | null>(null);
+  const wizardconnectRef = ref<InstanceType<typeof WizSessions> | null>(null);
 
   // State.
   const dappUriInput = ref("");
@@ -53,9 +57,18 @@
       }
     }
     if(props.dappUriUrlParam?.startsWith('cc:')){
-      const { isWcAndCcInitialized } = storeToRefs(store);
-      await waitForInitialized(isWcAndCcInitialized);
+      const { isDappConnectionsInitialized } = storeToRefs(store);
+      await waitForInitialized(isDappConnectionsInitialized);
       await cashconnectStore?.pair(props.dappUriUrlParam);
+    }
+    if(props.dappUriUrlParam?.toLowerCase().startsWith('wiz:')){
+      const { isDappConnectionsInitialized } = storeToRefs(store);
+      await waitForInitialized(isDappConnectionsInitialized);
+      try {
+        wizardconnectStore.pair(props.dappUriUrlParam);
+      } catch (error) {
+        console.error("Error pairing WizardConnect URI:", error);
+      }
     }
   }
   // Check for dappUriUrlParam on component mount and watch for changes.
@@ -67,9 +80,9 @@
   // Methods.
   async function connectDappUriInput(dappUri: string) {
     try {
-      // Promise will wait for state indicating whether WC and CC are initialized
-      const { isWcAndCcInitialized } = storeToRefs(store);
-      await waitForInitialized(isWcAndCcInitialized);
+      // Promise will wait for state indicating whether the dapp connection stores are initialized
+      const { isDappConnectionsInitialized } = storeToRefs(store);
+      await waitForInitialized(isDappConnectionsInitialized);
 
       // If the URI begins with "wc:" (walletconnect)...
       if(dappUri.startsWith('wc:')) {
@@ -81,7 +94,14 @@
         await cashconnectRef.value?.connectDappUriInput(dappUri);
       }
 
-      // Otherwise, if it does not match CC or WC, throw an error.
+      // Otherwise, if the URI begins with "wiz:" (wizardconnect)...
+      // The case-insensitive check is deliberate: WizardConnect QR codes use an
+      // uppercased alphanumeric-mode form (WIZ://...)
+      else if (dappUri.toLowerCase().startsWith('wiz:')) {
+        wizardconnectRef.value?.connectDappUriInput(dappUri);
+      }
+
+      // Otherwise, if it does not match CC, WC or WIZ, throw an error.
       else {
         throw new Error(t('dapp.errors.invalidUri'));
       }
@@ -105,8 +125,11 @@
   const qrFilter = (content: string) => {
     const matchWalletConnect = String(content).match(/^wc:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
     const matchCashConnect = String(content).match(/^cc:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
+    // WizardConnect QR codes use an uppercased, percent-escaped alphanumeric-mode form
+    // (WIZ://%3FP%3D...), so only the scheme is matched here; the full URI is validated on pairing
+    const matchWizardConnect = String(content).match(/^wiz:\/\//i);
 
-    if (!matchWalletConnect && !matchCashConnect) {
+    if (!matchWalletConnect && !matchCashConnect && !matchWizardConnect) {
       return t('dapp.errors.notValidUri');
     }
     return true;
@@ -136,6 +159,7 @@
 
     <WCSessions ref="walletconnectRef"/>
     <CCSessions ref="cashconnectRef" />
+    <WizSessions ref="wizardconnectRef" />
 
     <div v-if="showQrCodeDialog">
       <QrCodeDialog @hide="() => showQrCodeDialog = false" @decode="qrDecode" :filter="qrFilter"/>

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ref, watch } from 'vue'
+  import { ref, computed, watch } from 'vue'
   import { useQuasar } from 'quasar';
   import { storeToRefs } from 'pinia';
   import { useI18n } from 'vue-i18n'
@@ -40,6 +40,17 @@
   // State.
   const dappUriInput = ref("");
   const showQrCodeDialog = ref(false);
+
+  // Single shared empty state for the unified sessions box (the per-method
+  // sections in the child components hide themselves when empty)
+  const hasNoSessions = computed(() =>
+    !Object.keys(walletconnectStore.activeSessions ?? {}).length &&
+    !Object.keys(cashconnectStore.sessions).length &&
+    !Object.keys(wizardconnectStore.connections).length
+  );
+
+  // WizardConnect requires an HD wallet (see wizardconnectStore.pair)
+  const isHdWallet = computed(() => settingsStore.getWalletType(store.activeWalletName) === 'hd');
 
   // Handle Props.
   function isSessionRequest(uri: string): boolean {
@@ -140,9 +151,10 @@
     <fieldset class="item">
       <legend>{{ t('dapp.title') }}</legend>
       <div style="margin-bottom: 10px;">
-        <i18n-t keypath="dapp.exploreText" tag="span">
+        <!-- WizardConnect requires an HD wallet, so the listed connection methods depend on the wallet type -->
+        <i18n-t :keypath="isHdWallet ? 'dapp.exploreText' : 'dapp.exploreTextSingleAddress'" tag="span">
           <template #link>
-            <a href="https://tokenaut.cash/dapps?filter=walletconnect" target="_blank">Tokenaut.cash</a>
+            <a href="https://tokenaut.cash/dapps" target="_blank">Tokenaut.cash</a>
           </template>
         </i18n-t>
       </div>
@@ -157,11 +169,31 @@
       </div>
     </fieldset>
 
-    <WCSessions ref="walletconnectRef"/>
-    <CCSessions ref="cashconnectRef" />
-    <WizSessions ref="wizardconnectRef" />
+    <fieldset class="item">
+      <legend>{{ t('dapp.sessionsTitle') }}</legend>
+      <WCSessions ref="walletconnectRef"/>
+      <CCSessions ref="cashconnectRef" />
+      <WizSessions ref="wizardconnectRef" />
+      <div v-if="hasNoSessions" class="q-pa-md">{{ t('dapp.noActiveSessions') }}</div>
+      <div v-if="!isHdWallet" class="q-pa-md wiz-unavailable-note">{{ t('wizardConnect.sessions.notAvailableForWalletType') }}</div>
+    </fieldset>
 
     <div v-if="showQrCodeDialog">
       <QrCodeDialog @hide="() => showQrCodeDialog = false" @decode="qrDecode" :filter="qrFilter"/>
     </div>
 </template>
+
+<style>
+  /* Shared heading style for the per-method sections rendered by the child components */
+  .sessions-section-heading {
+    font-weight: 600;
+    margin: 8px 0 2px;
+  }
+</style>
+
+<style scoped>
+  .wiz-unavailable-note {
+    font-size: smaller;
+    color: var(--color-grey);
+  }
+</style>

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -65,7 +65,7 @@
       const { isDappConnectionsInitialized } = storeToRefs(store);
       await waitForInitialized(isDappConnectionsInitialized);
       try {
-        wizardconnectStore.pair(props.dappUriUrlParam);
+        await wizardconnectStore.pair(props.dappUriUrlParam);
       } catch (error) {
         console.error("Error pairing WizardConnect URI:", error);
       }
@@ -98,7 +98,7 @@
       // The case-insensitive check is deliberate: WizardConnect QR codes use an
       // uppercased alphanumeric-mode form (WIZ://...)
       else if (dappUri.toLowerCase().startsWith('wiz:')) {
-        wizardconnectRef.value?.connectDappUriInput(dappUri);
+        await wizardconnectRef.value?.connectDappUriInput(dappUri);
       }
 
       // Otherwise, if it does not match CC, WC or WIZ, throw an error.

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -68,13 +68,13 @@
       }
     }
     if(props.dappUriUrlParam?.startsWith('cc:')){
-      const { isDappConnectionsInitialized } = storeToRefs(store);
-      await waitForInitialized(isDappConnectionsInitialized);
+      const { dappConnectionStoresInitialized } = storeToRefs(store);
+      await waitForInitialized(dappConnectionStoresInitialized);
       await cashconnectStore?.pair(props.dappUriUrlParam);
     }
     if(props.dappUriUrlParam?.toLowerCase().startsWith('wiz:')){
-      const { isDappConnectionsInitialized } = storeToRefs(store);
-      await waitForInitialized(isDappConnectionsInitialized);
+      const { dappConnectionStoresInitialized } = storeToRefs(store);
+      await waitForInitialized(dappConnectionStoresInitialized);
       try {
         await wizardconnectStore.pair(props.dappUriUrlParam);
       } catch (error) {
@@ -92,8 +92,8 @@
   async function connectDappUriInput(dappUri: string) {
     try {
       // Promise will wait for state indicating whether the dapp connection stores are initialized
-      const { isDappConnectionsInitialized } = storeToRefs(store);
-      await waitForInitialized(isDappConnectionsInitialized);
+      const { dappConnectionStoresInitialized } = storeToRefs(store);
+      await waitForInitialized(dappConnectionStoresInitialized);
 
       // If the URI begins with "wc:" (walletconnect)...
       if(dappUri.startsWith('wc:')) {

--- a/src/components/walletconnect/WC2TransactionRequest.vue
+++ b/src/components/walletconnect/WC2TransactionRequest.vue
@@ -189,7 +189,8 @@
         </div>
 
         <div style="font-size: large; margin-top: 1.5rem;">{{ t('walletConnect.transactionRequest.origin') }}</div>
-        <div style="display: flex;">
+        <!-- align-items center so a name-only WizardConnect origin (no url) centers against the icon -->
+        <div style="display: flex; align-items: center;">
           <img v-if="dappMetadata.icons[0]" :src="dappMetadata.icons[0]" style="display: flex; height: 55px; width: 55px;">
           <div style="margin-left: 10px;">
             <div>{{ dappMetadata.name }}</div>

--- a/src/components/walletconnect/WC2TransactionRequest.vue
+++ b/src/components/walletconnect/WC2TransactionRequest.vue
@@ -3,11 +3,10 @@
   import { binToHex, decodeTransactionUnsafe, hexToBin, lockingBytecodeToCashAddress, type Output } from "@bitauth/libauth"
   import { useDialogPluginComponent } from 'quasar'
   import { useStore } from 'src/stores/store'
-  import { convertToCurrency, formatFiatAmount, formatNumber, parseExtendedJson, sanitizeUrl } from 'src/utils/utils'
+  import { convertToCurrency, formatFiatAmount, formatNumber, sanitizeUrl } from 'src/utils/utils'
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { type DappMetadata } from "src/interfaces/interfaces"
   import { type WcSignTransactionRequest } from "@bch-wc2/interfaces"
-  import { type WalletKitTypes } from '@reown/walletkit';
   import { type BcmrTokenResponse } from 'src/utils/zodValidation';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
@@ -19,21 +18,22 @@
   // Same approach as CCSignTransactionDialog.vue
   const unverifiedTokenMetadata = ref<Record<string, BcmrTokenResponse>>({});
 
+  // This dialog is shared by the WalletConnect and WizardConnect stores, which validate
+  // the untrusted request params and pass the parsed transaction request object.
   const props = defineProps<{
     dappMetadata: DappMetadata,
-    transactionRequestWC: WalletKitTypes.SessionRequest,
+    transactionRequest: WcSignTransactionRequest,
     exchangeRate: number,
   }>()
-  const { transactionRequestWC, exchangeRate } = toRefs(props);
+  const { exchangeRate } = toRefs(props);
   const safeUrl = sanitizeUrl(props.dappMetadata.url);
 
   defineEmits([
     ...useDialogPluginComponent.emits
   ])
   const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
-  
-  // parse params from transactionRequestWC as extended JSON to handle stringified/encoded Uint8Array and BigInt
-  const requestParams = parseExtendedJson(JSON.stringify(transactionRequestWC.value.params.request.params)) as WcSignTransactionRequest;
+
+  const requestParams = props.transactionRequest;
   const { transaction:wcTransactionItem, sourceOutputs } = requestParams;
 
   // We can use decodeTransactionUnsafe because we already perform validation in isValidSignTransactionRequest
@@ -190,11 +190,12 @@
 
         <div style="font-size: large; margin-top: 1.5rem;">{{ t('walletConnect.transactionRequest.origin') }}</div>
         <div style="display: flex;">
-          <img :src="dappMetadata.icons[0] ?? ''" style="display: flex; height: 55px; width: 55px;">
+          <img v-if="dappMetadata.icons[0]" :src="dappMetadata.icons[0]" style="display: flex; height: 55px; width: 55px;">
           <div style="margin-left: 10px;">
             <div>{{ dappMetadata.name }}</div>
             <a v-if="safeUrl" :href="safeUrl" target="_blank">{{ dappMetadata.url }}</a>
-            <span v-else style="color: var(--color-error);">{{ t('common.unsafeUrl') }}</span>
+            <!-- WizardConnect sessions carry no dapp url, so only warn when a url is present but unsafe -->
+            <span v-else-if="dappMetadata.url" style="color: var(--color-error);">{{ t('common.unsafeUrl') }}</span>
           </div>
         </div>
 

--- a/src/components/walletconnect/WCSessions.vue
+++ b/src/components/walletconnect/WCSessions.vue
@@ -45,18 +45,14 @@
 </script>
 
 <template>
-  <fieldset class="item">
-    <legend>{{ t('walletConnect.sessions.title') }}</legend>
+  <!-- Section inside the shared 'dApp Sessions' fieldset (connectDapp.vue); hidden when empty -->
+  <div v-if="Object.keys(activeSessions || {}).length">
+    <div class="sessions-section-heading">{{ t('walletConnect.sessions.title') }}</div>
 
     <div v-for="sessionInfo in Object.values(activeSessions || {}).reverse()" :key="sessionInfo.topic" class="wc2sessions" >
       <WC2ActiveSession :dappMetadata="sessionInfo.peer.metadata" :sessionId="sessionInfo.topic" :activeSessions="activeSessions" @delete-session="(arg) => walletconnectStore.deleteSession(arg)"/>
     </div>
-    <!-- Show Empty Message if no Sessions are active -->
-    <template v-if="!Object.keys(activeSessions || {}).length">
-      <div class="q-pa-md">{{ t('walletConnect.sessions.noActiveSessions') }}</div>
-    </template>
-
-  </fieldset>
+  </div>
 </template>
 
 <style>

--- a/src/components/wizardconnect/WizPairingDialog.vue
+++ b/src/components/wizardconnect/WizPairingDialog.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+  import { useDialogPluginComponent } from 'quasar'
+  import { useI18n } from 'vue-i18n'
+  const { t } = useI18n()
+
+  defineEmits([
+    ...useDialogPluginComponent.emits
+  ])
+
+  const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
+</script>
+
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide" persistent transition-show="scale" transition-hide="scale">
+    <q-card>
+      <fieldset class="dialogFieldset">
+        <legend style="font-size: large;">{{ t('wizardConnect.pairing.title') }}</legend>
+        <div>{{ t('wizardConnect.pairing.intro') }}</div>
+        <ul class="pairing-bullets">
+          <li>{{ t('wizardConnect.pairing.bulletHistory') }}</li>
+          <li>{{ t('wizardConnect.pairing.bulletPrivacy') }}</li>
+          <li>{{ t('wizardConnect.pairing.bulletSpending') }}</li>
+        </ul>
+        <!-- The pairing URI carries no dapp metadata, so unlike the other connection
+             methods there is no dapp name or icon to show before connecting -->
+        <div class="pairing-note">{{ t('wizardConnect.pairing.dappInfoNote') }}</div>
+        <div style="margin-top: 1.5rem; display: flex; gap: 1rem;">
+          <input type="button" class="primaryButton" :value="t('wizardConnect.pairing.connectButton')" @click="onDialogOK" v-close-popup>
+          <input type="button" :value="t('wizardConnect.pairing.cancelButton')" @click="onDialogCancel">
+        </div>
+      </fieldset>
+    </q-card>
+  </q-dialog>
+</template>
+
+<style scoped>
+  .dialogFieldset{
+    padding: 2rem 3rem;
+    width: 500px;
+    max-width: 100%;
+    background-color: white;
+  }
+  body.dark .dialogFieldset {
+    background-color: #050a14;
+  }
+  .q-card{
+    box-shadow: none;
+    background: none;
+  }
+  .pairing-bullets {
+    margin: 1rem 0;
+    padding-left: 1.25rem;
+  }
+  .pairing-bullets li {
+    margin-bottom: 0.5rem;
+  }
+  .pairing-note {
+    font-size: smaller;
+    color: var(--color-grey);
+  }
+</style>

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+  import { computed } from 'vue';
   import { useQuasar } from 'quasar';
+  import { useStore } from 'src/stores/store';
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useWizardconnectStore } from 'src/stores/wizardconnectStore'
   import { caughtErrorToString } from 'src/utils/errorHandling';
@@ -12,9 +14,13 @@
   });
 
   const $q = useQuasar();
+  const store = useStore();
   const settingsStore = useSettingsStore();
 
   const wizardconnectStore = useWizardconnectStore();
+
+  // WizardConnect requires an HD wallet (see wizardconnectStore.pair)
+  const isHdWallet = computed(() => settingsStore.getWalletType(store.activeWalletName) === 'hd');
 
   // Note: the initialization is awaited when the function is used in the 'connectDapp' component.
   async function connectDappUriInput(url: string){
@@ -65,7 +71,8 @@
         </template>
         <!-- Show Empty Message if no Sessions are active -->
         <template v-if="!Object.keys(wizardconnectStore.connections).length">
-          <div class="q-pa-md">{{ t('wizardConnect.sessions.noActiveSessions') }}</div>
+          <div v-if="isHdWallet" class="q-pa-md">{{ t('wizardConnect.sessions.noActiveSessions') }}</div>
+          <div v-else class="q-pa-md">{{ t('wizardConnect.sessions.notAvailableForWalletType') }}</div>
         </template>
       </div>
     </fieldset>

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+  import { useQuasar } from 'quasar';
+  import { useSettingsStore } from 'src/stores/settingsStore';
+  import { useWizardconnectStore } from 'src/stores/wizardconnectStore'
+  import { caughtErrorToString } from 'src/utils/errorHandling';
+  import { useI18n } from 'vue-i18n'
+  const { t } = useI18n()
+
+  // Expose to 'connectDapp' parent component.
+  defineExpose({
+    connectDappUriInput
+  });
+
+  const $q = useQuasar();
+  const settingsStore = useSettingsStore();
+
+  const wizardconnectStore = useWizardconnectStore();
+
+  // Note: the initialization is awaited when the function is used in the 'connectDapp' component.
+  function connectDappUriInput(url: string){
+    try {
+      wizardconnectStore.pair(url);
+    } catch(error) {
+      const errorMessage = caughtErrorToString(error)
+      console.error(errorMessage)
+
+      $q.notify({
+        message: errorMessage,
+        icon: 'warning',
+        color: 'negative'
+      })
+    }
+  }
+
+  function statusLabel(status: { status: string }): string {
+    if (status.status === 'connected') return t('wizardConnect.sessions.statusConnected');
+    if (status.status === 'reconnecting') return t('wizardConnect.sessions.statusReconnecting');
+    return t('wizardConnect.sessions.statusDisconnected');
+  }
+</script>
+
+<template>
+    <!-- Sessions -->
+    <fieldset class="item">
+      <legend>{{ t('wizardConnect.sessions.title') }}</legend>
+      <div class="wiz-session-items-container">
+        <!-- Iterate over active connections -->
+        <template v-for="(connection, connectionId) of wizardconnectStore.connections" :key="connectionId">
+          <div class="wiz-session-item">
+            <div class="wiz-session-item-app-icon">
+              <img v-if="connection.dappIcon" :src="connection.dappIcon" />
+            </div>
+            <div class="wiz-session-item-details-container">
+              <div>{{ connection.dappName ?? t('wizardConnect.sessions.connecting') }}</div>
+              <div :class="'wiz-session-status ' + (connection.status.status === 'connected' ? 'wiz-session-status-connected' : '')">
+                {{ statusLabel(connection.status) }}
+              </div>
+            </div>
+            <div class="wiz-session-item-action-container">
+              <div class="wiz-session-item-action-icon" @click="wizardconnectStore.disconnectSession(String(connectionId))">
+                <img :src="settingsStore.darkMode? 'images/trashLightGrey.svg': 'images/trash.svg'" style="max-width: none" />
+              </div>
+            </div>
+          </div>
+        </template>
+        <!-- Show Empty Message if no Sessions are active -->
+        <template v-if="!Object.keys(wizardconnectStore.connections).length">
+          <div class="q-pa-md">{{ t('wizardConnect.sessions.noActiveSessions') }}</div>
+        </template>
+      </div>
+    </fieldset>
+</template>
+
+<style>
+.wiz-session-items-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.wiz-session-item {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 10px;
+  padding: 7px;
+}
+
+.wiz-session-item-details-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.wiz-session-item-app-icon {
+  display: flex;
+  align-items: center;
+  height: 64px;
+  width: 64px;
+}
+
+.wiz-session-status {
+  font-size: smaller;
+  color: var(--color-grey);
+}
+
+.wiz-session-status-connected {
+  color: hsla(160, 100%, 37%, 1);
+}
+
+.wiz-session-item-action-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.wiz-session-item-action-icon {
+  height: 24px;
+  cursor: pointer;
+}
+</style>

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
   import { computed } from 'vue';
   import { useQuasar } from 'quasar';
+  import { decodeKeyExchangeURI } from '@wizardconnect/core';
   import { useStore } from 'src/stores/store';
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useWizardconnectStore } from 'src/stores/wizardconnectStore'
   import { caughtErrorToString } from 'src/utils/errorHandling';
+  import { useWindowSize } from 'src/utils/composables'
   import { useI18n } from 'vue-i18n'
   const { t } = useI18n()
 
@@ -21,6 +23,29 @@
 
   // WizardConnect requires an HD wallet (see wizardconnectStore.pair)
   const isHdWallet = computed(() => settingsStore.getWalletType(store.activeWalletName) === 'hd');
+
+  const { width } = useWindowSize();
+  const isMobilePhone = computed(() => width.value < 480);
+
+  // When multiple sessions share the same dapp name, append a short session identifier
+  // (mirrors WC2ActiveSession). The manager's internal connection id is regenerated on
+  // every reconnect, so the stable identifier is the dapp's pubkey from the pairing URI.
+  function sessionIdTag(connectionId: string): string {
+    const connections = wizardconnectStore.connections;
+    const connection = connections[connectionId];
+    if (!connection) return '';
+    const hasDuplicateName = Object.entries(connections).some(([otherId, otherConnection]) =>
+      otherConnection.dappName === connection.dappName && otherId !== connectionId
+    );
+    if (!hasDuplicateName) return '';
+    try {
+      const dappPubkey = decodeKeyExchangeURI(connection.uri).publicKey;
+      const sessionPrefix = !isMobilePhone.value ? t('wizardConnect.sessions.session') + ' ' : '';
+      return ` - ${sessionPrefix}${dappPubkey.slice(0, 6)}`;
+    } catch {
+      return '';
+    }
+  }
 
   // Note: the initialization is awaited when the function is used in the 'connectDapp' component.
   async function connectDappUriInput(url: string){
@@ -67,7 +92,7 @@
               <img v-if="connection.dappIcon" :src="connection.dappIcon" />
             </div>
             <div class="wiz-session-item-details-container">
-              <div>{{ connection.dappName ?? t('wizardConnect.sessions.unknownDapp') }}</div>
+              <div>{{ (connection.dappName ?? t('wizardConnect.sessions.unknownDapp')) + sessionIdTag(String(connectionId)) }}</div>
               <div :class="'wiz-session-status ' + (isDappConnected(connection) ? 'wiz-session-status-connected' : '')">
                 {{ statusLabel(connection) }}
               </div>

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -17,9 +17,9 @@
   const wizardconnectStore = useWizardconnectStore();
 
   // Note: the initialization is awaited when the function is used in the 'connectDapp' component.
-  function connectDappUriInput(url: string){
+  async function connectDappUriInput(url: string){
     try {
-      wizardconnectStore.pair(url);
+      await wizardconnectStore.pair(url);
     } catch(error) {
       const errorMessage = caughtErrorToString(error)
       console.error(errorMessage)

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -38,10 +38,20 @@
     }
   }
 
-  function statusLabel(status: { status: string }): string {
-    if (status.status === 'connected') return t('wizardConnect.sessions.statusConnected');
-    if (status.status === 'reconnecting') return t('wizardConnect.sessions.statusReconnecting');
-    return t('wizardConnect.sessions.statusDisconnected');
+  // A connection's status reflects the Nostr relay, not the dapp: the relay can be
+  // connected while the dapp has not (yet) announced itself with dapp_ready. Only show
+  // "Connected" once the dapp is actually there (it sent its name); a relay-only
+  // connection shows "Waiting for dApp..." instead.
+  function isDappConnected(connection: { status: { status: string }, dappName: string | null }): boolean {
+    return connection.status.status === 'connected' && connection.dappName !== null;
+  }
+
+  function statusLabel(connection: { status: { status: string }, dappName: string | null }): string {
+    if (connection.status.status === 'reconnecting') return t('wizardConnect.sessions.statusReconnecting');
+    if (connection.status.status !== 'connected') return t('wizardConnect.sessions.statusDisconnected');
+    return isDappConnected(connection)
+      ? t('wizardConnect.sessions.statusConnected')
+      : t('wizardConnect.sessions.statusWaitingForDapp');
   }
 </script>
 
@@ -57,9 +67,9 @@
               <img v-if="connection.dappIcon" :src="connection.dappIcon" />
             </div>
             <div class="wiz-session-item-details-container">
-              <div>{{ connection.dappName ?? t('wizardConnect.sessions.connecting') }}</div>
-              <div :class="'wiz-session-status ' + (connection.status.status === 'connected' ? 'wiz-session-status-connected' : '')">
-                {{ statusLabel(connection.status) }}
+              <div>{{ connection.dappName ?? t('wizardConnect.sessions.unknownDapp') }}</div>
+              <div :class="'wiz-session-status ' + (isDappConnected(connection) ? 'wiz-session-status-connected' : '')">
+                {{ statusLabel(connection) }}
               </div>
             </div>
             <div class="wiz-session-item-action-container">

--- a/src/components/wizardconnect/WizSessions.vue
+++ b/src/components/wizardconnect/WizSessions.vue
@@ -2,7 +2,6 @@
   import { computed } from 'vue';
   import { useQuasar } from 'quasar';
   import { decodeKeyExchangeURI } from '@wizardconnect/core';
-  import { useStore } from 'src/stores/store';
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useWizardconnectStore } from 'src/stores/wizardconnectStore'
   import { caughtErrorToString } from 'src/utils/errorHandling';
@@ -16,13 +15,9 @@
   });
 
   const $q = useQuasar();
-  const store = useStore();
   const settingsStore = useSettingsStore();
 
   const wizardconnectStore = useWizardconnectStore();
-
-  // WizardConnect requires an HD wallet (see wizardconnectStore.pair)
-  const isHdWallet = computed(() => settingsStore.getWalletType(store.activeWalletName) === 'hd');
 
   const { width } = useWindowSize();
   const isMobilePhone = computed(() => width.value < 480);
@@ -81,9 +76,9 @@
 </script>
 
 <template>
-    <!-- Sessions -->
-    <fieldset class="item">
-      <legend>{{ t('wizardConnect.sessions.title') }}</legend>
+    <!-- Section inside the shared 'dApp Sessions' fieldset (connectDapp.vue); hidden when empty -->
+    <div v-if="Object.keys(wizardconnectStore.connections).length">
+      <div class="sessions-section-heading">{{ t('wizardConnect.sessions.title') }}</div>
       <div class="wiz-session-items-container">
         <!-- Iterate over active connections -->
         <template v-for="(connection, connectionId) of wizardconnectStore.connections" :key="connectionId">
@@ -104,13 +99,8 @@
             </div>
           </div>
         </template>
-        <!-- Show Empty Message if no Sessions are active -->
-        <template v-if="!Object.keys(wizardconnectStore.connections).length">
-          <div v-if="isHdWallet" class="q-pa-md">{{ t('wizardConnect.sessions.noActiveSessions') }}</div>
-          <div v-else class="q-pa-md">{{ t('wizardConnect.sessions.notAvailableForWalletType') }}</div>
-        </template>
       </div>
-    </fieldset>
+    </div>
 </template>
 
 <style>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -36,7 +36,7 @@ header {
   text-align: center;
 }
 nav div {
-  padding: 1rem 1.8rem;
+  padding: 1rem 2.5rem;
   cursor: pointer;
   border-bottom: 2px solid var(--color-lightGrey);
 }
@@ -315,10 +315,17 @@ body.dark .q-toggle--dense .q-toggle__inner:not(.q-toggle__inner--truthy) .q-tog
     margin-left: 0;
   }
 }
-@media only screen and (max-width: 570px) {
+@media only screen and (max-width: 650px) {
+  .tabs div {
+    padding: 1rem 1.8rem;
+  }
+}
+@media only screen and (max-width: 600px) {
   .tabs div {
     padding: 1rem;
   }
+}
+@media only screen and (max-width: 570px) {
   .sendCurrencyInput {
     position: relative;
     width: 140px;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -75,7 +75,7 @@
       "title": "Willkommen bei Cashonize",
       "description": "Ein benutzerfreundliches Bitcoin Cash Wallet mit Fokus auf CashTokens und BCH dApps.",
       "featureSendReceive": "BCH und CashTokens senden & empfangen",
-      "featureWalletConnect": "Mit dApps über WalletConnect verbinden",
+      "featureWalletConnect": "Mit dApps über WalletConnect, CashConnect oder WizardConnect verbinden",
       "featureOpenSource": "Open-Source und selbstverwaltet"
     },
     "create": {
@@ -99,7 +99,7 @@
       "label": "Wallet-Typ:",
       "hd": "HD Wallet (mehrere Adressen)",
       "single": "Einzelne Adresse",
-      "hdDescription": "Verwendet für jede Transaktion eine neue Adresse. Bessere Privatsphäre, aber erfordert die Auswahl einer Adresse beim Verbinden mit dApps.",
+      "hdDescription": "Verwendet für jede Transaktion eine neue Adresse für bessere Privatsphäre. Beim Verbinden mit WalletConnect wählst du, welche Adresse geteilt wird.",
       "singleDescription": "Verwendet eine feste Adresse für alle Transaktionen. Alle Vermögenswerte an einem Ort, aber weniger privat. Die WizardConnect-Verbindungsmethode wird nicht unterstützt.",
       "singleAddressNote": "Hinweis: Nur die erste Adresse deiner seed phrase wird verwendet. Wenn du diese seed phrase bereits mit anderen Wallets verwendet hast, werden Guthaben auf anderen Adressen nicht angezeigt."
     },
@@ -354,7 +354,7 @@
   "dapp": {
     "title": "Mit Dapp verbinden",
     "exploreText": "Besuche {link}, um die vollständige Liste der BCH-Dapps mit WalletConnect zu erkunden",
-    "uriPlaceholder": "Wallet Connect URI",
+    "uriPlaceholder": "Verbindungs-URI",
     "connectButton": "Neue dApp verbinden",
     "errors": {
       "invalidUri": "Ungültige WalletConnect-, CashConnect- oder WizardConnect-URI",
@@ -819,7 +819,7 @@
     },
     "pairing": {
       "title": "Wallet-Adressen mit dieser Dapp teilen?",
-      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen — auch nach dem Trennen — und du verlierst die Privatsphäre frischer HD-Adressen. Zum Ausgeben deiner Gelder ist weiterhin für jede Transaktion deine Zustimmung erforderlich.",
+      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen, auch nach dem Trennen, und du verlierst die Privatsphäre frischer HD-Adressen. Zum Ausgeben deiner Gelder ist weiterhin für jede Transaktion deine Zustimmung erforderlich.",
       "connectButton": "Verbinden",
       "cancelButton": "Abbrechen"
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -816,6 +816,12 @@
       "statusReconnecting": "Wiederverbinden...",
       "statusDisconnected": "Getrennt"
     },
+    "pairing": {
+      "title": "Wallet-Adressen mit dieser Dapp teilen?",
+      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen — auch nach dem Trennen — und du verlierst die Privatsphäre frischer HD-Adressen. Die Dapp kann deine Gelder nicht ausgeben.",
+      "connectButton": "Verbinden",
+      "cancelButton": "Abbrechen"
+    },
     "errors": {
       "hdWalletRequired": "WizardConnect erfordert ein HD-Wallet",
       "notInitialized": "WizardConnect noch nicht initialisiert. Bitte versuche es gleich erneut.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -100,7 +100,7 @@
       "hd": "HD Wallet (mehrere Adressen)",
       "single": "Einzelne Adresse",
       "hdDescription": "Verwendet für jede Transaktion eine neue Adresse. Bessere Privatsphäre, aber erfordert die Auswahl einer Adresse beim Verbinden mit dApps.",
-      "singleDescription": "Verwendet eine feste Adresse für alle Transaktionen. Alle Vermögenswerte an einem Ort, aber weniger privat.",
+      "singleDescription": "Verwendet eine feste Adresse für alle Transaktionen. Alle Vermögenswerte an einem Ort, aber weniger privat. Die WizardConnect-Verbindungsmethode wird nicht unterstützt.",
       "singleAddressNote": "Hinweis: Nur die erste Adresse deiner seed phrase wird verwendet. Wenn du diese seed phrase bereits mit anderen Wallets verwendet hast, werden Guthaben auf anderen Adressen nicht angezeigt."
     },
     "derivationPath": {
@@ -811,6 +811,7 @@
     "sessions": {
       "title": "WizardConnect-Sitzungen",
       "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
+      "notAvailableForWalletType": "WizardConnect ist für diesen Wallet-Typ nicht verfügbar. Es erfordert ein HD-Wallet, da Dapps die Adressliste des Wallets (xpub) erhalten, um neue Adressen abzuleiten, die ein Einzeladressen-Wallet nicht überwachen kann.",
       "connecting": "Verbinden...",
       "statusConnected": "Verbunden",
       "statusReconnecting": "Wiederverbinden...",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -811,7 +811,7 @@
       "signedTransaction": "WalletConnect-Transaktion '{userPrompt}' signiert. Bitte kehren Sie zur Dapp zurück.",
       "transactionSignedTitle": "Transaktion signiert",
       "transactionSent": "Transaktion erfolgreich gesendet!",
-      "transactionSigned": "Transaktion erfolgreich signiert!",
+      "transactionSigned": "Transaktion signiert und an die Dapp zurückgesendet",
       "requestExpired": "Anfrage abgelaufen, bitte kehren Sie zu {dappName} zurück, um es erneut zu versuchen"
     }
   },
@@ -850,7 +850,7 @@
       "signedTransaction": "WizardConnect-Transaktion für {dappName} signiert. Bitte kehren Sie zur Dapp zurück.",
       "transactionSignedTitle": "Transaktion signiert",
       "transactionSent": "Transaktion erfolgreich gesendet!",
-      "transactionSigned": "Transaktion erfolgreich signiert!",
+      "transactionSigned": "Transaktion signiert und an die Dapp zurückgesendet",
       "requestCancelled": "Signieranfrage wurde von {dappName} abgebrochen",
       "dappDisconnected": "WizardConnect-Sitzung wurde von {dappName} getrennt"
     }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -818,7 +818,7 @@
     },
     "pairing": {
       "title": "Wallet-Adressen mit dieser Dapp teilen?",
-      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen — auch nach dem Trennen — und du verlierst die Privatsphäre frischer HD-Adressen. Die Dapp kann deine Gelder nicht ausgeben.",
+      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen — auch nach dem Trennen — und du verlierst die Privatsphäre frischer HD-Adressen. Zum Ausgeben deiner Gelder ist weiterhin für jede Transaktion deine Zustimmung erforderlich.",
       "connectButton": "Verbinden",
       "cancelButton": "Abbrechen"
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -813,6 +813,7 @@
       "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
       "notAvailableForWalletType": "WizardConnect ist für diesen Wallet-Typ nicht verfügbar. Es erfordert ein HD-Wallet, da Dapps die Adressliste des Wallets (xpub) erhalten, um neue Adressen abzuleiten, die ein Einzeladressen-Wallet nicht überwachen kann.",
       "unknownDapp": "Unbekannte Dapp",
+      "session": "Sitzung",
       "statusConnected": "Verbunden",
       "statusWaitingForDapp": "Warten auf die Dapp...",
       "statusReconnecting": "Wiederverbinden...",
@@ -820,7 +821,11 @@
     },
     "pairing": {
       "title": "Wallet-Adressen mit dieser Dapp teilen?",
-      "message": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt. Die Dapp kann dann dein gesamtes Guthaben und deine Transaktionshistorie einsehen, auch nach dem Trennen, und du verlierst die Privatsphäre frischer HD-Adressen. Zum Ausgeben deiner Gelder ist weiterhin für jede Transaktion deine Zustimmung erforderlich.",
+      "intro": "Beim Verbinden wird die vollständige Liste aller aktuellen und zukünftigen Adressen deines Wallets (die xpub) mit der Dapp geteilt.",
+      "bulletHistory": "Die Dapp kann dein gesamtes Guthaben und deine Transaktionshistorie einsehen, auch nach dem Trennen.",
+      "bulletPrivacy": "Du verlierst die Privatsphäre frischer HD-Adressen.",
+      "bulletSpending": "Zum Ausgeben deiner Gelder ist weiterhin für jede Transaktion deine Zustimmung erforderlich.",
+      "dappInfoNote": "Hinweis: Name und Symbol der Dapp werden erst nach dem Verbinden empfangen.",
       "connectButton": "Verbinden",
       "cancelButton": "Abbrechen"
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -818,7 +818,6 @@
   "wizardConnect": {
     "sessions": {
       "title": "WizardConnect",
-      "notAvailableForWalletType": "WizardConnect ist für diesen Wallet-Typ nicht verfügbar. Es erfordert ein HD-Wallet, da Dapps die Adressliste des Wallets (xpub) erhalten, um neue Adressen abzuleiten, die ein Einzeladressen-Wallet nicht überwachen kann.",
       "unknownDapp": "Unbekannte Dapp",
       "session": "Sitzung",
       "statusConnected": "Verbunden",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -812,8 +812,9 @@
       "title": "WizardConnect-Sitzungen",
       "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
       "notAvailableForWalletType": "WizardConnect ist für diesen Wallet-Typ nicht verfügbar. Es erfordert ein HD-Wallet, da Dapps die Adressliste des Wallets (xpub) erhalten, um neue Adressen abzuleiten, die ein Einzeladressen-Wallet nicht überwachen kann.",
-      "connecting": "Verbinden...",
+      "unknownDapp": "Unbekannte Dapp",
       "statusConnected": "Verbunden",
+      "statusWaitingForDapp": "Warten auf die Dapp...",
       "statusReconnecting": "Wiederverbinden...",
       "statusDisconnected": "Getrennt"
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -63,6 +63,7 @@
       "walletNotFoundOnNetwork": "Wallet \"{name}\" existiert nicht auf {network}",
       "errorInitializingWalletConnect": "Fehler beim Initialisieren von WalletConnect",
       "errorInitializingCashConnect": "Fehler beim Initialisieren von CashConnect",
+      "errorInitializingWizardConnect": "Fehler beim Initialisieren von WizardConnect",
       "errorFetchingUtxos": "Fehler beim Abrufen der Wallet-UTXOs",
       "errorFetchingHistory": "Fehler beim Abrufen der Wallet-Historie",
       "unableToConnectElectrum": "Verbindung zum Electrum-Server '{server}' nicht möglich",
@@ -356,8 +357,8 @@
     "uriPlaceholder": "Wallet Connect URI",
     "connectButton": "Neue dApp verbinden",
     "errors": {
-      "invalidUri": "Ungültige WalletConnect- oder CashConnect-URI",
-      "notValidUri": "Keine gültige WalletConnect- oder CashConnect-URI"
+      "invalidUri": "Ungültige WalletConnect-, CashConnect- oder WizardConnect-URI",
+      "notValidUri": "Keine gültige WalletConnect-, CashConnect- oder WizardConnect-URI"
     }
   },
   "history": {
@@ -804,6 +805,34 @@
       "transactionSent": "Transaktion erfolgreich gesendet!",
       "transactionSigned": "Transaktion erfolgreich signiert!",
       "requestExpired": "Anfrage abgelaufen, bitte kehren Sie zu {dappName} zurück, um es erneut zu versuchen"
+    }
+  },
+  "wizardConnect": {
+    "sessions": {
+      "title": "WizardConnect-Sitzungen",
+      "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
+      "connecting": "Verbinden...",
+      "statusConnected": "Verbunden",
+      "statusReconnecting": "Wiederverbinden...",
+      "statusDisconnected": "Getrennt"
+    },
+    "errors": {
+      "hdWalletRequired": "WizardConnect erfordert ein HD-Wallet",
+      "notInitialized": "WizardConnect noch nicht initialisiert. Bitte versuche es gleich erneut.",
+      "invalidUri": "Keine gültige WizardConnect-URI",
+      "invalidTransactionSchema": "Fehler bei der Schema-Validierung der WizardConnect-Transaktionsanfrage",
+      "failedToSignTransaction": "Transaktion konnte nicht signiert werden",
+      "errorSendingTransaction": "Fehler beim Senden der Transaktion"
+    },
+    "notifications": {
+      "sendingTransaction": "Transaktion wird gesendet...",
+      "sentTransaction": "WizardConnect-Transaktion für {dappName} gesendet",
+      "signedTransaction": "WizardConnect-Transaktion für {dappName} signiert. Bitte kehren Sie zur Dapp zurück.",
+      "transactionSignedTitle": "Transaktion signiert",
+      "transactionSent": "Transaktion erfolgreich gesendet!",
+      "transactionSigned": "Transaktion erfolgreich signiert!",
+      "requestCancelled": "Signieranfrage wurde von {dappName} abgebrochen",
+      "dappDisconnected": "WizardConnect-Sitzung wurde von {dappName} getrennt"
     }
   },
   "settings": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -353,9 +353,12 @@
   },
   "dapp": {
     "title": "Mit Dapp verbinden",
-    "exploreText": "Besuche {link}, um die vollständige Liste der BCH-Dapps mit WalletConnect zu erkunden",
+    "exploreText": "Verbinde dich mit dApps über die Verbindungsmethoden WalletConnect, CashConnect oder WizardConnect. Besuche {link}, um die vollständige Liste der BCH-dApps zu erkunden.",
+    "exploreTextSingleAddress": "Verbinde dich mit dApps über die Verbindungsmethoden WalletConnect oder CashConnect. Besuche {link}, um die vollständige Liste der BCH-dApps zu erkunden.",
     "uriPlaceholder": "Verbindungs-URI",
     "connectButton": "Neue dApp verbinden",
+    "sessionsTitle": "dApp-Sitzungen",
+    "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
     "errors": {
       "invalidUri": "Ungültige WalletConnect-, CashConnect- oder WizardConnect-URI",
       "notValidUri": "Keine gültige WalletConnect-, CashConnect- oder WizardConnect-URI"
@@ -683,8 +686,7 @@
   },
   "cashConnect": {
     "sessions": {
-      "title": "CashConnect (Alpha) Sitzungen",
-      "noActiveSessions": "Derzeit keine aktiven Sitzungen."
+      "title": "CashConnect (Alpha)"
     },
     "sessionProposal": {
       "title": "Sitzung genehmigen?",
@@ -727,8 +729,7 @@
   },
   "walletConnect": {
     "sessions": {
-      "title": "WalletConnect Sitzungen",
-      "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
+      "title": "WalletConnect",
       "session": "Sitzung"
     },
     "transactionRequest": {
@@ -809,8 +810,7 @@
   },
   "wizardConnect": {
     "sessions": {
-      "title": "WizardConnect-Sitzungen",
-      "noActiveSessions": "Derzeit keine aktiven Sitzungen.",
+      "title": "WizardConnect",
       "notAvailableForWalletType": "WizardConnect ist für diesen Wallet-Typ nicht verfügbar. Es erfordert ein HD-Wallet, da Dapps die Adressliste des Wallets (xpub) erhalten, um neue Adressen abzuleiten, die ein Einzeladressen-Wallet nicht überwachen kann.",
       "unknownDapp": "Unbekannte Dapp",
       "session": "Sitzung",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -20,6 +20,13 @@
     "wallet": "Wallet",
     "wallets": "Wallets"
   },
+  "nav": {
+    "wallet": "Wallet",
+    "addresses": "Adressen",
+    "tokens": "Tokens",
+    "history": "Historie",
+    "connect": "Verbinden"
+  },
   "walletUtils": {
     "errors": {
       "enterWalletName": "Bitte gib einen Wallet-Namen ein",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -816,6 +816,12 @@
       "statusReconnecting": "Reconnecting...",
       "statusDisconnected": "Disconnected"
     },
+    "pairing": {
+      "title": "Share wallet addresses with this dApp?",
+      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history — even after disconnecting — so you lose the privacy of using fresh HD wallet addresses. The dApp cannot spend your funds.",
+      "connectButton": "Connect",
+      "cancelButton": "Cancel"
+    },
     "errors": {
       "hdWalletRequired": "WizardConnect requires an HD wallet",
       "notInitialized": "WizardConnect not initialized yet. Please try again in a moment.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -75,7 +75,7 @@
       "title": "Welcome to Cashonize",
       "description": "An easy-to-use Bitcoin Cash wallet with a focus on CashTokens and BCH dApps.",
       "featureSendReceive": "Send & receive BCH and CashTokens",
-      "featureWalletConnect": "Connect to dApps via WalletConnect",
+      "featureWalletConnect": "Connect to dApps via WalletConnect, CashConnect or WizardConnect",
       "featureOpenSource": "Open-source and non-custodial"
     },
     "create": {
@@ -99,7 +99,7 @@
       "label": "Wallet type:",
       "hd": "HD Wallet (multiple addresses)",
       "single": "Single address",
-      "hdDescription": "Uses a new address for each transaction. Better privacy, but requires selecting an address when connecting to dApps.",
+      "hdDescription": "Uses a new address for each transaction for better privacy. When connecting with WalletConnect, you select which address to share.",
       "singleDescription": "Uses one fixed address for all transactions. All assets in one place, but less private. The WizardConnect connection method is not supported.",
       "singleAddressNote": "Note: Only the first address from your seed phrase will be used. If you've used this seed with other wallets, funds on other addresses won't appear."
     },
@@ -354,7 +354,7 @@
   "dapp": {
     "title": "Connect to Dapp",
     "exploreText": "See {link} to explore the full list of BCH Dapps with WalletConnect",
-    "uriPlaceholder": "Wallet Connect URI",
+    "uriPlaceholder": "Connection URI",
     "connectButton": "Connect New dApp",
     "errors": {
       "invalidUri": "Invalid WalletConnect, CashConnect or WizardConnect URI",
@@ -819,7 +819,7 @@
     },
     "pairing": {
       "title": "Share wallet addresses with this dApp?",
-      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history — even after disconnecting — so you lose the privacy of using fresh HD wallet addresses. Spending your funds will still require your approval for each transaction.",
+      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history, even after disconnecting, so you lose the privacy of using fresh HD wallet addresses. Spending your funds will still require your approval for each transaction.",
       "connectButton": "Connect",
       "cancelButton": "Cancel"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -20,6 +20,13 @@
     "wallet": "wallet",
     "wallets": "wallets"
   },
+  "nav": {
+    "wallet": "Wallet",
+    "addresses": "Addresses",
+    "tokens": "Tokens",
+    "history": "History",
+    "connect": "Connect"
+  },
   "walletUtils": {
     "errors": {
       "enterWalletName": "Please enter a wallet name",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -353,9 +353,12 @@
   },
   "dapp": {
     "title": "Connect to Dapp",
-    "exploreText": "See {link} to explore the full list of BCH Dapps with WalletConnect",
+    "exploreText": "Connect to dApps with the WalletConnect, CashConnect or WizardConnect connection methods. See {link} to explore the full list of BCH dApps.",
+    "exploreTextSingleAddress": "Connect to dApps with the WalletConnect or CashConnect connection methods. See {link} to explore the full list of BCH dApps.",
     "uriPlaceholder": "Connection URI",
     "connectButton": "Connect New dApp",
+    "sessionsTitle": "dApp Sessions",
+    "noActiveSessions": "No sessions currently active.",
     "errors": {
       "invalidUri": "Invalid WalletConnect, CashConnect or WizardConnect URI",
       "notValidUri": "Not a valid WalletConnect, CashConnect or WizardConnect URI"
@@ -683,8 +686,7 @@
   },
   "cashConnect": {
     "sessions": {
-      "title": "CashConnect (Alpha) Sessions",
-      "noActiveSessions": "No sessions currently active."
+      "title": "CashConnect (Alpha)"
     },
     "sessionProposal": {
       "title": "Approve Session?",
@@ -727,8 +729,7 @@
   },
   "walletConnect": {
     "sessions": {
-      "title": "WalletConnect Sessions",
-      "noActiveSessions": "No sessions currently active.",
+      "title": "WalletConnect",
       "session": "session"
     },
     "transactionRequest": {
@@ -809,8 +810,7 @@
   },
   "wizardConnect": {
     "sessions": {
-      "title": "WizardConnect Sessions",
-      "noActiveSessions": "No sessions currently active.",
+      "title": "WizardConnect",
       "notAvailableForWalletType": "WizardConnect is not available for this wallet type. It requires an HD wallet, because dApps receive the wallet's address list (xpub) to derive new addresses, which a single-address wallet cannot watch.",
       "unknownDapp": "Unknown dApp",
       "session": "session",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -811,7 +811,7 @@
       "signedTransaction": "Signed WalletConnect transaction '{userPrompt}'. Please return to the dapp.",
       "transactionSignedTitle": "Transaction Signed",
       "transactionSent": "Transaction successfully sent!",
-      "transactionSigned": "Transaction successfully signed!",
+      "transactionSigned": "Transaction signed and returned to the dApp",
       "requestExpired": "Request expired, please return to {dappName} if you would like to retry"
     }
   },
@@ -850,7 +850,7 @@
       "signedTransaction": "Signed WizardConnect transaction for {dappName}. Please return to the dapp.",
       "transactionSignedTitle": "Transaction Signed",
       "transactionSent": "Transaction successfully sent!",
-      "transactionSigned": "Transaction successfully signed!",
+      "transactionSigned": "Transaction signed and returned to the dApp",
       "requestCancelled": "Signing request was cancelled by {dappName}",
       "dappDisconnected": "WizardConnect session was disconnected by {dappName}"
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -812,8 +812,9 @@
       "title": "WizardConnect Sessions",
       "noActiveSessions": "No sessions currently active.",
       "notAvailableForWalletType": "WizardConnect is not available for this wallet type. It requires an HD wallet, because dApps receive the wallet's address list (xpub) to derive new addresses, which a single-address wallet cannot watch.",
-      "connecting": "Connecting...",
+      "unknownDapp": "Unknown dApp",
       "statusConnected": "Connected",
+      "statusWaitingForDapp": "Waiting for dApp...",
       "statusReconnecting": "Reconnecting...",
       "statusDisconnected": "Disconnected"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -818,7 +818,7 @@
     },
     "pairing": {
       "title": "Share wallet addresses with this dApp?",
-      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history — even after disconnecting — so you lose the privacy of using fresh HD wallet addresses. The dApp cannot spend your funds.",
+      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history — even after disconnecting — so you lose the privacy of using fresh HD wallet addresses. Spending your funds will still require your approval for each transaction.",
       "connectButton": "Connect",
       "cancelButton": "Cancel"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -818,7 +818,6 @@
   "wizardConnect": {
     "sessions": {
       "title": "WizardConnect",
-      "notAvailableForWalletType": "WizardConnect is not available for this wallet type. It requires an HD wallet, because dApps receive the wallet's address list (xpub) to derive new addresses, which a single-address wallet cannot watch.",
       "unknownDapp": "Unknown dApp",
       "session": "session",
       "statusConnected": "Connected",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -100,7 +100,7 @@
       "hd": "HD Wallet (multiple addresses)",
       "single": "Single address",
       "hdDescription": "Uses a new address for each transaction. Better privacy, but requires selecting an address when connecting to dApps.",
-      "singleDescription": "Uses one fixed address for all transactions. All assets in one place, but less private.",
+      "singleDescription": "Uses one fixed address for all transactions. All assets in one place, but less private. The WizardConnect connection method is not supported.",
       "singleAddressNote": "Note: Only the first address from your seed phrase will be used. If you've used this seed with other wallets, funds on other addresses won't appear."
     },
     "derivationPath": {
@@ -811,6 +811,7 @@
     "sessions": {
       "title": "WizardConnect Sessions",
       "noActiveSessions": "No sessions currently active.",
+      "notAvailableForWalletType": "WizardConnect is not available for this wallet type. It requires an HD wallet, because dApps receive the wallet's address list (xpub) to derive new addresses, which a single-address wallet cannot watch.",
       "connecting": "Connecting...",
       "statusConnected": "Connected",
       "statusReconnecting": "Reconnecting...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -63,6 +63,7 @@
       "walletNotFoundOnNetwork": "Wallet \"{name}\" does not exist on {network}",
       "errorInitializingWalletConnect": "Error initializing WalletConnect",
       "errorInitializingCashConnect": "Error initializing CashConnect",
+      "errorInitializingWizardConnect": "Error initializing WizardConnect",
       "errorFetchingUtxos": "Error in fetching wallet UTXOs",
       "errorFetchingHistory": "Error in fetching wallet history",
       "unableToConnectElectrum": "Unable to connect to Electrum server '{server}'",
@@ -356,8 +357,8 @@
     "uriPlaceholder": "Wallet Connect URI",
     "connectButton": "Connect New dApp",
     "errors": {
-      "invalidUri": "Invalid WalletConnect or CashConnect URI",
-      "notValidUri": "Not a valid WalletConnect or CashConnect URI"
+      "invalidUri": "Invalid WalletConnect, CashConnect or WizardConnect URI",
+      "notValidUri": "Not a valid WalletConnect, CashConnect or WizardConnect URI"
     }
   },
   "history": {
@@ -804,6 +805,34 @@
       "transactionSent": "Transaction successfully sent!",
       "transactionSigned": "Transaction successfully signed!",
       "requestExpired": "Request expired, please return to {dappName} if you would like to retry"
+    }
+  },
+  "wizardConnect": {
+    "sessions": {
+      "title": "WizardConnect Sessions",
+      "noActiveSessions": "No sessions currently active.",
+      "connecting": "Connecting...",
+      "statusConnected": "Connected",
+      "statusReconnecting": "Reconnecting...",
+      "statusDisconnected": "Disconnected"
+    },
+    "errors": {
+      "hdWalletRequired": "WizardConnect requires an HD wallet",
+      "notInitialized": "WizardConnect not initialized yet. Please try again in a moment.",
+      "invalidUri": "Not a valid WizardConnect URI",
+      "invalidTransactionSchema": "Error in validating schema of WizardConnect transaction request",
+      "failedToSignTransaction": "Failed to sign transaction",
+      "errorSendingTransaction": "Error in sending transaction"
+    },
+    "notifications": {
+      "sendingTransaction": "Sending transaction...",
+      "sentTransaction": "Sent WizardConnect transaction for {dappName}",
+      "signedTransaction": "Signed WizardConnect transaction for {dappName}. Please return to the dapp.",
+      "transactionSignedTitle": "Transaction Signed",
+      "transactionSent": "Transaction successfully sent!",
+      "transactionSigned": "Transaction successfully signed!",
+      "requestCancelled": "Signing request was cancelled by {dappName}",
+      "dappDisconnected": "WizardConnect session was disconnected by {dappName}"
     }
   },
   "settings": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -813,6 +813,7 @@
       "noActiveSessions": "No sessions currently active.",
       "notAvailableForWalletType": "WizardConnect is not available for this wallet type. It requires an HD wallet, because dApps receive the wallet's address list (xpub) to derive new addresses, which a single-address wallet cannot watch.",
       "unknownDapp": "Unknown dApp",
+      "session": "session",
       "statusConnected": "Connected",
       "statusWaitingForDapp": "Waiting for dApp...",
       "statusReconnecting": "Reconnecting...",
@@ -820,7 +821,11 @@
     },
     "pairing": {
       "title": "Share wallet addresses with this dApp?",
-      "message": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp. The dApp can then see your entire balance and transaction history, even after disconnecting, so you lose the privacy of using fresh HD wallet addresses. Spending your funds will still require your approval for each transaction.",
+      "intro": "Connecting shares your wallet's full current and future address list (the xpub) with the dApp.",
+      "bulletHistory": "The dApp can see your entire balance and transaction history, even after disconnecting.",
+      "bulletPrivacy": "You lose the privacy of using fresh HD wallet addresses.",
+      "bulletSpending": "Spending your funds still requires your approval for each transaction.",
+      "dappInfoNote": "Note: the dApp's name and icon are only received after connecting.",
       "connectButton": "Connect",
       "cancelButton": "Cancel"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -816,6 +816,12 @@
       "statusReconnecting": "Reconectando...",
       "statusDisconnected": "Desconectado"
     },
+    "pairing": {
+      "title": "¿Compartir las direcciones de la billetera con esta dApp?",
+      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones — incluso después de desconectar — por lo que pierdes la privacidad de usar direcciones HD nuevas. La dApp no puede gastar tus fondos.",
+      "connectButton": "Conectar",
+      "cancelButton": "Cancelar"
+    },
     "errors": {
       "hdWalletRequired": "WizardConnect requiere una billetera HD",
       "notInitialized": "WizardConnect aún no inicializado. Por favor intenta de nuevo en un momento.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -353,9 +353,12 @@
   },
   "dapp": {
     "title": "Conectar a dApp",
-    "exploreText": "Visita {link} para explorar la lista completa de dApps de BCH con WalletConnect",
+    "exploreText": "Conéctate a dApps mediante los métodos de conexión WalletConnect, CashConnect o WizardConnect. Visita {link} para explorar la lista completa de dApps de BCH.",
+    "exploreTextSingleAddress": "Conéctate a dApps mediante los métodos de conexión WalletConnect o CashConnect. Visita {link} para explorar la lista completa de dApps de BCH.",
     "uriPlaceholder": "URI de conexión",
     "connectButton": "Conectar nueva dApp",
+    "sessionsTitle": "Sesiones de dApps",
+    "noActiveSessions": "No hay sesiones activas actualmente.",
     "errors": {
       "invalidUri": "URI de WalletConnect, CashConnect o WizardConnect inválida",
       "notValidUri": "No es una URI válida de WalletConnect, CashConnect o WizardConnect"
@@ -683,8 +686,7 @@
   },
   "cashConnect": {
     "sessions": {
-      "title": "Sesiones de CashConnect (Alpha)",
-      "noActiveSessions": "No hay sesiones activas actualmente."
+      "title": "CashConnect (Alpha)"
     },
     "sessionProposal": {
       "title": "¿Aprobar sesión?",
@@ -727,8 +729,7 @@
   },
   "walletConnect": {
     "sessions": {
-      "title": "Sesiones de WalletConnect",
-      "noActiveSessions": "No hay sesiones activas actualmente.",
+      "title": "WalletConnect",
       "session": "sesión"
     },
     "transactionRequest": {
@@ -809,8 +810,7 @@
   },
   "wizardConnect": {
     "sessions": {
-      "title": "Sesiones WizardConnect",
-      "noActiveSessions": "No hay sesiones activas actualmente.",
+      "title": "WizardConnect",
       "notAvailableForWalletType": "WizardConnect no está disponible para este tipo de billetera. Requiere una billetera HD, porque las dApps reciben la lista de direcciones de la billetera (xpub) para derivar nuevas direcciones, que una billetera de dirección única no puede observar.",
       "unknownDapp": "dApp desconocida",
       "session": "sesión",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -100,7 +100,7 @@
       "hd": "Billetera HD (múltiples direcciones)",
       "single": "Dirección única",
       "hdDescription": "Usa una nueva dirección para cada transacción. Mayor privacidad, pero requiere seleccionar una dirección al conectarse a dApps.",
-      "singleDescription": "Usa una dirección fija para todas las transacciones. Todos los activos en un solo lugar, pero menos privado.",
+      "singleDescription": "Usa una dirección fija para todas las transacciones. Todos los activos en un solo lugar, pero menos privado. El método de conexión WizardConnect no es compatible.",
       "singleAddressNote": "Nota: Solo se usará la primera dirección de tu frase semilla. Si has usado esta semilla con otras billeteras, los fondos en otras direcciones no aparecerán."
     },
     "derivationPath": {
@@ -811,6 +811,7 @@
     "sessions": {
       "title": "Sesiones WizardConnect",
       "noActiveSessions": "No hay sesiones activas actualmente.",
+      "notAvailableForWalletType": "WizardConnect no está disponible para este tipo de billetera. Requiere una billetera HD, porque las dApps reciben la lista de direcciones de la billetera (xpub) para derivar nuevas direcciones, que una billetera de dirección única no puede observar.",
       "connecting": "Conectando...",
       "statusConnected": "Conectado",
       "statusReconnecting": "Reconectando...",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -818,7 +818,6 @@
   "wizardConnect": {
     "sessions": {
       "title": "WizardConnect",
-      "notAvailableForWalletType": "WizardConnect no está disponible para este tipo de billetera. Requiere una billetera HD, porque las dApps reciben la lista de direcciones de la billetera (xpub) para derivar nuevas direcciones, que una billetera de dirección única no puede observar.",
       "unknownDapp": "dApp desconocida",
       "session": "sesión",
       "statusConnected": "Conectado",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -75,7 +75,7 @@
       "title": "Bienvenido a Cashonize",
       "description": "Una billetera de Bitcoin Cash fácil de usar, con enfoque en CashTokens y dApps de BCH.",
       "featureSendReceive": "Envía y recibe BCH y CashTokens",
-      "featureWalletConnect": "Conéctate a dApps mediante WalletConnect",
+      "featureWalletConnect": "Conéctate a dApps mediante WalletConnect, CashConnect o WizardConnect",
       "featureOpenSource": "Código abierto y sin custodia"
     },
     "create": {
@@ -99,7 +99,7 @@
       "label": "Tipo de billetera:",
       "hd": "Billetera HD (múltiples direcciones)",
       "single": "Dirección única",
-      "hdDescription": "Usa una nueva dirección para cada transacción. Mayor privacidad, pero requiere seleccionar una dirección al conectarse a dApps.",
+      "hdDescription": "Usa una dirección nueva para cada transacción para mayor privacidad. Al conectar con WalletConnect, eliges qué dirección compartir.",
       "singleDescription": "Usa una dirección fija para todas las transacciones. Todos los activos en un solo lugar, pero menos privado. El método de conexión WizardConnect no es compatible.",
       "singleAddressNote": "Nota: Solo se usará la primera dirección de tu frase semilla. Si has usado esta semilla con otras billeteras, los fondos en otras direcciones no aparecerán."
     },
@@ -354,7 +354,7 @@
   "dapp": {
     "title": "Conectar a dApp",
     "exploreText": "Visita {link} para explorar la lista completa de dApps de BCH con WalletConnect",
-    "uriPlaceholder": "URI de WalletConnect",
+    "uriPlaceholder": "URI de conexión",
     "connectButton": "Conectar nueva dApp",
     "errors": {
       "invalidUri": "URI de WalletConnect, CashConnect o WizardConnect inválida",
@@ -819,7 +819,7 @@
     },
     "pairing": {
       "title": "¿Compartir las direcciones de la billetera con esta dApp?",
-      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones — incluso después de desconectar — por lo que pierdes la privacidad de usar direcciones HD nuevas. Gastar tus fondos seguirá requiriendo tu aprobación para cada transacción.",
+      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones, incluso después de desconectar, por lo que pierdes la privacidad de usar direcciones HD nuevas. Gastar tus fondos seguirá requiriendo tu aprobación para cada transacción.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -813,6 +813,7 @@
       "noActiveSessions": "No hay sesiones activas actualmente.",
       "notAvailableForWalletType": "WizardConnect no está disponible para este tipo de billetera. Requiere una billetera HD, porque las dApps reciben la lista de direcciones de la billetera (xpub) para derivar nuevas direcciones, que una billetera de dirección única no puede observar.",
       "unknownDapp": "dApp desconocida",
+      "session": "sesión",
       "statusConnected": "Conectado",
       "statusWaitingForDapp": "Esperando a la dApp...",
       "statusReconnecting": "Reconectando...",
@@ -820,7 +821,11 @@
     },
     "pairing": {
       "title": "¿Compartir las direcciones de la billetera con esta dApp?",
-      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones, incluso después de desconectar, por lo que pierdes la privacidad de usar direcciones HD nuevas. Gastar tus fondos seguirá requiriendo tu aprobación para cada transacción.",
+      "intro": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub).",
+      "bulletHistory": "La dApp puede ver todo tu saldo y tu historial de transacciones, incluso después de desconectar.",
+      "bulletPrivacy": "Pierdes la privacidad de usar direcciones HD nuevas.",
+      "bulletSpending": "Gastar tus fondos sigue requiriendo tu aprobación para cada transacción.",
+      "dappInfoNote": "Nota: el nombre y el icono de la dApp solo se reciben después de conectar.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -63,6 +63,7 @@
       "walletNotFoundOnNetwork": "La billetera \"{name}\" no existe en {network}",
       "errorInitializingWalletConnect": "Error al inicializar WalletConnect",
       "errorInitializingCashConnect": "Error al inicializar CashConnect",
+      "errorInitializingWizardConnect": "Error al inicializar WizardConnect",
       "errorFetchingUtxos": "Error al obtener los UTXOs de la billetera",
       "errorFetchingHistory": "Error al obtener el historial de la billetera",
       "unableToConnectElectrum": "No se puede conectar al servidor Electrum '{server}'",
@@ -356,8 +357,8 @@
     "uriPlaceholder": "URI de WalletConnect",
     "connectButton": "Conectar nueva dApp",
     "errors": {
-      "invalidUri": "URI de WalletConnect o CashConnect inválida",
-      "notValidUri": "No es una URI válida de WalletConnect o CashConnect"
+      "invalidUri": "URI de WalletConnect, CashConnect o WizardConnect inválida",
+      "notValidUri": "No es una URI válida de WalletConnect, CashConnect o WizardConnect"
     }
   },
   "history": {
@@ -804,6 +805,34 @@
       "transactionSent": "¡Transacción enviada exitosamente!",
       "transactionSigned": "¡Transacción firmada exitosamente!",
       "requestExpired": "Solicitud expirada, por favor regrese a {dappName} para reintentar"
+    }
+  },
+  "wizardConnect": {
+    "sessions": {
+      "title": "Sesiones WizardConnect",
+      "noActiveSessions": "No hay sesiones activas actualmente.",
+      "connecting": "Conectando...",
+      "statusConnected": "Conectado",
+      "statusReconnecting": "Reconectando...",
+      "statusDisconnected": "Desconectado"
+    },
+    "errors": {
+      "hdWalletRequired": "WizardConnect requiere una billetera HD",
+      "notInitialized": "WizardConnect aún no inicializado. Por favor intenta de nuevo en un momento.",
+      "invalidUri": "No es una URI válida de WizardConnect",
+      "invalidTransactionSchema": "Error al validar el esquema de la solicitud de transacción de WizardConnect",
+      "failedToSignTransaction": "Error al firmar la transacción",
+      "errorSendingTransaction": "Error al enviar la transacción"
+    },
+    "notifications": {
+      "sendingTransaction": "Enviando transacción...",
+      "sentTransaction": "Enviada transacción WizardConnect para {dappName}",
+      "signedTransaction": "Transacción WizardConnect para {dappName} firmada. Por favor, regresa a la dapp.",
+      "transactionSignedTitle": "Transacción firmada",
+      "transactionSent": "¡Transacción enviada exitosamente!",
+      "transactionSigned": "¡Transacción firmada exitosamente!",
+      "requestCancelled": "La solicitud de firma fue cancelada por {dappName}",
+      "dappDisconnected": "La sesión WizardConnect fue desconectada por {dappName}"
     }
   },
   "settings": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -812,8 +812,9 @@
       "title": "Sesiones WizardConnect",
       "noActiveSessions": "No hay sesiones activas actualmente.",
       "notAvailableForWalletType": "WizardConnect no está disponible para este tipo de billetera. Requiere una billetera HD, porque las dApps reciben la lista de direcciones de la billetera (xpub) para derivar nuevas direcciones, que una billetera de dirección única no puede observar.",
-      "connecting": "Conectando...",
+      "unknownDapp": "dApp desconocida",
       "statusConnected": "Conectado",
+      "statusWaitingForDapp": "Esperando a la dApp...",
       "statusReconnecting": "Reconectando...",
       "statusDisconnected": "Desconectado"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -818,7 +818,7 @@
     },
     "pairing": {
       "title": "¿Compartir las direcciones de la billetera con esta dApp?",
-      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones — incluso después de desconectar — por lo que pierdes la privacidad de usar direcciones HD nuevas. La dApp no puede gastar tus fondos.",
+      "message": "Al conectar se comparte con la dApp la lista completa de direcciones actuales y futuras de tu billetera (la xpub). La dApp podrá ver todo tu saldo y tu historial de transacciones — incluso después de desconectar — por lo que pierdes la privacidad de usar direcciones HD nuevas. Gastar tus fondos seguirá requiriendo tu aprobación para cada transacción.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -811,7 +811,7 @@
       "signedTransaction": "Transacción WalletConnect '{userPrompt}' firmada. Por favor, regresa a la dapp.",
       "transactionSignedTitle": "Transacción firmada",
       "transactionSent": "¡Transacción enviada exitosamente!",
-      "transactionSigned": "¡Transacción firmada exitosamente!",
+      "transactionSigned": "Transacción firmada y devuelta a la dApp",
       "requestExpired": "Solicitud expirada, por favor regrese a {dappName} para reintentar"
     }
   },
@@ -850,7 +850,7 @@
       "signedTransaction": "Transacción WizardConnect para {dappName} firmada. Por favor, regresa a la dapp.",
       "transactionSignedTitle": "Transacción firmada",
       "transactionSent": "¡Transacción enviada exitosamente!",
-      "transactionSigned": "¡Transacción firmada exitosamente!",
+      "transactionSigned": "Transacción firmada y devuelta a la dApp",
       "requestCancelled": "La solicitud de firma fue cancelada por {dappName}",
       "dappDisconnected": "La sesión WizardConnect fue desconectada por {dappName}"
     }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -20,6 +20,13 @@
     "wallet": "billetera",
     "wallets": "billeteras"
   },
+  "nav": {
+    "wallet": "Billetera",
+    "addresses": "Direcciones",
+    "tokens": "Tokens",
+    "history": "Historial",
+    "connect": "Conectar"
+  },
   "walletUtils": {
     "errors": {
       "enterWalletName": "Por favor ingresa un nombre de billetera",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -75,7 +75,7 @@
       "title": "Bienvenue sur Cashonize",
       "description": "Un portefeuille Bitcoin Cash facile à utiliser, axé sur les CashTokens et les dApps BCH.",
       "featureSendReceive": "Envoyez et recevez des BCH et CashTokens",
-      "featureWalletConnect": "Connectez-vous aux dApps via WalletConnect",
+      "featureWalletConnect": "Connectez-vous aux dApps via WalletConnect, CashConnect ou WizardConnect",
       "featureOpenSource": "Open source et non-custodial"
     },
     "create": {
@@ -99,7 +99,7 @@
       "label": "Type de portefeuille :",
       "hd": "Portefeuille HD (adresses multiples)",
       "single": "Adresse unique",
-      "hdDescription": "Utilise une nouvelle adresse pour chaque transaction. Meilleure confidentialité, mais nécessite de sélectionner une adresse lors de la connexion aux dApps.",
+      "hdDescription": "Utilise une nouvelle adresse pour chaque transaction pour une meilleure confidentialité. Lors d'une connexion avec WalletConnect, vous choisissez quelle adresse partager.",
       "singleDescription": "Utilise une seule adresse fixe pour toutes les transactions. Tous les actifs au même endroit, mais moins privé. La méthode de connexion WizardConnect n'est pas prise en charge.",
       "singleAddressNote": "Remarque : Seule la première adresse de votre phrase de récupération sera utilisée. Si vous avez utilisé cette phrase avec d'autres portefeuilles, les fonds sur d'autres adresses n'apparaîtront pas."
     },
@@ -354,7 +354,7 @@
   "dapp": {
     "title": "Connecter à une dApp",
     "exploreText": "Visitez {link} pour explorer la liste complète des dApps BCH avec WalletConnect",
-    "uriPlaceholder": "URI WalletConnect",
+    "uriPlaceholder": "URI de connexion",
     "connectButton": "Connecter nouvelle dApp",
     "errors": {
       "invalidUri": "URI WalletConnect, CashConnect ou WizardConnect invalide",
@@ -819,7 +819,7 @@
     },
     "pairing": {
       "title": "Partager les adresses du portefeuille avec cette dApp ?",
-      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions — même après déconnexion — et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. Dépenser vos fonds nécessitera toujours votre approbation pour chaque transaction.",
+      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions, même après déconnexion, et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. Dépenser vos fonds nécessitera toujours votre approbation pour chaque transaction.",
       "connectButton": "Connecter",
       "cancelButton": "Annuler"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -20,6 +20,13 @@
     "wallet": "portefeuille",
     "wallets": "portefeuilles"
   },
+  "nav": {
+    "wallet": "Portefeuille",
+    "addresses": "Adresses",
+    "tokens": "Tokens",
+    "history": "Historique",
+    "connect": "Connecter"
+  },
   "walletUtils": {
     "errors": {
       "enterWalletName": "Veuillez entrer un nom de portefeuille",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -818,7 +818,6 @@
   "wizardConnect": {
     "sessions": {
       "title": "WizardConnect",
-      "notAvailableForWalletType": "WizardConnect n'est pas disponible pour ce type de portefeuille. Il nécessite un portefeuille HD, car les dApps reçoivent la liste des adresses du portefeuille (xpub) pour dériver de nouvelles adresses, qu'un portefeuille à adresse unique ne peut pas surveiller.",
       "unknownDapp": "dApp inconnue",
       "session": "session",
       "statusConnected": "Connecté",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -353,9 +353,12 @@
   },
   "dapp": {
     "title": "Connecter à une dApp",
-    "exploreText": "Visitez {link} pour explorer la liste complète des dApps BCH avec WalletConnect",
+    "exploreText": "Connectez-vous aux dApps avec les méthodes de connexion WalletConnect, CashConnect ou WizardConnect. Visitez {link} pour explorer la liste complète des dApps BCH.",
+    "exploreTextSingleAddress": "Connectez-vous aux dApps avec les méthodes de connexion WalletConnect ou CashConnect. Visitez {link} pour explorer la liste complète des dApps BCH.",
     "uriPlaceholder": "URI de connexion",
     "connectButton": "Connecter nouvelle dApp",
+    "sessionsTitle": "Sessions dApp",
+    "noActiveSessions": "Aucune session active actuellement.",
     "errors": {
       "invalidUri": "URI WalletConnect, CashConnect ou WizardConnect invalide",
       "notValidUri": "Ce n'est pas une URI WalletConnect, CashConnect ou WizardConnect valide"
@@ -683,8 +686,7 @@
   },
   "cashConnect": {
     "sessions": {
-      "title": "Sessions CashConnect (Alpha)",
-      "noActiveSessions": "Aucune session active actuellement."
+      "title": "CashConnect (Alpha)"
     },
     "sessionProposal": {
       "title": "Approuver la session ?",
@@ -727,8 +729,7 @@
   },
   "walletConnect": {
     "sessions": {
-      "title": "Sessions WalletConnect",
-      "noActiveSessions": "Aucune session active actuellement.",
+      "title": "WalletConnect",
       "session": "session"
     },
     "transactionRequest": {
@@ -809,8 +810,7 @@
   },
   "wizardConnect": {
     "sessions": {
-      "title": "Sessions WizardConnect",
-      "noActiveSessions": "Aucune session active actuellement.",
+      "title": "WizardConnect",
       "notAvailableForWalletType": "WizardConnect n'est pas disponible pour ce type de portefeuille. Il nécessite un portefeuille HD, car les dApps reçoivent la liste des adresses du portefeuille (xpub) pour dériver de nouvelles adresses, qu'un portefeuille à adresse unique ne peut pas surveiller.",
       "unknownDapp": "dApp inconnue",
       "session": "session",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -812,8 +812,9 @@
       "title": "Sessions WizardConnect",
       "noActiveSessions": "Aucune session active actuellement.",
       "notAvailableForWalletType": "WizardConnect n'est pas disponible pour ce type de portefeuille. Il nécessite un portefeuille HD, car les dApps reçoivent la liste des adresses du portefeuille (xpub) pour dériver de nouvelles adresses, qu'un portefeuille à adresse unique ne peut pas surveiller.",
-      "connecting": "Connexion...",
+      "unknownDapp": "dApp inconnue",
       "statusConnected": "Connecté",
+      "statusWaitingForDapp": "En attente de la dApp...",
       "statusReconnecting": "Reconnexion...",
       "statusDisconnected": "Déconnecté"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -816,6 +816,12 @@
       "statusReconnecting": "Reconnexion...",
       "statusDisconnected": "Déconnecté"
     },
+    "pairing": {
+      "title": "Partager les adresses du portefeuille avec cette dApp ?",
+      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions — même après déconnexion — et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. La dApp ne peut pas dépenser vos fonds.",
+      "connectButton": "Connecter",
+      "cancelButton": "Annuler"
+    },
     "errors": {
       "hdWalletRequired": "WizardConnect nécessite un portefeuille HD",
       "notInitialized": "WizardConnect pas encore initialisé. Veuillez réessayer dans un moment.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -818,7 +818,7 @@
     },
     "pairing": {
       "title": "Partager les adresses du portefeuille avec cette dApp ?",
-      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions — même après déconnexion — et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. La dApp ne peut pas dépenser vos fonds.",
+      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions — même après déconnexion — et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. Dépenser vos fonds nécessitera toujours votre approbation pour chaque transaction.",
       "connectButton": "Connecter",
       "cancelButton": "Annuler"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -811,7 +811,7 @@
       "signedTransaction": "Transaction WalletConnect '{userPrompt}' signée. Veuillez retourner à la dapp.",
       "transactionSignedTitle": "Transaction signée",
       "transactionSent": "Transaction envoyée avec succès !",
-      "transactionSigned": "Transaction signée avec succès !",
+      "transactionSigned": "Transaction signée et renvoyée à la dApp",
       "requestExpired": "Requête expirée, veuillez retourner à {dappName} pour réessayer"
     }
   },
@@ -850,7 +850,7 @@
       "signedTransaction": "Transaction WizardConnect pour {dappName} signée. Veuillez retourner à la dapp.",
       "transactionSignedTitle": "Transaction signée",
       "transactionSent": "Transaction envoyée avec succès !",
-      "transactionSigned": "Transaction signée avec succès !",
+      "transactionSigned": "Transaction signée et renvoyée à la dApp",
       "requestCancelled": "La demande de signature a été annulée par {dappName}",
       "dappDisconnected": "La session WizardConnect a été déconnectée par {dappName}"
     }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -63,6 +63,7 @@
       "walletNotFoundOnNetwork": "Le portefeuille \"{name}\" n'existe pas sur {network}",
       "errorInitializingWalletConnect": "Erreur lors de l'initialisation de WalletConnect",
       "errorInitializingCashConnect": "Erreur lors de l'initialisation de CashConnect",
+      "errorInitializingWizardConnect": "Erreur lors de l'initialisation de WizardConnect",
       "errorFetchingUtxos": "Erreur lors de la récupération des UTXOs du portefeuille",
       "errorFetchingHistory": "Erreur lors de la récupération de l'historique du portefeuille",
       "unableToConnectElectrum": "Impossible de se connecter au serveur Electrum '{server}'",
@@ -356,8 +357,8 @@
     "uriPlaceholder": "URI WalletConnect",
     "connectButton": "Connecter nouvelle dApp",
     "errors": {
-      "invalidUri": "URI WalletConnect ou CashConnect invalide",
-      "notValidUri": "Ce n'est pas une URI WalletConnect ou CashConnect valide"
+      "invalidUri": "URI WalletConnect, CashConnect ou WizardConnect invalide",
+      "notValidUri": "Ce n'est pas une URI WalletConnect, CashConnect ou WizardConnect valide"
     }
   },
   "history": {
@@ -804,6 +805,34 @@
       "transactionSent": "Transaction envoyée avec succès !",
       "transactionSigned": "Transaction signée avec succès !",
       "requestExpired": "Requête expirée, veuillez retourner à {dappName} pour réessayer"
+    }
+  },
+  "wizardConnect": {
+    "sessions": {
+      "title": "Sessions WizardConnect",
+      "noActiveSessions": "Aucune session active actuellement.",
+      "connecting": "Connexion...",
+      "statusConnected": "Connecté",
+      "statusReconnecting": "Reconnexion...",
+      "statusDisconnected": "Déconnecté"
+    },
+    "errors": {
+      "hdWalletRequired": "WizardConnect nécessite un portefeuille HD",
+      "notInitialized": "WizardConnect pas encore initialisé. Veuillez réessayer dans un moment.",
+      "invalidUri": "Ce n'est pas une URI WizardConnect valide",
+      "invalidTransactionSchema": "Erreur lors de la validation du schéma de la demande de transaction WizardConnect",
+      "failedToSignTransaction": "Échec de la signature de la transaction",
+      "errorSendingTransaction": "Erreur lors de l'envoi de la transaction"
+    },
+    "notifications": {
+      "sendingTransaction": "Envoi de la transaction...",
+      "sentTransaction": "Transaction WizardConnect envoyée pour {dappName}",
+      "signedTransaction": "Transaction WizardConnect pour {dappName} signée. Veuillez retourner à la dapp.",
+      "transactionSignedTitle": "Transaction signée",
+      "transactionSent": "Transaction envoyée avec succès !",
+      "transactionSigned": "Transaction signée avec succès !",
+      "requestCancelled": "La demande de signature a été annulée par {dappName}",
+      "dappDisconnected": "La session WizardConnect a été déconnectée par {dappName}"
     }
   },
   "settings": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -100,7 +100,7 @@
       "hd": "Portefeuille HD (adresses multiples)",
       "single": "Adresse unique",
       "hdDescription": "Utilise une nouvelle adresse pour chaque transaction. Meilleure confidentialité, mais nécessite de sélectionner une adresse lors de la connexion aux dApps.",
-      "singleDescription": "Utilise une seule adresse fixe pour toutes les transactions. Tous les actifs au même endroit, mais moins privé.",
+      "singleDescription": "Utilise une seule adresse fixe pour toutes les transactions. Tous les actifs au même endroit, mais moins privé. La méthode de connexion WizardConnect n'est pas prise en charge.",
       "singleAddressNote": "Remarque : Seule la première adresse de votre phrase de récupération sera utilisée. Si vous avez utilisé cette phrase avec d'autres portefeuilles, les fonds sur d'autres adresses n'apparaîtront pas."
     },
     "derivationPath": {
@@ -811,6 +811,7 @@
     "sessions": {
       "title": "Sessions WizardConnect",
       "noActiveSessions": "Aucune session active actuellement.",
+      "notAvailableForWalletType": "WizardConnect n'est pas disponible pour ce type de portefeuille. Il nécessite un portefeuille HD, car les dApps reçoivent la liste des adresses du portefeuille (xpub) pour dériver de nouvelles adresses, qu'un portefeuille à adresse unique ne peut pas surveiller.",
       "connecting": "Connexion...",
       "statusConnected": "Connecté",
       "statusReconnecting": "Reconnexion...",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -813,6 +813,7 @@
       "noActiveSessions": "Aucune session active actuellement.",
       "notAvailableForWalletType": "WizardConnect n'est pas disponible pour ce type de portefeuille. Il nécessite un portefeuille HD, car les dApps reçoivent la liste des adresses du portefeuille (xpub) pour dériver de nouvelles adresses, qu'un portefeuille à adresse unique ne peut pas surveiller.",
       "unknownDapp": "dApp inconnue",
+      "session": "session",
       "statusConnected": "Connecté",
       "statusWaitingForDapp": "En attente de la dApp...",
       "statusReconnecting": "Reconnexion...",
@@ -820,7 +821,11 @@
     },
     "pairing": {
       "title": "Partager les adresses du portefeuille avec cette dApp ?",
-      "message": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub). La dApp pourra alors voir l'intégralité de votre solde et de votre historique de transactions, même après déconnexion, et vous perdez donc la confidentialité offerte par les nouvelles adresses HD. Dépenser vos fonds nécessitera toujours votre approbation pour chaque transaction.",
+      "intro": "La connexion partage avec la dApp la liste complète des adresses actuelles et futures de votre portefeuille (la xpub).",
+      "bulletHistory": "La dApp peut voir l'intégralité de votre solde et de votre historique de transactions, même après déconnexion.",
+      "bulletPrivacy": "Vous perdez la confidentialité offerte par les nouvelles adresses HD.",
+      "bulletSpending": "Dépenser vos fonds nécessite toujours votre approbation pour chaque transaction.",
+      "dappInfoNote": "Remarque : le nom et l'icône de la dApp ne sont reçus qu'après la connexion.",
       "connectButton": "Connecter",
       "cancelButton": "Annuler"
     },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -818,7 +818,7 @@
     },
     "pairing": {
       "title": "Compartilhar os endereços da carteira com esta dApp?",
-      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações — mesmo após desconectar — e você perde a privacidade de usar novos endereços HD. A dApp não pode gastar seus fundos.",
+      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações — mesmo após desconectar — e você perde a privacidade de usar novos endereços HD. Gastar seus fundos continuará exigindo sua aprovação para cada transação.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -63,6 +63,7 @@
       "walletNotFoundOnNetwork": "A carteira \"{name}\" não existe em {network}",
       "errorInitializingWalletConnect": "Erro ao inicializar WalletConnect",
       "errorInitializingCashConnect": "Erro ao inicializar CashConnect",
+      "errorInitializingWizardConnect": "Erro ao inicializar WizardConnect",
       "errorFetchingUtxos": "Erro ao buscar UTXOs da carteira",
       "errorFetchingHistory": "Erro ao buscar histórico da carteira",
       "unableToConnectElectrum": "Não foi possível conectar ao servidor Electrum '{server}'",
@@ -356,8 +357,8 @@
     "uriPlaceholder": "URI do WalletConnect",
     "connectButton": "Conectar novo dApp",
     "errors": {
-      "invalidUri": "URI de WalletConnect ou CashConnect inválida",
-      "notValidUri": "URI de WalletConnect ou CashConnect inválida"
+      "invalidUri": "URI de WalletConnect, CashConnect ou WizardConnect inválida",
+      "notValidUri": "URI de WalletConnect, CashConnect ou WizardConnect inválida"
     }
   },
   "history": {
@@ -804,6 +805,34 @@
       "transactionSent": "Transação enviada com sucesso!",
       "transactionSigned": "Transação assinada com sucesso!",
       "requestExpired": "Requisição expirou, retorne ao {dappName} se deseja tentar novamente"
+    }
+  },
+  "wizardConnect": {
+    "sessions": {
+      "title": "Sessões WizardConnect",
+      "noActiveSessions": "Nenhuma sessão ativa no momento.",
+      "connecting": "Conectando...",
+      "statusConnected": "Conectado",
+      "statusReconnecting": "Reconectando...",
+      "statusDisconnected": "Desconectado"
+    },
+    "errors": {
+      "hdWalletRequired": "WizardConnect requer uma carteira HD",
+      "notInitialized": "WizardConnect ainda não foi inicializado. Por favor, tente novamente em instantes.",
+      "invalidUri": "URI WizardConnect inválida",
+      "invalidTransactionSchema": "Erro na validação do schema da requisição de transação WizardConnect",
+      "failedToSignTransaction": "Falha ao assinar transação",
+      "errorSendingTransaction": "Erro ao enviar transação"
+    },
+    "notifications": {
+      "sendingTransaction": "Enviando transação...",
+      "sentTransaction": "Transação WizardConnect enviada para {dappName}",
+      "signedTransaction": "Transação WizardConnect para {dappName} assinada. Por favor, retorne ao dapp.",
+      "transactionSignedTitle": "Transação Assinada",
+      "transactionSent": "Transação enviada com sucesso!",
+      "transactionSigned": "Transação assinada com sucesso!",
+      "requestCancelled": "A solicitação de assinatura foi cancelada por {dappName}",
+      "dappDisconnected": "A sessão WizardConnect foi desconectada por {dappName}"
     }
   },
   "settings": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -353,9 +353,12 @@
   },
   "dapp": {
     "title": "Conectar a Dapp",
-    "exploreText": "Veja {link} para explorar a lista completa de Dapps BCH com WalletConnect",
+    "exploreText": "Conecte-se a dApps com os métodos de conexão WalletConnect, CashConnect ou WizardConnect. Veja {link} para explorar a lista completa de dApps BCH.",
+    "exploreTextSingleAddress": "Conecte-se a dApps com os métodos de conexão WalletConnect ou CashConnect. Veja {link} para explorar a lista completa de dApps BCH.",
     "uriPlaceholder": "URI de conexão",
     "connectButton": "Conectar novo dApp",
+    "sessionsTitle": "Sessões de dApps",
+    "noActiveSessions": "Nenhuma sessão ativa no momento.",
     "errors": {
       "invalidUri": "URI de WalletConnect, CashConnect ou WizardConnect inválida",
       "notValidUri": "URI de WalletConnect, CashConnect ou WizardConnect inválida"
@@ -683,8 +686,7 @@
   },
   "cashConnect": {
     "sessions": {
-      "title": "Sessões CashConnect (Alfa)",
-      "noActiveSessions": "Nenhuma sessão ativa no momento."
+      "title": "CashConnect (Alfa)"
     },
     "sessionProposal": {
       "title": "Aprovar sessão?",
@@ -727,8 +729,7 @@
   },
   "walletConnect": {
     "sessions": {
-      "title": "Sessões WalletConnect",
-      "noActiveSessions": "Nenhuma sessão ativa no momento.",
+      "title": "WalletConnect",
       "session": "sessão"
     },
     "transactionRequest": {
@@ -809,8 +810,7 @@
   },
   "wizardConnect": {
     "sessions": {
-      "title": "Sessões WizardConnect",
-      "noActiveSessions": "Nenhuma sessão ativa no momento.",
+      "title": "WizardConnect",
       "notAvailableForWalletType": "WizardConnect não está disponível para este tipo de carteira. Requer uma carteira HD, porque as dApps recebem a lista de endereços da carteira (xpub) para derivar novos endereços, que uma carteira de endereço único não pode observar.",
       "unknownDapp": "dApp desconhecida",
       "session": "sessão",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -20,6 +20,13 @@
     "wallet": "carteira",
     "wallets": "carteiras"
   },
+  "nav": {
+    "wallet": "Carteira",
+    "addresses": "Endereços",
+    "tokens": "Tokens",
+    "history": "Histórico",
+    "connect": "Conectar"
+  },
   "walletUtils": {
     "errors": {
       "enterWalletName": "Por favor, insira um nome para a carteira",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -811,7 +811,7 @@
       "signedTransaction": "Transação WalletConnect assinada '{userPrompt}'. Por favor, retorne ao dapp.",
       "transactionSignedTitle": "Transação Assinada",
       "transactionSent": "Transação enviada com sucesso!",
-      "transactionSigned": "Transação assinada com sucesso!",
+      "transactionSigned": "Transação assinada e devolvida à dApp",
       "requestExpired": "Requisição expirou, retorne ao {dappName} se deseja tentar novamente"
     }
   },
@@ -850,7 +850,7 @@
       "signedTransaction": "Transação WizardConnect para {dappName} assinada. Por favor, retorne ao dapp.",
       "transactionSignedTitle": "Transação Assinada",
       "transactionSent": "Transação enviada com sucesso!",
-      "transactionSigned": "Transação assinada com sucesso!",
+      "transactionSigned": "Transação assinada e devolvida à dApp",
       "requestCancelled": "A solicitação de assinatura foi cancelada por {dappName}",
       "dappDisconnected": "A sessão WizardConnect foi desconectada por {dappName}"
     }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -75,7 +75,7 @@
       "title": "Bem-vindo ao Cashonize",
       "description": "Uma carteira Bitcoin Cash fácil de usar, focada em CashTokens e dApps BCH.",
       "featureSendReceive": "Envie e receba BCH e CashTokens",
-      "featureWalletConnect": "Conecte-se a dApps via WalletConnect",
+      "featureWalletConnect": "Conecte-se a dApps via WalletConnect, CashConnect ou WizardConnect",
       "featureOpenSource": "Código aberto e sem custódia"
     },
     "create": {
@@ -99,7 +99,7 @@
       "label": "Tipo de carteira:",
       "hd": "Carteira HD (múltiplos endereços)",
       "single": "Endereço único",
-      "hdDescription": "Usa um novo endereço para cada transação. Maior privacidade, mas requer selecionar um endereço ao conectar a dApps.",
+      "hdDescription": "Usa um novo endereço para cada transação para maior privacidade. Ao conectar com WalletConnect, você escolhe qual endereço compartilhar.",
       "singleDescription": "Usa um endereço fixo para todas as transações. Todos os ativos em um só lugar, porém menos privado. O método de conexão WizardConnect não é suportado.",
       "singleAddressNote": "Nota: Apenas o primeiro endereço da sua seed phrase será usado. Se você usou essa seed com outras carteiras, fundos em outros endereços não aparecerão."
     },
@@ -354,7 +354,7 @@
   "dapp": {
     "title": "Conectar a Dapp",
     "exploreText": "Veja {link} para explorar a lista completa de Dapps BCH com WalletConnect",
-    "uriPlaceholder": "URI do WalletConnect",
+    "uriPlaceholder": "URI de conexão",
     "connectButton": "Conectar novo dApp",
     "errors": {
       "invalidUri": "URI de WalletConnect, CashConnect ou WizardConnect inválida",
@@ -819,7 +819,7 @@
     },
     "pairing": {
       "title": "Compartilhar os endereços da carteira com esta dApp?",
-      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações — mesmo após desconectar — e você perde a privacidade de usar novos endereços HD. Gastar seus fundos continuará exigindo sua aprovação para cada transação.",
+      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações, mesmo após desconectar, e você perde a privacidade de usar novos endereços HD. Gastar seus fundos continuará exigindo sua aprovação para cada transação.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -818,7 +818,6 @@
   "wizardConnect": {
     "sessions": {
       "title": "WizardConnect",
-      "notAvailableForWalletType": "WizardConnect não está disponível para este tipo de carteira. Requer uma carteira HD, porque as dApps recebem a lista de endereços da carteira (xpub) para derivar novos endereços, que uma carteira de endereço único não pode observar.",
       "unknownDapp": "dApp desconhecida",
       "session": "sessão",
       "statusConnected": "Conectado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -100,7 +100,7 @@
       "hd": "Carteira HD (múltiplos endereços)",
       "single": "Endereço único",
       "hdDescription": "Usa um novo endereço para cada transação. Maior privacidade, mas requer selecionar um endereço ao conectar a dApps.",
-      "singleDescription": "Usa um endereço fixo para todas as transações. Todos os ativos em um só lugar, porém menos privado.",
+      "singleDescription": "Usa um endereço fixo para todas as transações. Todos os ativos em um só lugar, porém menos privado. O método de conexão WizardConnect não é suportado.",
       "singleAddressNote": "Nota: Apenas o primeiro endereço da sua seed phrase será usado. Se você usou essa seed com outras carteiras, fundos em outros endereços não aparecerão."
     },
     "derivationPath": {
@@ -811,6 +811,7 @@
     "sessions": {
       "title": "Sessões WizardConnect",
       "noActiveSessions": "Nenhuma sessão ativa no momento.",
+      "notAvailableForWalletType": "WizardConnect não está disponível para este tipo de carteira. Requer uma carteira HD, porque as dApps recebem a lista de endereços da carteira (xpub) para derivar novos endereços, que uma carteira de endereço único não pode observar.",
       "connecting": "Conectando...",
       "statusConnected": "Conectado",
       "statusReconnecting": "Reconectando...",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -816,6 +816,12 @@
       "statusReconnecting": "Reconectando...",
       "statusDisconnected": "Desconectado"
     },
+    "pairing": {
+      "title": "Compartilhar os endereços da carteira com esta dApp?",
+      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações — mesmo após desconectar — e você perde a privacidade de usar novos endereços HD. A dApp não pode gastar seus fundos.",
+      "connectButton": "Conectar",
+      "cancelButton": "Cancelar"
+    },
     "errors": {
       "hdWalletRequired": "WizardConnect requer uma carteira HD",
       "notInitialized": "WizardConnect ainda não foi inicializado. Por favor, tente novamente em instantes.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -812,8 +812,9 @@
       "title": "Sessões WizardConnect",
       "noActiveSessions": "Nenhuma sessão ativa no momento.",
       "notAvailableForWalletType": "WizardConnect não está disponível para este tipo de carteira. Requer uma carteira HD, porque as dApps recebem a lista de endereços da carteira (xpub) para derivar novos endereços, que uma carteira de endereço único não pode observar.",
-      "connecting": "Conectando...",
+      "unknownDapp": "dApp desconhecida",
       "statusConnected": "Conectado",
+      "statusWaitingForDapp": "Aguardando a dApp...",
       "statusReconnecting": "Reconectando...",
       "statusDisconnected": "Desconectado"
     },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -813,6 +813,7 @@
       "noActiveSessions": "Nenhuma sessão ativa no momento.",
       "notAvailableForWalletType": "WizardConnect não está disponível para este tipo de carteira. Requer uma carteira HD, porque as dApps recebem a lista de endereços da carteira (xpub) para derivar novos endereços, que uma carteira de endereço único não pode observar.",
       "unknownDapp": "dApp desconhecida",
+      "session": "sessão",
       "statusConnected": "Conectado",
       "statusWaitingForDapp": "Aguardando a dApp...",
       "statusReconnecting": "Reconectando...",
@@ -820,7 +821,11 @@
     },
     "pairing": {
       "title": "Compartilhar os endereços da carteira com esta dApp?",
-      "message": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp. A dApp poderá ver todo o seu saldo e histórico de transações, mesmo após desconectar, e você perde a privacidade de usar novos endereços HD. Gastar seus fundos continuará exigindo sua aprovação para cada transação.",
+      "intro": "Ao conectar, a lista completa de endereços atuais e futuros da sua carteira (a xpub) é compartilhada com a dApp.",
+      "bulletHistory": "A dApp pode ver todo o seu saldo e histórico de transações, mesmo após desconectar.",
+      "bulletPrivacy": "Você perde a privacidade de usar novos endereços HD.",
+      "bulletSpending": "Gastar seus fundos continua exigindo sua aprovação para cada transação.",
+      "dappInfoNote": "Nota: o nome e o ícone da dApp só são recebidos após a conexão.",
       "connectButton": "Conectar",
       "cancelButton": "Cancelar"
     },

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -109,12 +109,12 @@
   // If no wallet exists, displayView stays undefined and onboarding is shown
   
   // check if session request in URL params passed through props
-  if(props?.uri?.startsWith('wc:') || props?.uri?.startsWith('cc:')){
+  if(props?.uri?.startsWith('wc:') || props?.uri?.startsWith('cc:') || props?.uri?.toLowerCase().startsWith('wiz:')){
     if(walletExists){
       dappUriUrlParam.value = props.uri
-      // Promise will wait for state indicating whether WC and CC are initialized
-      const { isWcAndCcInitialized } = storeToRefs(store);
-      await waitForInitialized(isWcAndCcInitialized); 
+      // Promise will wait for state indicating whether the dapp connection stores are initialized
+      const { isDappConnectionsInitialized } = storeToRefs(store);
+      await waitForInitialized(isDappConnectionsInitialized);
       store.changeView(4);
     } else {
       $q.notify({
@@ -155,7 +155,7 @@
     // check live wallet state, not the setup-time walletExists: a wallet may have been created via onboarding since
     if(!store._wallet) return
     // check if session request in URL params passed through props
-    if(props?.uri?.startsWith('wc:') || props?.uri?.startsWith('cc:')){
+    if(props?.uri?.startsWith('wc:') || props?.uri?.startsWith('cc:') || props?.uri?.toLowerCase().startsWith('wiz:')){
       dappUriUrlParam.value = props.uri
       store.changeView(4);
     }

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -112,8 +112,8 @@
     if(walletExists){
       dappUriUrlParam.value = props.uri
       // Promise will wait for state indicating whether the dapp connection stores are initialized
-      const { isDappConnectionsInitialized } = storeToRefs(store);
-      await waitForInitialized(isDappConnectionsInitialized);
+      const { dappConnectionStoresInitialized } = storeToRefs(store);
+      await waitForInitialized(dappConnectionStoresInitialized);
       store.changeView(4);
     } else {
       $q.notify({

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -20,7 +20,6 @@
   const settingsStore = useSettingsStore()
   import { useWindowSize } from 'src/utils/composables'
   const { width } = useWindowSize();
-  const isMobile = computed(() => width.value < 480)
   import { useQuasar } from 'quasar'
   const $q = useQuasar()
   import { useI18n } from 'vue-i18n'
@@ -191,11 +190,11 @@
   <header>
     <img :src="settingsStore.darkMode? 'images/cashonize-logo-dark.png' : 'images/cashonize-logo.png'" alt="Cashonize: a Bitcoin Cash Wallet" style="height: 85px;" >
     <nav v-if="store.displayView" style="display: flex; justify-content: center; user-select: none;" class="tabs">
-      <div @click="store.changeView(1)" :class="{ active: store.displayView == 1 }"> {{ isMobile ? "Wallet" : "BchWallet" }} </div>
-      <div v-if="width > 570 && store.wallet.walletType === 'hd'" @click="store.changeView(10)" :class="{ active: store.displayView == 10 }"> Addresses </div>
-      <div @click="store.changeView(2)" :class="{ active: store.displayView == 2 }"> {{ isMobile ? "Tokens" : "MyTokens" }} </div>
-      <div @click="store.changeView(3)" :class="{ active: store.displayView == 3 }"> {{ isMobile ? "History" : "TxHistory" }} </div>
-      <div @click="store.changeView(4)" :class="{ active: store.displayView == 4 }"> {{ isMobile ? "Connect" : "WalletConnect" }} </div>
+      <div @click="store.changeView(1)" :class="{ active: store.displayView == 1 }"> {{ t('nav.wallet') }} </div>
+      <div v-if="width > 450 && store.wallet.walletType === 'hd'" @click="store.changeView(10)" :class="{ active: store.displayView == 10 }"> {{ t('nav.addresses') }} </div>
+      <div @click="store.changeView(2)" :class="{ active: store.displayView == 2 }"> {{ t('nav.tokens') }} </div>
+      <div @click="store.changeView(3)" :class="{ active: store.displayView == 3 }"> {{ t('nav.history') }} </div>
+      <div @click="store.changeView(4)" :class="{ active: store.displayView == 4 }"> {{ t('nav.connect') }} </div>
       <div @click="store.changeView(5)" style="width: max-content; position: relative;">
         <img style="vertical-align: text-bottom;" :src="store.displayView == 5 ? 'images/settingsGreen.svg' : (
           settingsStore.darkMode? 'images/settingsLightGrey.svg' : 'images/settings.svg')">

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -41,6 +41,7 @@ import { Notify } from "quasar";
 import { useSettingsStore } from './settingsStore'
 import { useWalletconnectStore } from "./walletconnectStore"
 import { useCashconnectStore } from "./cashconnectStore"
+import { useWizardconnectStore } from "./wizardconnectStore"
 import { displayAndLogError } from "src/utils/errorHandling"
 import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
@@ -99,6 +100,7 @@ export const useStore = defineStore('store', () => {
   let cauldronPriceInterval: ReturnType<typeof setInterval> | undefined;
   const isWcInitialized = ref(false as boolean)
   const isCcInitialized = ref(false as boolean)
+  const isWizInitialized = ref(false as boolean)
   const walletInitialized = ref(false as boolean)
   const latestGithubRelease = ref(undefined as undefined | string);
 
@@ -113,7 +115,7 @@ export const useStore = defineStore('store', () => {
     return _wallet.value
   })
 
-  const isWcAndCcInitialized =  computed(() => isWcInitialized.value && isCcInitialized.value)
+  const isDappConnectionsInitialized = computed(() => isWcInitialized.value && isCcInitialized.value && isWizInitialized.value)
   const bcmrIndexer = computed(() => network.value == 'mainnet' ? defaultBcmrIndexer : defaultBcmrIndexerChipnet)
 
   // Filtered token list based on display filter setting
@@ -265,9 +267,11 @@ export const useStore = defineStore('store', () => {
           console.error("Electrum connect error:", error)
         });
       })();
-      console.time('initialize walletconnect and cashconnect');
+      console.time('initialize dapp connection stores');
+      // WizardConnect initialization is synchronous (key derivation only, connections are fire-and-forget)
+      initializeWizardConnect();
       await Promise.all([initializeWalletConnect(), initializeCashConnect()]);
-      console.timeEnd('initialize walletconnect and cashconnect');
+      console.timeEnd('initialize dapp connection stores');
       // wait until the electrumConnectionPromise is resolved
       await electrumConnectionPromise;
       if (initialization !== currentInitialization) return;
@@ -474,11 +478,12 @@ export const useStore = defineStore('store', () => {
     walletInitialized.value = false;
 
     if (resetDappConnections) {
-      // Reset WC/CC initialized flags so re-initialization runs after reset
+      // Reset WC/CC/Wiz initialized flags so re-initialization runs after reset
       isWcInitialized.value = false;
       isCcInitialized.value = false;
+      isWizInitialized.value = false;
 
-      // Await WC/CC cleanup so stop() finishes before start() can be called again
+      // Await WC/CC/Wiz cleanup so stop() finishes before start() can be called again
       const cleanupPromises = networkChangeCallbacks.map(callback => callback().catch(() => {}));
       await Promise.all(cleanupPromises);
       // Clear the networkChangeCallbacks before initialising newWallet
@@ -657,6 +662,29 @@ export const useStore = defineStore('store', () => {
       console.error("Error initializing CashConnect:", error);
       Notify.create({
         message: t('store.errors.errorInitializingCashConnect'),
+        icon: 'warning',
+        color: "red"
+      });
+    }
+  }
+
+  function initializeWizardConnect() {
+    try {
+      const wizardconnectStore = useWizardconnectStore();
+
+      // Start the wizardconnect service (no-op for single-address wallets).
+      wizardconnectStore.start();
+      isWizInitialized.value = true;
+
+      // Setup network change callback to disconnect all sessions.
+      networkChangeCallbacks.push(() => {
+        wizardconnectStore.stop();
+        return Promise.resolve();
+      });
+    } catch (error) {
+      console.error("Error initializing WizardConnect:", error);
+      Notify.create({
+        message: t('store.errors.errorInitializingWizardConnect'),
         icon: 'warning',
         color: "red"
       });
@@ -906,7 +934,7 @@ export const useStore = defineStore('store', () => {
     walletHistory,
     isHistoryPartial,
     plannedTokenId,
-    isWcAndCcInitialized,
+    isDappConnectionsInitialized,
     latestGithubRelease,
     network,
     explorerUrl,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -115,7 +115,7 @@ export const useStore = defineStore('store', () => {
     return _wallet.value
   })
 
-  const isDappConnectionsInitialized = computed(() => isWcInitialized.value && isCcInitialized.value && isWizInitialized.value)
+  const dappConnectionStoresInitialized = computed(() => isWcInitialized.value && isCcInitialized.value && isWizInitialized.value)
   const bcmrIndexer = computed(() => network.value == 'mainnet' ? defaultBcmrIndexer : defaultBcmrIndexerChipnet)
 
   // Filtered token list based on display filter setting
@@ -934,7 +934,7 @@ export const useStore = defineStore('store', () => {
     walletHistory,
     isHistoryPartial,
     plannedTokenId,
-    isDappConnectionsInitialized,
+    dappConnectionStoresInitialized,
     latestGithubRelease,
     network,
     explorerUrl,

--- a/src/stores/walletconnectStore.ts
+++ b/src/stores/walletconnectStore.ts
@@ -427,11 +427,13 @@ export const useWalletconnectStore = defineStore("walletconnectStore", () => {
           void rejectRequest(event);
           return;
         }
+        // parse params as extended JSON to handle stringified/encoded Uint8Array and BigInt
+        const wcTransactionObj = parseExtendedJson(JSON.stringify(request.params)) as WcSignTransactionRequest;
         const handle = Dialog.create({
           component: WC2TransactionRequest,
           componentProps: {
             dappMetadata,
-            transactionRequestWC: event,
+            transactionRequest: wcTransactionObj,
             exchangeRate
           },
         })

--- a/src/stores/wizardconnectStore.ts
+++ b/src/stores/wizardconnectStore.ts
@@ -1,0 +1,505 @@
+import { ref } from "vue";
+import { defineStore } from "pinia";
+import { Dialog, Notify } from "quasar";
+import { convert, NetworkType, HDWallet } from "mainnet-js";
+import {
+  WalletConnectionManager,
+  DerivationPath,
+  type WalletAdapter,
+  type PendingSignRequest,
+  type RelayConnectionState,
+} from "@wizardconnect/wallet";
+import { decodeKeyExchangeURI } from "@wizardconnect/core";
+import {
+  hexToBin,
+  binToHex,
+  sha256,
+  secp256k1,
+  hmacSha256,
+  utf8ToBin,
+  decodeTransaction,
+  deriveSeedFromBip39Mnemonic,
+  deriveHdPrivateNodeFromSeed,
+  deriveHdPrivateNodeChild,
+  deriveHdPublicNode,
+  deriveHdPath,
+  encodeHdPublicKey,
+  type HdPrivateNodeValid,
+} from "@bitauth/libauth";
+import type { WcSignTransactionRequest } from "@bch-wc2/interfaces";
+import type { WalletType, DappMetadata } from "src/interfaces/interfaces";
+import { useStore } from "./store";
+import { useSettingsStore } from "./settingsStore";
+import { walletConnectMetadata } from "./constants";
+import { createSignedWizTransaction, type WizInputSigningKey } from "src/utils/wizSigning";
+import { WizSignTransactionRequestSchema, type WizSignTransactionRequest } from "src/utils/zodValidation";
+import { displayAndLogError } from "src/utils/errorHandling";
+import WC2TransactionRequest from "src/components/walletconnect/WC2TransactionRequest.vue";
+import alertDialog from "src/components/general/alertDialog.vue";
+import { i18n } from "src/boot/i18n";
+const { t } = i18n.global;
+const settingsStore = useSettingsStore();
+
+// hdwalletv1 chain indices for the well-known path names shared in wallet_ready
+const PATH_NAME_TO_CHILD: Record<string, DerivationPath> = {
+  receive: DerivationPath.Receive,
+  change: DerivationPath.Change,
+  defi: DerivationPath.Cauldron,
+};
+
+// Bound the approval queue so a misbehaving dapp can't stack unlimited dialogs
+const MAX_QUEUED_SIGN_REQUESTS = 10;
+
+// localStorage key holding a Record<`${network}:${walletName}`, wizUri[]> so sessions
+// can be restored after an app reload (the relay key is re-derived from seed + URI)
+const WIZ_URIS_STORAGE_KEY = "wizardConnectUris";
+
+interface WizHdNodes {
+  // chain-level private nodes (receive/change/defi) under the wallet's parent derivation path
+  privateChains: Map<DerivationPath, HdPrivateNodeValid>;
+  // secret used to derive per-URI Nostr relay identity keys
+  relayHmacKey: Uint8Array;
+  xpubNetwork: "mainnet" | "testnet";
+}
+
+export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
+  // Accesses the wallet reactively via cross-store ref (mainStore.wallet) inside defineStore setup,
+  // which Pinia resolves lazily — so the circular import with store.ts is safe.
+  const mainStore = useStore();
+  // Reactive projection of the manager's connection states, synced on manager events.
+  const connections = ref<Record<string, RelayConnectionState>>({});
+  // The manager and derived key material live outside Vue reactivity on purpose:
+  // wrapping the manager's internal Maps/EventEmitter in a reactive proxy is unnecessary
+  // and holding key material in reactive state would spread it through devtools/watchers.
+  let manager: WalletConnectionManager | undefined;
+  let hdNodes: WizHdNodes | undefined;
+  // Track the approval dialog so it can be closed when the dapp cancels the request
+  let pendingDialog: { connectionId: string; sequence: number; handle: ReturnType<typeof Dialog.create> } | null = null;
+  let requestQueue: { connectionId: string; request: WizSignTransactionRequest }[] = [];
+  // Sign requests cancelled by the dapp; also guards against a sign_cancel arriving
+  // before its sign_transaction_request (relay delivery order is not guaranteed)
+  const cancelledRequests = new Set<string>();
+
+  function start() {
+    // Make sure we don't start more than once, otherwise we'd register multiple
+    // handlers and end up with multiple dialogs.
+    if (manager) return;
+    // cast undoes Pinia's ref-unwrapping of the class union; instanceof below does the real check
+    const wallet = mainStore.wallet as WalletType;
+    // WizardConnect shares chain-level xpubs so dapps can derive addresses, which requires
+    // an HD wallet. For single-address wallets the manager stays undefined and pairing
+    // attempts get a clear error in pair().
+    if (!(wallet instanceof HDWallet)) return;
+    hdNodes = deriveWizHdNodes(wallet);
+    const newManager = new WalletConnectionManager(createWizAdapter(hdNodes));
+    newManager.on("connectionsChanged", refreshConnections);
+    newManager.on("connectionStatusChanged", refreshConnections);
+    newManager.on("pendingSignRequest", (pendingRequest) => {
+      try {
+        handleSignRequest(pendingRequest);
+      } catch (error) {
+        console.error("Error when processing WizardConnect sign request:", error);
+      }
+    });
+    newManager.on("signCancelled", handleSignCancelled);
+    newManager.on("remoteDisconnect", handleRemoteDisconnect);
+    manager = newManager;
+    // Restore persisted sessions: reconnecting with the same URI re-derives the same
+    // relay identity, so the dapp recognizes the wallet after an app reload
+    for (const wizUri of getSavedUris()) {
+      try {
+        newManager.connect(wizUri);
+      } catch (error) {
+        console.error("Failed to restore WizardConnect session:", error);
+      }
+    }
+    refreshConnections();
+  }
+
+  function stop() {
+    if (!manager) return;
+    // Clear our reference first (mirrors the CashConnect stop() work-around): resetWalletState
+    // fires callbacks without awaiting each other, so start() must see a clean slate.
+    const prevManager = manager;
+    manager = undefined;
+    hdNodes = undefined;
+    requestQueue = [];
+    cancelledRequests.clear();
+    pendingDialog?.handle.hide();
+    pendingDialog = null;
+    // Sessions don't survive a wallet/network switch (same behavior as WC/CC), so
+    // also drop the persisted URIs — otherwise the next app start would silently
+    // reconnect sessions the dapp was just told are disconnected.
+    for (const conn of Object.values(prevManager.getConnections())) {
+      removeSavedUri(conn.uri);
+    }
+    // Remove listeners before disconnecting so the deferred cleanup events
+    // (sent after the courtesy disconnect message settles) don't mutate fresh state
+    prevManager.removeAllListeners();
+    prevManager.disconnectAll();
+    connections.value = {};
+  }
+
+  function pair(wizUri: string) {
+    if (!manager) {
+      const wallet = mainStore.wallet as WalletType;
+      if (!(wallet instanceof HDWallet)) throw new Error(t('wizardConnect.errors.hdWalletRequired'));
+      throw new Error(t('wizardConnect.errors.notInitialized'));
+    }
+    const trimmedUri = wizUri.trim();
+    try {
+      // validate the URI shape (accepts both the standard and QR-alphanumeric forms)
+      decodeKeyExchangeURI(trimmedUri);
+    } catch (error) {
+      throw new Error(t('wizardConnect.errors.invalidUri'), { cause: error });
+    }
+    manager.connect(trimmedUri);
+    addSavedUri(trimmedUri);
+    refreshConnections();
+  }
+
+  function disconnectSession(connectionId: string) {
+    if (!manager) return;
+    const connection = manager.getConnections()[connectionId];
+    if (!connection) return;
+    removeSavedUri(connection.uri);
+    manager.disconnect(connectionId);
+    // Cleanup inside the manager waits for the courtesy disconnect message to settle,
+    // so remove the session from the UI optimistically
+    const remaining = { ...connections.value };
+    delete remaining[connectionId];
+    connections.value = remaining;
+  }
+
+  function refreshConnections() {
+    connections.value = manager ? manager.getConnections() : {};
+  }
+
+  //-----------------------------------------------------------------------------
+  // Sign request handling
+  //-----------------------------------------------------------------------------
+  function handleSignRequest(pendingRequest: PendingSignRequest) {
+    const { connectionId, request } = pendingRequest;
+    const rawSequence = (request as { sequence?: unknown }).sequence;
+    // drop requests the dapp already cancelled (a sign_cancel can arrive first)
+    if (typeof rawSequence === "number" && cancelledRequests.has(`${connectionId}:${rawSequence}`)) return;
+    const respondWithError = (errorMessage: string) => {
+      if (typeof rawSequence !== "number") return;
+      manager?.sendSignError(connectionId, rawSequence, errorMessage).catch(console.error);
+    };
+    // the request arrives over the relay from an untrusted source, so validate the schema with zod
+    const parseResult = WizSignTransactionRequestSchema.safeParse(request);
+    if (!parseResult.success) {
+      displayAndLogError(t('wizardConnect.errors.invalidTransactionSchema'));
+      console.error(parseResult.error.message);
+      respondWithError('Transaction signing request aborted with error: invalid request schema');
+      return;
+    }
+    const validatedRequest = parseResult.data;
+    // structural validation that needs the decoded transaction
+    const validationError = validateWizTransaction(validatedRequest);
+    if (validationError) {
+      displayAndLogError(t('wizardConnect.errors.invalidTransactionSchema'));
+      console.error(validationError);
+      respondWithError('Transaction signing request aborted with error: ' + validationError);
+      return;
+    }
+    if (requestQueue.length >= MAX_QUEUED_SIGN_REQUESTS) {
+      respondWithError('Transaction signing request aborted with error: too many pending requests');
+      return;
+    }
+    requestQueue.push({ connectionId, request: validatedRequest });
+    void showNextSignRequest();
+  }
+
+  // Cross-checks between the transaction, sourceOutputs and inputPaths
+  function validateWizTransaction(request: WizSignTransactionRequest): string | undefined {
+    const { transaction, sourceOutputs } = request.transaction;
+    const decodedTransaction = typeof transaction === "string" ? decodeTransaction(hexToBin(transaction)) : transaction;
+    if (typeof decodedTransaction === "string") {
+      return "Invalid transaction hex string in sign request: " + decodedTransaction;
+    }
+    if (decodedTransaction.inputs.length !== sourceOutputs.length) {
+      return "Transaction inputs and sourceOutputs length mismatch";
+    }
+    const invalidInputPath = request.inputPaths.find(([inputIndex]) => inputIndex >= decodedTransaction.inputs.length);
+    if (invalidInputPath) {
+      return `inputPaths entry references non-existent input ${invalidInputPath[0]}`;
+    }
+    return undefined;
+  }
+
+  async function showNextSignRequest() {
+    if (pendingDialog) return;
+    const queuedRequest = requestQueue.shift();
+    if (!queuedRequest) return;
+    const { connectionId, request } = queuedRequest;
+    // the connection (or the whole manager) may be gone by the time the queue advances
+    const connection = manager?.getConnections()[connectionId];
+    if (!manager || !connection) {
+      void showNextSignRequest();
+      return;
+    }
+    // Fetch the exchange rate before showing the dialog, falling back to the last known rate.
+    // Without any rate we can't display the fiat impact, so reject instead of showing the dialog.
+    let exchangeRate: number | undefined;
+    try {
+      exchangeRate = await convert(1, "bch", settingsStore.currency);
+    } catch {
+      exchangeRate = mainStore.exchangeRate;
+    }
+    if (exchangeRate === undefined) {
+      Notify.create({ color: "negative", message: t('common.errors.exchangeRateUnavailable') });
+      manager.sendSignError(connectionId, request.sequence, 'Transaction signing request aborted with error: exchange rate unavailable').catch(console.error);
+      void showNextSignRequest();
+      return;
+    }
+    // the dapp may have cancelled the request while the exchange rate was being fetched
+    if (cancelledRequests.has(`${connectionId}:${request.sequence}`)) {
+      void showNextSignRequest();
+      return;
+    }
+    const dappMetadata: DappMetadata = {
+      name: connection.dappName ?? connection.label,
+      description: '',
+      url: '',
+      icons: connection.dappIcon ? [connection.dappIcon] : [],
+    };
+    const handle = Dialog.create({
+      component: WC2TransactionRequest,
+      componentProps: {
+        dappMetadata,
+        transactionRequest: request.transaction as WcSignTransactionRequest,
+        exchangeRate,
+      },
+    })
+      // Dialog listeners expect synchronous callbacks, this means the promise is fire-and-forget
+      .onOk(() => {
+        signWizTransaction(connectionId, request)
+          .catch((error) => {
+            console.error('Failed to sign transaction:', error);
+            Notify.create({
+              color: "negative",
+              message: error instanceof Error ? error.message : t('wizardConnect.errors.failedToSignTransaction'),
+            });
+            manager?.sendSignError(connectionId, request.sequence, 'Transaction signing failed').catch(console.error);
+          });
+      })
+      .onCancel(() => {
+        manager?.sendSignError(connectionId, request.sequence, 'User rejected the transaction').catch(console.error);
+      })
+      .onDismiss(() => {
+        pendingDialog = null;
+        void showNextSignRequest();
+      });
+    pendingDialog = { connectionId, sequence: request.sequence, handle };
+  }
+
+  async function signWizTransaction(connectionId: string, request: WizSignTransactionRequest) {
+    if (!manager || !hdNodes) throw new Error(t('wizardConnect.errors.notInitialized'));
+    const inputKeys = deriveInputKeys(hdNodes, request.inputPaths);
+    // the zod schema already validated and transformed this shape (see WizSignTransactionRequestSchema)
+    const wizTransactionObj = request.transaction as WcSignTransactionRequest;
+    const encodedTransaction = createSignedWizTransaction(wizTransactionObj, inputKeys);
+    const signedTransactionHex = binToHex(encodedTransaction);
+    const hash = binToHex(sha256.hash(sha256.hash(encodedTransaction)).reverse());
+    if (request.transaction.broadcast) {
+      try {
+        Notify.create({
+          spinner: true,
+          message: t('wizardConnect.notifications.sendingTransaction'),
+          color: 'grey-5',
+          timeout: 750
+        });
+        const txId = await mainStore.wallet.submitTransaction(hexToBin(signedTransactionHex));
+        const alertMessage = t('wizardConnect.notifications.sentTransaction', { dappName: dappNameForConnection(connectionId) });
+        Dialog.create({
+          component: alertDialog,
+          componentProps: {
+            alertInfo: { message: alertMessage, txid: txId }
+          }
+        });
+      } catch (error) {
+        displayAndLogError(error);
+        const errorMessage = typeof error == 'string' ? error : ((error instanceof Error) ? error.message : t('wizardConnect.errors.errorSendingTransaction'));
+        await manager.sendSignError(connectionId, request.sequence, 'Transaction failed to send: ' + errorMessage);
+        return;
+      }
+    }
+    if (!request.transaction.broadcast) {
+      const alertMessage = t('wizardConnect.notifications.signedTransaction', { dappName: dappNameForConnection(connectionId) });
+      Dialog.create({
+        component: alertDialog,
+        componentProps: {
+          alertInfo: {
+            message: alertMessage,
+            txid: hash,
+            title: t('wizardConnect.notifications.transactionSignedTitle'),
+            hideExplorerLink: true,
+          }
+        }
+      });
+    }
+    await manager.sendSignResponse(connectionId, request.sequence, signedTransactionHex);
+    const message = request.transaction.broadcast
+      ? t('wizardConnect.notifications.transactionSent')
+      : t('wizardConnect.notifications.transactionSigned');
+    Notify.create({
+      type: 'positive',
+      message
+    });
+  }
+
+  function dappNameForConnection(connectionId: string): string {
+    const connection = manager?.getConnections()[connectionId];
+    return connection?.dappName ?? connection?.label ?? 'dapp';
+  }
+
+  function handleSignCancelled(connectionId: string, sequence: number) {
+    cancelledRequests.add(`${connectionId}:${sequence}`);
+    requestQueue = requestQueue.filter(
+      (queued) => !(queued.connectionId === connectionId && queued.request.sequence === sequence)
+    );
+    if (pendingDialog && pendingDialog.connectionId === connectionId && pendingDialog.sequence === sequence) {
+      // programmatic hide fires only onDismiss, which advances the queue
+      pendingDialog.handle.hide();
+      Notify.create({
+        color: "negative",
+        message: t('wizardConnect.notifications.requestCancelled', { dappName: dappNameForConnection(connectionId) }),
+      });
+    }
+  }
+
+  function handleRemoteDisconnect(connectionId: string) {
+    // this handler runs synchronously during the emit, before the manager removes the connection
+    const connection = manager?.getConnections()[connectionId];
+    if (connection) removeSavedUri(connection.uri);
+    Notify.create({
+      color: "grey-7",
+      message: t('wizardConnect.notifications.dappDisconnected', { dappName: dappNameForConnection(connectionId) }),
+    });
+    requestQueue = requestQueue.filter((queued) => queued.connectionId !== connectionId);
+    if (pendingDialog?.connectionId === connectionId) {
+      pendingDialog.handle.hide();
+    }
+  }
+
+  //-----------------------------------------------------------------------------
+  // Key derivation
+  //-----------------------------------------------------------------------------
+  function deriveWizHdNodes(wallet: HDWallet): WizHdNodes {
+    const seed = deriveSeedFromBip39Mnemonic(wallet.mnemonic);
+    const hdNode = deriveHdPrivateNodeFromSeed(seed);
+    // the wallet's parent derivation path, e.g. "m/44'/145'/0'"
+    const parentDerivation = wallet.derivation;
+    const privateChains = new Map<DerivationPath, HdPrivateNodeValid>();
+    for (const childIndex of [DerivationPath.Receive, DerivationPath.Change, DerivationPath.Cauldron]) {
+      privateChains.set(childIndex, deriveHdPath(hdNode, `${parentDerivation}/${childIndex}`));
+    }
+    // Relay identity keys are HMAC(dedicated chain key, pairing URI): deterministic per URI so
+    // reconnects restore the same Nostr identity, distinct per URI so dapps can't correlate
+    // sessions. Chain index 8 keeps the relay secret off the xpub chains shared with dapps.
+    const relaySecretNode = deriveHdPrivateNodeChild(deriveHdPath(hdNode, `${parentDerivation}/8`), 0);
+    return {
+      privateChains,
+      relayHmacKey: relaySecretNode.privateKey,
+      xpubNetwork: wallet.network === NetworkType.Mainnet ? "mainnet" : "testnet",
+    };
+  }
+
+  function createWizAdapter(nodes: WizHdNodes): WalletAdapter {
+    return {
+      walletName: walletConnectMetadata.name,
+      walletIcon: walletConnectMetadata.icons[0] ?? '',
+      getRelayPrivateKey: (uri: string) => hmacSha256(nodes.relayHmacKey, utf8ToBin(uri)),
+      getPublicKey: (path: DerivationPath, index: bigint) => {
+        const chain = nodes.privateChains.get(path);
+        if (!chain) throw new Error(`Unsupported derivation path: ${path}`);
+        const childNode = deriveHdPrivateNodeChild(chain, Number(index));
+        const pubkeyCompressed = secp256k1.derivePublicKeyCompressed(childNode.privateKey);
+        if (typeof pubkeyCompressed === "string") throw new Error("Failed to derive public key: " + pubkeyCompressed);
+        return pubkeyCompressed;
+      },
+      getXpub: (path: DerivationPath) => {
+        const chain = nodes.privateChains.get(path);
+        if (!chain) throw new Error(`Unsupported derivation path: ${path}`);
+        return encodeHdPublicKey({ node: deriveHdPublicNode(chain), network: nodes.xpubNetwork }).hdPublicKey;
+      },
+      // never called by the library; signing runs through the pendingSignRequest flow
+      signTransaction: () => Promise.reject(new Error("signTransaction is handled via the pendingSignRequest flow")),
+    };
+  }
+
+  function deriveInputKeys(nodes: WizHdNodes, inputPaths: WizSignTransactionRequest['inputPaths']) {
+    const inputKeys = new Map<number, WizInputSigningKey>();
+    for (const [inputIndex, pathName, addressIndex] of inputPaths) {
+      const chain = nodes.privateChains.get(PATH_NAME_TO_CHILD[pathName] as DerivationPath);
+      if (!chain) throw new Error(`Unknown path name: ${pathName}`);
+      const childNode = deriveHdPrivateNodeChild(chain, addressIndex);
+      const pubkeyCompressed = secp256k1.derivePublicKeyCompressed(childNode.privateKey);
+      if (typeof pubkeyCompressed === "string") throw new Error("Failed to derive public key: " + pubkeyCompressed);
+      inputKeys.set(inputIndex, { privateKey: childNode.privateKey, pubkeyCompressed });
+    }
+    return inputKeys;
+  }
+
+  //-----------------------------------------------------------------------------
+  // Session persistence
+  //-----------------------------------------------------------------------------
+  function storageSubKey() {
+    return `${mainStore.network}:${mainStore.activeWalletName}`;
+  }
+
+  function readAllSavedUris(): Record<string, string[]> {
+    try {
+      const rawJson = localStorage.getItem(WIZ_URIS_STORAGE_KEY);
+      if (!rawJson) return {};
+      const parsed: unknown = JSON.parse(rawJson);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+      const validated: Record<string, string[]> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (Array.isArray(value)) validated[key] = value.filter((uri): uri is string => typeof uri === "string");
+      }
+      return validated;
+    } catch (error) {
+      console.error("Failed to read persisted WizardConnect sessions:", error);
+      return {};
+    }
+  }
+
+  function getSavedUris(): string[] {
+    return readAllSavedUris()[storageSubKey()] ?? [];
+  }
+
+  function addSavedUri(wizUri: string) {
+    const allUris = readAllSavedUris();
+    const walletUris = allUris[storageSubKey()] ?? [];
+    if (!walletUris.includes(wizUri)) walletUris.push(wizUri);
+    allUris[storageSubKey()] = walletUris;
+    localStorage.setItem(WIZ_URIS_STORAGE_KEY, JSON.stringify(allUris));
+  }
+
+  function removeSavedUri(wizUri: string) {
+    const allUris = readAllSavedUris();
+    const walletUris = (allUris[storageSubKey()] ?? []).filter((savedUri) => savedUri !== wizUri);
+    if (walletUris.length) {
+      allUris[storageSubKey()] = walletUris;
+    } else {
+      delete allUris[storageSubKey()];
+    }
+    localStorage.setItem(WIZ_URIS_STORAGE_KEY, JSON.stringify(allUris));
+  }
+
+  //-----------------------------------------------------------------------------
+  // Expose
+  //-----------------------------------------------------------------------------
+  return {
+    // Methods
+    start,
+    stop,
+    pair,
+    disconnectSession,
+    // Properties
+    connections,
+  };
+});

--- a/src/stores/wizardconnectStore.ts
+++ b/src/stores/wizardconnectStore.ts
@@ -140,7 +140,7 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
     connections.value = {};
   }
 
-  function pair(wizUri: string) {
+  async function pair(wizUri: string) {
     if (!manager) {
       const wallet = mainStore.wallet as WalletType;
       if (!(wallet instanceof HDWallet)) throw new Error(t('wizardConnect.errors.hdWalletRequired'));
@@ -153,6 +153,23 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
     } catch (error) {
       throw new Error(t('wizardConnect.errors.invalidUri'), { cause: error });
     }
+    // Explicit consent before connecting: connect() shares the wallet's chain-level xpubs
+    // with the dapp right after key exchange, which reveals all current and future wallet
+    // addresses (watch-only, irrevocable). The pairing URI carries no dapp metadata — it
+    // only arrives after the xpubs are shared — so this dialog is necessarily generic.
+    // Restored sessions (start()) reconnect without re-prompting, like WC/CC sessions.
+    const approved = await new Promise<boolean>((resolve) => {
+      Dialog.create({
+        title: t('wizardConnect.pairing.title'),
+        message: t('wizardConnect.pairing.message'),
+        persistent: true,
+        ok: { label: t('wizardConnect.pairing.connectButton'), color: 'primary', unelevated: true },
+        cancel: { label: t('wizardConnect.pairing.cancelButton'), flat: true },
+      })
+        .onOk(() => resolve(true))
+        .onDismiss(() => resolve(false));
+    });
+    if (!approved) return;
     manager.connect(trimmedUri);
     addSavedUri(trimmedUri);
     refreshConnections();

--- a/src/stores/wizardconnectStore.ts
+++ b/src/stores/wizardconnectStore.ts
@@ -427,6 +427,10 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
       getPublicKey: (path: DerivationPath, index: bigint) => {
         const chain = nodes.privateChains.get(path);
         if (!chain) throw new Error(`Unsupported derivation path: ${path}`);
+        // Only the BIP32 non-hardened range is valid here: dapps derive addresses from the
+        // shared xpubs, which cannot do hardened derivation. This also keeps the bigint to
+        // Number conversion exact (mirrors the inputPaths cap in WizSignTransactionRequestSchema).
+        if (index < 0n || index >= 0x80000000n) throw new Error(`Unsupported address index: ${index.toString()}`);
         const childNode = deriveHdPrivateNodeChild(chain, Number(index));
         const pubkeyCompressed = secp256k1.derivePublicKeyCompressed(childNode.privateKey);
         if (typeof pubkeyCompressed === "string") throw new Error("Failed to derive public key: " + pubkeyCompressed);

--- a/src/stores/wizardconnectStore.ts
+++ b/src/stores/wizardconnectStore.ts
@@ -35,6 +35,7 @@ import { createSignedWizTransaction, type WizInputSigningKey } from "src/utils/w
 import { WizSignTransactionRequestSchema, type WizSignTransactionRequest } from "src/utils/zodValidation";
 import { displayAndLogError } from "src/utils/errorHandling";
 import WC2TransactionRequest from "src/components/walletconnect/WC2TransactionRequest.vue";
+import WizPairingDialog from "src/components/wizardconnect/WizPairingDialog.vue";
 import alertDialog from "src/components/general/alertDialog.vue";
 import { i18n } from "src/boot/i18n";
 const { t } = i18n.global;
@@ -159,13 +160,7 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
     // only arrives after the xpubs are shared — so this dialog is necessarily generic.
     // Restored sessions (start()) reconnect without re-prompting, like WC/CC sessions.
     const approved = await new Promise<boolean>((resolve) => {
-      Dialog.create({
-        title: t('wizardConnect.pairing.title'),
-        message: t('wizardConnect.pairing.message'),
-        persistent: true,
-        ok: { label: t('wizardConnect.pairing.connectButton'), color: 'primary', unelevated: true },
-        cancel: { label: t('wizardConnect.pairing.cancelButton'), flat: true },
-      })
+      Dialog.create({ component: WizPairingDialog })
         .onOk(() => resolve(true))
         .onDismiss(() => resolve(false));
     });

--- a/src/utils/wcSigning.ts
+++ b/src/utils/wcSigning.ts
@@ -48,8 +48,8 @@ export function createSignedWcTransaction(
 
       // replace pubkey and sig placeholders
       let unlockingBytecodeHex = binToHex(correspondingSourceOutput.unlockingBytecode);
-      const sigPlaceholder = "41" + binToHex(Uint8Array.from(Array(65)));
-      const pubkeyPlaceholder = "21" + binToHex(Uint8Array.from(Array(33)));
+      const sigPlaceholder = "41" + binToHex(new Uint8Array(65));
+      const pubkeyPlaceholder = "21" + binToHex(new Uint8Array(33));
       if (unlockingBytecodeHex.indexOf(sigPlaceholder) !== -1) {
         // compute the signature argument
         const hashType = SigningSerializationFlag.allOutputs | SigningSerializationFlag.utxos | SigningSerializationFlag.forkId;

--- a/src/utils/wizSigning.ts
+++ b/src/utils/wizSigning.ts
@@ -58,8 +58,8 @@ export function createSignedWizTransaction(
       // contract input: replace the sig and pubkey placeholders in the provided unlocking bytecode
 
       let unlockingBytecodeHex = binToHex(correspondingSourceOutput.unlockingBytecode);
-      const sigPlaceholder = "41" + binToHex(Uint8Array.from(Array(65)));
-      const pubkeyPlaceholder = "21" + binToHex(Uint8Array.from(Array(33)));
+      const sigPlaceholder = "41" + binToHex(new Uint8Array(65));
+      const pubkeyPlaceholder = "21" + binToHex(new Uint8Array(33));
       if (unlockingBytecodeHex.indexOf(sigPlaceholder) !== -1) {
         if (!signingKey) {
           throw new Error(`No signing key provided in inputPaths for contract input ${index}`);

--- a/src/utils/wizSigning.ts
+++ b/src/utils/wizSigning.ts
@@ -1,0 +1,96 @@
+import {
+  hexToBin,
+  binToHex,
+  hash256,
+  secp256k1,
+  SigningSerializationFlag,
+  generateSigningSerializationBch,
+  decodeTransaction,
+  encodeTransaction,
+  encodeDataPush,
+  type CompilationContextBch,
+} from "@bitauth/libauth"
+import type { WcSignTransactionRequest } from "@bch-wc2/interfaces";
+
+export interface WizInputSigningKey {
+  privateKey: Uint8Array;
+  pubkeyCompressed: Uint8Array;
+}
+
+// The WizardConnect spec mandates signing every input with SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID.
+// Because the dapp selects which keys sign which inputs (inputPaths), this hashType is what makes that
+// safe: the signature commits to the full transaction and all source outputs, so it cannot be grafted
+// onto a different transaction and the dapp cannot misrepresent input amounts.
+const wizHashType = SigningSerializationFlag.allOutputs | SigningSerializationFlag.utxos | SigningSerializationFlag.forkId;
+
+export function createSignedWizTransaction(
+  wizTransactionObj: WcSignTransactionRequest,
+  inputKeys: Map<number, WizInputSigningKey>,
+){
+  const { transaction: wizTransactionItem, sourceOutputs } = wizTransactionObj;
+
+  const unsignedTransaction = typeof wizTransactionItem === "string" ? decodeTransaction(hexToBin(wizTransactionItem)) : wizTransactionItem;
+  // If unsignedTransaction is still a string that means decodeTransaction failed
+  if(typeof unsignedTransaction == "string") {
+    throw new Error("Transaction decode error: " + unsignedTransaction);
+  }
+  if(unsignedTransaction.inputs.length !== sourceOutputs.length) {
+    throw new Error("Transaction inputs and sourceOutputs length mismatch");
+  }
+
+  const signInput = (inputIndex: number, coveredBytecode: Uint8Array, privateKey: Uint8Array) => {
+    const context: CompilationContextBch = { inputIndex, sourceOutputs, transaction: unsignedTransaction };
+    const signingSerializationType = new Uint8Array([wizHashType]);
+    const sighashPreimage = generateSigningSerializationBch(context, { coveredBytecode, signingSerializationType });
+    const sighash = hash256(sighashPreimage);
+    const signature = secp256k1.signMessageHashSchnorr(privateKey, sighash);
+    if (typeof signature === "string") {
+      throw new Error("Signature error: " + signature);
+    }
+    return Uint8Array.from([...signature, wizHashType]);
+  };
+
+  for (const [index, input] of unsignedTransaction.inputs.entries()) {
+    const correspondingSourceOutput = sourceOutputs[index] as (typeof sourceOutputs)[number];
+    const signingKey = inputKeys.get(index);
+
+    if (correspondingSourceOutput.contract?.artifact.contractName) {
+      // contract input: replace the sig and pubkey placeholders in the provided unlocking bytecode
+
+      let unlockingBytecodeHex = binToHex(correspondingSourceOutput.unlockingBytecode);
+      const sigPlaceholder = "41" + binToHex(Uint8Array.from(Array(65)));
+      const pubkeyPlaceholder = "21" + binToHex(Uint8Array.from(Array(33)));
+      if (unlockingBytecodeHex.indexOf(sigPlaceholder) !== -1) {
+        if (!signingKey) {
+          throw new Error(`No signing key provided in inputPaths for contract input ${index}`);
+        }
+        // coveredBytecode is the encoded script being executed, used by libauth for sighash computation
+        const coveredBytecode = correspondingSourceOutput.contract?.redeemScript;
+        if (!coveredBytecode) {
+          throw new Error("Not enough information provided, please include contract redeemScript");
+        }
+        const signature = signInput(index, coveredBytecode, signingKey.privateKey);
+        unlockingBytecodeHex = unlockingBytecodeHex.replace(sigPlaceholder, "41" + binToHex(signature));
+      }
+      if (unlockingBytecodeHex.indexOf(pubkeyPlaceholder) !== -1) {
+        if (!signingKey) {
+          throw new Error(`No signing key provided in inputPaths for contract input ${index}`);
+        }
+        unlockingBytecodeHex = unlockingBytecodeHex.replace(pubkeyPlaceholder, "21" + binToHex(signingKey.pubkeyCompressed));
+      }
+      input.unlockingBytecode = hexToBin(unlockingBytecodeHex);
+    } else if (signingKey) {
+      // P2PKH input the dapp asked us to sign (listed in inputPaths).
+      // For P2PKH the coveredBytecode is the locking script itself. The derived key is not checked
+      // against the locking bytecode: with SIGHASH_UTXOS a wrong-key signature is simply invalid.
+      const signature = signInput(index, correspondingSourceOutput.lockingBytecode, signingKey.privateKey);
+      input.unlockingBytecode = Uint8Array.from([
+        ...encodeDataPush(signature),
+        ...encodeDataPush(signingKey.pubkeyCompressed),
+      ]);
+    }
+    // inputs without a signing key keep their dapp-provided unlocking bytecode
+  }
+
+  return encodeTransaction(unsignedTransaction);
+}

--- a/src/utils/zodValidation.ts
+++ b/src/utils/zodValidation.ts
@@ -126,6 +126,110 @@ export const WcMessageObjSchema = z.object({
 export type WcMessageObj = z.infer<typeof WcMessageObjSchema>;
 
 
+/* WizSignTransactionRequestSchema */
+
+// WizardConnect's reference serializer transmits Uint8Array fields as plain hex strings,
+// but the extended stringified form is also legal on the wire, so both are accepted.
+const wizUint8ArraySchema = z.union([
+  z.string()
+    .regex(/^(?:[0-9a-fA-F]{2})*$/, "Must be a hex string")
+    .transform((val) => hexToBin(val)),
+  stringifiedUint8ArraySchema,
+]);
+
+const wizUint8Array32Schema = wizUint8ArraySchema.refine(
+  (val) => val instanceof Uint8Array && val.length === 32,
+  "Must be a 32-byte Uint8Array",
+);
+
+// bigint fields arrive as "<bigint: Xn>" from the reference serializer; plain numeric strings
+// and safe integers are also accepted for robustness across dapp implementations
+const wizBigIntSchema = z.union([
+  stringifiedBigIntSchema,
+  z.string().regex(/^\d+$/, "Must be a numeric string").transform(BigInt),
+  z.number().int().nonnegative().transform(BigInt),
+]);
+
+// The reference serializer omits nft capability/commitment when undefined,
+// so both are defaulted to match libauth's required token nft shape
+const wizNftSchema = z.object({
+  capability: z.optional(z.enum(["none", "mutable", "minting"])),
+  commitment: z.optional(wizUint8ArraySchema),
+}).transform((nft) => ({
+  capability: nft.capability ?? "none" as const,
+  commitment: nft.commitment ?? new Uint8Array(),
+}));
+
+const wizTokenSchema = z.object({
+  amount: z.optional(wizBigIntSchema).transform((amount) => amount ?? 0n),
+  category: wizUint8Array32Schema,
+  nft: z.optional(wizNftSchema),
+});
+
+// Same fields as the WC2-BCH contract schema (contractName, abiFunction.name, redeemScript),
+// with the WizardConnect byte encoding for redeemScript
+const wizContractSchema = z.object({
+  abiFunction: z.object({ name: z.string() }),
+  redeemScript: wizUint8ArraySchema,
+  artifact: z.object({ contractName: z.string() }),
+});
+
+const wizSourceOutputSchema = z.object({
+  outpointIndex: nonNegativeIntSchema,
+  outpointTransactionHash: wizUint8Array32Schema,
+  sequenceNumber: nonNegativeIntSchema,
+  lockingBytecode: wizUint8ArraySchema,
+  unlockingBytecode: wizUint8ArraySchema,
+  valueSatoshis: wizBigIntSchema,
+  token: z.optional(wizTokenSchema),
+  contract: z.optional(wizContractSchema),
+});
+
+const wizTransactionInputSchema = z.object({
+  outpointIndex: nonNegativeIntSchema,
+  outpointTransactionHash: wizUint8Array32Schema,
+  sequenceNumber: nonNegativeIntSchema,
+  unlockingBytecode: wizUint8ArraySchema,
+});
+
+const wizTransactionOutputSchema = z.object({
+  lockingBytecode: wizUint8ArraySchema,
+  token: z.optional(wizTokenSchema),
+  valueSatoshis: wizBigIntSchema,
+});
+
+const wizTransactionSchema = z.object({
+  inputs: z.array(wizTransactionInputSchema).min(1),
+  locktime: nonNegativeIntSchema,
+  outputs: z.array(wizTransactionOutputSchema).min(1),
+  version: nonNegativeIntSchema,
+});
+
+// A sign_transaction_request message arriving over the WizardConnect relay. The transport
+// (NIP-17 gift wrap) authenticates the sender, but the payload shape is fully untrusted.
+export const WizSignTransactionRequestSchema = z.object({
+  sequence: nonNegativeIntSchema,
+  // [inputIndex, pathName, addressIndex] tuples: which HD key signs each input.
+  // addressIndex is capped to the BIP32 non-hardened range.
+  inputPaths: z.array(z.tuple([
+    nonNegativeIntSchema,
+    z.enum(["receive", "change", "defi"]),
+    z.number().int().nonnegative().max(2 ** 31 - 1),
+  ])).refine(
+    (paths) => new Set(paths.map((path) => path[0])).size === paths.length,
+    "Duplicate input index in inputPaths",
+  ),
+  transaction: z.object({
+    transaction: z.union([hexEncodedStringSchema, wizTransactionSchema]),
+    sourceOutputs: z.array(wizSourceOutputSchema).min(1),
+    broadcast: z.optional(z.boolean()),
+    userPrompt: z.optional(z.string()),
+  }),
+});
+
+export type WizSignTransactionRequest = z.infer<typeof WizSignTransactionRequestSchema>;
+
+
 /* BcmrIndexerResponseSchema */
 
 const Hex64Schema = z.string().regex(/^[0-9a-f]{64}$/i);

--- a/test/e2e/cashconnect.test.ts
+++ b/test/e2e/cashconnect.test.ts
@@ -21,7 +21,7 @@ async function pairFromDapp() {
   await expect(dappPage.locator('#cc-pairing-uri')).toContainText('bch-cc-v1:', { timeout: 15_000 })
   const uri = await dappPage.textContent('#cc-pairing-uri')
 
-  await walletPage.getByPlaceholder('Wallet Connect URI').fill(uri!)
+  await walletPage.getByPlaceholder('Connection URI').fill(uri!)
   await walletPage.locator('input.primaryButton[value*="Connect"]').click()
 }
 
@@ -39,9 +39,10 @@ test.describe.serial('CashConnect E2E', () => {
     walletAddress = (await walletPage.locator('.depositAddr').first().textContent() ?? '').trim()
     expect(walletAddress).toContain('bchtest:')
 
-    // Navigate to WalletConnect tab (hosts the shared URI input and the CashConnect sessions list)
-    await walletPage.locator('nav').getByText('WalletConnect').click()
-    await walletPage.getByText('Connect to Dapp').waitFor({ timeout: 15_000 })
+    // Navigate to the Connect tab (hosts the shared URI input and the CashConnect sessions list)
+    await walletPage.locator('nav').getByText('Connect', { exact: true }).click()
+    // exact: the intro text ("Connect to dApps with the...") is a case-insensitive substring match otherwise
+    await walletPage.getByText('Connect to Dapp', { exact: true }).waitFor({ timeout: 15_000 })
 
     // Open test dApp
     await dappPage.goto(DAPP_URL)
@@ -86,9 +87,9 @@ test.describe.serial('CashConnect E2E', () => {
     // dApp: Assert connected
     await expect(dappPage.locator('#cc-session-status')).toHaveText('connected', { timeout: 20_000 })
 
-    // Wallet: Session appears in the CashConnect sessions list
+    // Wallet: Session appears in the shared dApp Sessions list
     await expect(walletPage
-      .locator('fieldset:has(legend:has-text("CashConnect"))').getByText('BCH CC Test dApp'))
+      .locator('fieldset:has(legend:text("dApp Sessions"))').getByText('BCH CC Test dApp'))
       .toBeVisible({ timeout: 15_000 })
   })
 
@@ -173,9 +174,9 @@ test.describe.serial('CashConnect E2E', () => {
     // dApp: Assert disconnected
     await expect(dappPage.locator('#cc-session-status')).toHaveText('disconnected', { timeout: 15_000 })
 
-    // Wallet: Assert no active CashConnect sessions
+    // Wallet: Assert no active sessions remain in the shared dApp Sessions list
     await expect(walletPage
-      .locator('fieldset:has(legend:has-text("CashConnect"))').getByText('No sessions currently active.'))
+      .locator('fieldset:has(legend:text("dApp Sessions"))').getByText('No sessions currently active.'))
       .toBeVisible({ timeout: 15_000 })
   })
 })

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -19,7 +19,7 @@ export async function waitForDialog(page: Page, timeout = 15_000) {
 }
 
 // Run the wallet onboarding (importing E2E_SEED_PHRASE when set, creating a fresh wallet
-// otherwise) and switch the wallet to chipnet. Leaves the wallet on the BchWallet tab.
+// otherwise) and switch the wallet to chipnet. Leaves the wallet on the Wallet tab.
 export async function setupWalletOnChipnet(walletPage: Page) {
   await walletPage.goto(CASHONIZE_URL)
 
@@ -48,5 +48,5 @@ export async function setupWalletOnChipnet(walletPage: Page) {
   await walletPage.getByText('Developer settings').click()
   await walletPage.locator('select').first().selectOption('chipnet')
   // Wait for network switch to complete. It resets the active view back to the wallet tab.
-  await expect(walletPage.locator('nav').getByText('BchWallet')).toHaveClass(/active/, { timeout: 15_000 })
+  await expect(walletPage.locator('nav').getByText('Wallet', { exact: true })).toHaveClass(/active/, { timeout: 15_000 })
 }

--- a/test/e2e/test-dapp/package.json
+++ b/test/e2e/test-dapp/package.json
@@ -8,7 +8,9 @@
     "start": "vite preview"
   },
   "dependencies": {
+    "@bitauth/libauth": "3.1.0-next.8",
     "@walletconnect/sign-client": "2.23.9",
+    "@wizardconnect/dapp": "0.2.2",
     "vue": "^3.5.35"
   },
   "devDependencies": {

--- a/test/e2e/test-dapp/pnpm-lock.yaml
+++ b/test/e2e/test-dapp/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
 
   .:
     dependencies:
+      '@bitauth/libauth':
+        specifier: 3.1.0-next.8
+        version: 3.1.0-next.8
       '@walletconnect/sign-client':
         specifier: 2.23.9
         version: 2.23.9
+      '@wizardconnect/dapp':
+        specifier: 0.2.2
+        version: 0.2.2
       vue:
         specifier: ^3.5.35
         version: 3.5.39
@@ -47,6 +53,15 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@bch-wc2/interfaces@0.0.8':
+    resolution: {integrity: sha512-gRt95azHVqoViGI4X3F1ObgTpYBh3//KaCHRBWSMJbAKNM09T+TA/h9kx9u9SZmE8otMtpFSy4awSHWHUQZmbg==}
+    peerDependencies:
+      '@bitauth/libauth': ^3.1.0-next.2
+
+  '@bitauth/libauth@3.1.0-next.8':
+    resolution: {integrity: sha512-Pm+Ju+YP3JeBLLTiVrBnia2wwE4G17r4XqpvPRMcklElJTe8J6x3JgKRg1by0Xm3ZY6UFxACkEAoSA+x419/zA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
@@ -73,6 +88,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.8.0':
     resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
     engines: {node: ^14.21.3 || >=16}
@@ -85,6 +104,10 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.7.0':
     resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
     engines: {node: ^14.21.3 || >=16}
@@ -92,6 +115,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -197,11 +224,20 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
+  '@scure/bip32@2.0.1':
+    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -305,6 +341,12 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
+  '@wizardconnect/core@0.2.4':
+    resolution: {integrity: sha512-CHcm3YWEdZHGSH6+Ml2H8LE4HCe2DWKX6PbzvGIaExYg1LGbiTXABPoBWMhCOibcQFz3BIgjfcewP29M0JFrUw==}
+
+  '@wizardconnect/dapp@0.2.2':
+    resolution: {integrity: sha512-A71y5Qg5SIdIjXNngfpgBGxuQFgWRLQOigFa7zRX8HCoOh/62yOBfQUFtQDOgfRtGV7jv8nZ1Xb6wFqXVoEQvg==}
+
   abitype@1.2.4:
     resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
     peerDependencies:
@@ -393,6 +435,11 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
 
@@ -470,6 +517,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lossless-json@4.3.0:
+    resolution: {integrity: sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -494,6 +544,17 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nostr-tools@2.23.9:
+    resolution: {integrity: sha512-PBN3TpGh+EszlTZWpQdvcqEMqhcKcY1vTw0Xkkccg+TyP7y/icu9/iXJw72aFZ/ETm35ehU0hneGTXLaTSkImw==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -722,6 +783,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
 snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
@@ -738,6 +811,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bch-wc2/interfaces@0.0.8(@bitauth/libauth@3.1.0-next.8)':
+    dependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+
+  '@bitauth/libauth@3.1.0-next.8': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -768,6 +847,8 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.1.1': {}
+
   '@noble/curves@1.8.0':
     dependencies:
       '@noble/hashes': 1.7.0
@@ -780,9 +861,15 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
   '@noble/hashes@1.7.0': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.0.1': {}
 
   '@oxc-project/types@0.138.0': {}
 
@@ -839,16 +926,29 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/base@2.0.0': {}
+
   '@scure/bip32@1.7.0':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/bip32@2.0.1':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1169,6 +1269,29 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
+  '@wizardconnect/core@0.2.4':
+    dependencies:
+      '@bch-wc2/interfaces': 0.0.8(@bitauth/libauth@3.1.0-next.8)
+      '@bitauth/libauth': 3.1.0-next.8
+      eventemitter3: 5.0.1
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      lossless-json: 4.3.0
+      nostr-tools: 2.23.9
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@wizardconnect/dapp@0.2.2':
+    dependencies:
+      '@wizardconnect/core': 0.2.4
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   abitype@1.2.4: {}
 
   anymatch@3.1.3:
@@ -1233,6 +1356,10 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
+  isomorphic-ws@5.0.0(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
+
   keyvaluestorage-interface@1.0.0: {}
 
   lightningcss-android-arm64@1.32.0:
@@ -1284,6 +1411,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lossless-json@4.3.0: {}
+
   lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
@@ -1299,6 +1428,18 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   normalize-path@3.0.0: {}
+
+  nostr-tools@2.23.9:
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+
+  nostr-wasm@0.1.0: {}
 
   ofetch@1.5.1:
     dependencies:
@@ -1450,3 +1591,5 @@ snapshots:
       '@vue/shared': 3.5.39
 
   ws@7.5.11: {}
+
+  ws@8.21.0: {}

--- a/test/e2e/test-dapp/src/App.vue
+++ b/test/e2e/test-dapp/src/App.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, shallowRef } from 'vue'
 import SignClient from '@walletconnect/sign-client'
 import type { SessionTypes } from '@walletconnect/types'
+import WizardConnect from './WizardConnect.vue'
 
 const client = shallowRef<InstanceType<typeof SignClient> | null>(null)
 const session = shallowRef<SessionTypes.Struct | null>(null)
@@ -264,5 +265,7 @@ async function disconnect() {
       <label>Response:</label>
       <pre id="response" style="padding: 0.5rem; background: #f0f0f0; min-height: 2rem; white-space: pre-wrap; word-break: break-all;">{{ response }}</pre>
     </div>
+
+    <WizardConnect />
   </div>
 </template>

--- a/test/e2e/test-dapp/src/WizardConnect.vue
+++ b/test/e2e/test-dapp/src/WizardConnect.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { ref, shallowRef, onUnmounted } from 'vue'
+import { DappConnectionManager } from '@wizardconnect/dapp'
+import { initiateDappRelay, type DappRelayResult, type SignTransactionRequest } from '@wizardconnect/core'
+import {
+  binToHex,
+  hexToBin,
+  hash160,
+  encodeLockingBytecodeP2pkh,
+  encodeTransaction,
+  decodeTransaction,
+  createVirtualMachineBch,
+} from '@bitauth/libauth'
+
+const manager = shallowRef<DappConnectionManager | null>(null)
+const relay = shallowRef<DappRelayResult | null>(null)
+const pairingUri = ref('')
+const status = ref('disconnected')
+const response = ref('')
+const signing = ref(false)
+let signAbort: AbortController | null = null
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'object' && error !== null) return JSON.stringify(error)
+  return String(error)
+}
+
+function teardown() {
+  manager.value?.destroy()
+  relay.value?.cleanup()
+  manager.value = null
+  relay.value = null
+  pairingUri.value = ''
+  signAbort = null
+  signing.value = false
+}
+
+onUnmounted(teardown)
+
+function connect() {
+  teardown()
+  response.value = ''
+  // Session persistence is disabled so every test run starts from a clean pairing
+  const newManager = new DappConnectionManager('Wiz Test dApp', `${window.location.origin}/icon.png`, { session: false })
+  newManager.on('walletready', () => {
+    status.value = 'connected'
+    pairingUri.value = ''
+    response.value = JSON.stringify({
+      walletName: newManager.walletName,
+      paths: newManager.getSessionPaths().map((sessionPath) => sessionPath.name),
+    })
+  })
+  newManager.on('disconnect', (reason) => {
+    status.value = 'disconnected'
+    response.value = JSON.stringify({ event: 'disconnect', reason })
+  })
+  const newRelay = initiateDappRelay((payload) => {
+    newManager.updateConnection(payload.client, payload.status)
+  })
+  manager.value = newManager
+  relay.value = newRelay
+  pairingUri.value = newRelay.uri
+  status.value = 'waiting'
+}
+
+function copyUri() {
+  void navigator.clipboard.writeText(pairingUri.value)
+}
+
+async function signTransaction() {
+  if (!manager.value) return
+  response.value = ''
+  const receivePubkey = manager.value.getPubkey(0, 0n)
+  if (!receivePubkey) {
+    response.value = JSON.stringify({ error: 'No receive pubkey available (wallet_ready not received?)' })
+    return
+  }
+  // Fake UTXO paying to the wallet's receive/0 address. Signing does not require the
+  // UTXO to exist on-chain: the signature commits to the claimed sourceOutputs
+  // (SIGHASH_UTXOS), so the returned transaction can be fully VM-verified locally.
+  const walletLockingBytecode = encodeLockingBytecodeP2pkh(hash160(receivePubkey))
+  const fakeOutpointHash = new Uint8Array(32).fill(0xaa)
+  const sourceOutput = {
+    outpointIndex: 0,
+    outpointTransactionHash: fakeOutpointHash,
+    sequenceNumber: 0,
+    unlockingBytecode: new Uint8Array(),
+    lockingBytecode: walletLockingBytecode,
+    valueSatoshis: 10_000n,
+  }
+  const transaction = {
+    version: 2,
+    locktime: 0,
+    inputs: [{
+      outpointIndex: 0,
+      outpointTransactionHash: fakeOutpointHash,
+      sequenceNumber: 0,
+      unlockingBytecode: new Uint8Array(),
+    }],
+    outputs: [{
+      lockingBytecode: walletLockingBytecode,
+      valueSatoshis: 9_500n,
+    }],
+  }
+  // Wire format mirroring the reference serializer: hex strings for bytes, "<bigint: Xn>" for amounts
+  const wireRequest = {
+    transaction: {
+      transaction: binToHex(encodeTransaction(transaction)),
+      sourceOutputs: [{
+        outpointIndex: 0,
+        outpointTransactionHash: binToHex(fakeOutpointHash),
+        sequenceNumber: 0,
+        unlockingBytecode: '',
+        lockingBytecode: binToHex(walletLockingBytecode),
+        valueSatoshis: '<bigint: 10000n>',
+      }],
+      broadcast: false,
+      userPrompt: 'Wiz test transaction',
+    },
+    inputPaths: [[0, 'receive', 0]],
+  } as unknown as Pick<SignTransactionRequest, 'transaction' | 'inputPaths'>
+  signAbort = new AbortController()
+  signing.value = true
+  try {
+    const result = await manager.value.signTransaction(wireRequest, { signal: signAbort.signal })
+    // Verify the returned signature end-to-end with the libauth VM
+    const signedTransaction = decodeTransaction(hexToBin(result.signedTransaction))
+    const vmResult = typeof signedTransaction === 'string'
+      ? signedTransaction
+      : createVirtualMachineBch(true).verify({ transaction: signedTransaction, sourceOutputs: [sourceOutput] })
+    response.value = JSON.stringify({
+      signedTransaction: result.signedTransaction,
+      vmVerified: vmResult === true,
+      ...(vmResult !== true ? { vmError: vmResult } : {}),
+    })
+  } catch (error: unknown) {
+    response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    signAbort = null
+    signing.value = false
+  }
+}
+
+function cancelSign() {
+  signAbort?.abort('Cancelled by test dApp')
+}
+
+async function disconnect() {
+  if (!manager.value) return
+  try {
+    await manager.value.sendDisconnect('Test dApp disconnected')
+  } catch (error: unknown) {
+    console.error('sendDisconnect failed:', error)
+  }
+  teardown()
+  status.value = 'disconnected'
+  response.value = JSON.stringify({ disconnected: true })
+}
+</script>
+
+<template>
+  <div style="margin-top: 2rem; border-top: 2px solid #ccc; padding-top: 1rem;">
+    <h2>WizardConnect Test dApp</h2>
+
+    <div style="margin-bottom: 1rem;">
+      <span>Status: <strong id="wiz-session-status">{{ status }}</strong></span>
+      <span v-if="signing"> (awaiting signature...)</span>
+    </div>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem;">
+      <button id="wiz-btn-connect" @click="connect">Connect</button>
+      <button id="wiz-btn-sign-transaction" @click="signTransaction" :disabled="status !== 'connected' || signing">Sign Transaction</button>
+      <button id="wiz-btn-cancel-sign" @click="cancelSign" :disabled="!signing">Cancel Sign</button>
+      <button id="wiz-btn-disconnect" @click="disconnect" :disabled="status === 'disconnected'">Disconnect</button>
+    </div>
+
+    <div v-if="pairingUri" style="margin-bottom: 1rem;">
+      <label>Pairing URI:</label>
+      <div id="wiz-pairing-uri" style="word-break: break-all; padding: 0.5rem; background: #f0f0f0; font-size: 0.75rem;">{{ pairingUri }}</div>
+      <button id="wiz-btn-copy-uri" @click="copyUri" style="margin-top: 0.25rem; font-size: 0.75rem;">Copy</button>
+    </div>
+
+    <div>
+      <label>Response:</label>
+      <pre id="wiz-response" style="padding: 0.5rem; background: #f0f0f0; min-height: 2rem; white-space: pre-wrap; word-break: break-all;">{{ response }}</pre>
+    </div>
+  </div>
+</template>

--- a/test/e2e/walletconnect.test.ts
+++ b/test/e2e/walletconnect.test.ts
@@ -84,8 +84,8 @@ test.describe.serial('WalletConnect E2E', () => {
     await expect(dappPage.locator('#pairing-uri')).toContainText('wc:', { timeout: 15_000 })
     const uri = await dappPage.textContent('#pairing-uri')
 
-    // Wallet: Paste URI into WalletConnect input and click Connect
-    await walletPage.getByPlaceholder('Wallet Connect URI').fill(uri!)
+    // Wallet: Paste URI into the connection URI input and click Connect
+    await walletPage.getByPlaceholder('Connection URI').fill(uri!)
     await walletPage.locator('input.primaryButton[value*="Connect"]').click()
 
     // Wallet: Approve session proposal

--- a/test/e2e/walletconnect.test.ts
+++ b/test/e2e/walletconnect.test.ts
@@ -66,7 +66,8 @@ test.describe.serial('WalletConnect E2E', () => {
 
     // Navigate to WalletConnect tab, wait for sessions section
     await walletPage.locator('nav').getByText('WalletConnect').click()
-    await walletPage.getByText('Connect to Dapp').waitFor({ timeout: 15_000 })
+    // exact: the intro text ("Connect to dApps with the...") is a case-insensitive substring match otherwise
+    await walletPage.getByText('Connect to Dapp', { exact: true }).waitFor({ timeout: 15_000 })
 
     // Open test dApp, wait for SignClient to initialize (Connect button enabled)
     await dappPage.goto(DAPP_URL)

--- a/test/e2e/walletconnect.test.ts
+++ b/test/e2e/walletconnect.test.ts
@@ -62,10 +62,10 @@ test.describe.serial('WalletConnect E2E', () => {
     await walletPage.getByText('Developer settings').click()
     await walletPage.locator('select').first().selectOption('chipnet')
     // Wait for network switch to complete. It resets the active view back to the wallet tab.
-    await expect(walletPage.locator('nav').getByText('BchWallet')).toHaveClass(/active/, { timeout: 15_000 })
+    await expect(walletPage.locator('nav').getByText('Wallet', { exact: true })).toHaveClass(/active/, { timeout: 15_000 })
 
-    // Navigate to WalletConnect tab, wait for sessions section
-    await walletPage.locator('nav').getByText('WalletConnect').click()
+    // Navigate to the Connect tab, wait for sessions section
+    await walletPage.locator('nav').getByText('Connect', { exact: true }).click()
     // exact: the intro text ("Connect to dApps with the...") is a case-insensitive substring match otherwise
     await walletPage.getByText('Connect to Dapp', { exact: true }).waitFor({ timeout: 15_000 })
 

--- a/test/e2e/walletconnect.test.ts
+++ b/test/e2e/walletconnect.test.ts
@@ -197,9 +197,9 @@ test.describe.serial('WalletConnect E2E', () => {
     // dApp: Assert disconnected
     await expect(dappPage.locator('#session-status')).toHaveText('disconnected', { timeout: 15_000 })
 
-    // Wallet: Assert no active sessions
+    // Wallet: Assert no active sessions (shared empty state of the unified sessions box)
     await expect(walletPage
-      .locator('fieldset:has(legend:text("WalletConnect Sessions"))').getByText('No sessions currently active.'))
+      .locator('fieldset:has(legend:text("dApp Sessions"))').getByText('No sessions currently active.'))
       .toBeVisible({ timeout: 15_000 })
   })
 })

--- a/test/e2e/wizardconnect.test.ts
+++ b/test/e2e/wizardconnect.test.ts
@@ -43,7 +43,7 @@ async function startPairing() {
   // Wait for any previous pairing flow to release the URI input: connectDappUriInput clears
   // it only after its (consent-dialog-gated) promise resolves, so filling too early races
   // that late clear and the Connect click would submit an empty input.
-  const uriInput = walletPage.getByPlaceholder('Wallet Connect URI')
+  const uriInput = walletPage.getByPlaceholder('Connection URI')
   await expect(uriInput).toHaveValue('')
   await uriInput.fill(uri)
   await walletPage.locator('input.primaryButton[value*="Connect"]').click()

--- a/test/e2e/wizardconnect.test.ts
+++ b/test/e2e/wizardconnect.test.ts
@@ -23,9 +23,10 @@ async function waitForDialog(page: Page, timeout = 15_000) {
   return dialog
 }
 
-// The WizardConnect sessions section on the wallet's connect view
+// The unified dApp sessions box on the wallet's connect view (all three
+// connection methods render their sessions as sections inside it)
 function wizSection(page: Page) {
-  return page.locator('fieldset:has(legend:text("WizardConnect Sessions"))')
+  return page.locator('fieldset:has(legend:text("dApp Sessions"))')
 }
 
 // Track the previous pairing URI so a re-pair never reads the stale one off the page

--- a/test/e2e/wizardconnect.test.ts
+++ b/test/e2e/wizardconnect.test.ts
@@ -83,7 +83,7 @@ test.describe.serial('WizardConnect E2E', () => {
     await walletPage.locator('nav').waitFor({ timeout: 15_000 })
 
     // Navigate to the connect view, wait for sessions section
-    await walletPage.locator('nav').getByText('WalletConnect').click()
+    await walletPage.locator('nav').getByText('Connect', { exact: true }).click()
     // exact: the intro text ("Connect to dApps with the...") is a case-insensitive substring match otherwise
     await walletPage.getByText('Connect to Dapp', { exact: true }).waitFor({ timeout: 15_000 })
 
@@ -174,7 +174,7 @@ test.describe.serial('WizardConnect E2E', () => {
   test('session restore — wallet reload reconnects without re-prompting consent', async () => {
     await walletPage.reload()
     await walletPage.locator('nav').waitFor({ timeout: 30_000 })
-    await walletPage.locator('nav').getByText('WalletConnect').click()
+    await walletPage.locator('nav').getByText('Connect', { exact: true }).click()
 
     // The persisted session reconnects with the same relay identity; the dapp
     // re-announces itself (dapp_ready) so the session card regains its name.

--- a/test/e2e/wizardconnect.test.ts
+++ b/test/e2e/wizardconnect.test.ts
@@ -1,0 +1,207 @@
+// WizardConnect E2E tests for Cashonize Wallet.
+// Creates a fresh HD wallet via onboarding (WizardConnect requires an HD wallet) and drives
+// a WizardConnect test dapp (the wizardconnect section of test-dapp) through the live Nostr
+// relay (wss://relay.riften.net), matching the wizardconnect library's own integration tests.
+// The sign tests use a fake UTXO with broadcast: false, so no funds are needed.
+
+import { test, expect, type Page } from '@playwright/test'
+
+const CASHONIZE_URL = 'http://localhost:9000'
+const DAPP_URL = 'http://localhost:5188'
+
+// Live-relay round trips (gift-wrap publish + delivery) can take a few seconds
+const RELAY_TIMEOUT = 30_000
+
+let walletPage: Page
+let dappPage: Page
+
+// Resolve the currently-open Quasar dialog, scoped to the newest visible one, and wait
+// until it is shown (see walletconnect.test.ts for the rationale).
+async function waitForDialog(page: Page, timeout = 15_000) {
+  const dialog = page.locator('.q-dialog:visible').last()
+  await dialog.waitFor({ state: 'visible', timeout })
+  return dialog
+}
+
+// The WizardConnect sessions section on the wallet's connect view
+function wizSection(page: Page) {
+  return page.locator('fieldset:has(legend:text("WizardConnect Sessions"))')
+}
+
+// Track the previous pairing URI so a re-pair never reads the stale one off the page
+let lastPairingUri = ''
+
+// dApp: start a fresh pairing; wallet: paste the URI and wait for the consent dialog
+async function startPairing() {
+  await dappPage.click('#wiz-btn-connect')
+  const uriLocator = dappPage.locator('#wiz-pairing-uri')
+  await expect(uriLocator).toContainText('wiz://', { timeout: 15_000 })
+  if (lastPairingUri) await expect(uriLocator).not.toHaveText(lastPairingUri)
+  const uri = (await uriLocator.textContent())!.trim()
+  lastPairingUri = uri
+
+  // Wait for any previous pairing flow to release the URI input: connectDappUriInput clears
+  // it only after its (consent-dialog-gated) promise resolves, so filling too early races
+  // that late clear and the Connect click would submit an empty input.
+  const uriInput = walletPage.getByPlaceholder('Wallet Connect URI')
+  await expect(uriInput).toHaveValue('')
+  await uriInput.fill(uri)
+  await walletPage.locator('input.primaryButton[value*="Connect"]').click()
+
+  // Wallet: xpub-sharing consent dialog
+  return waitForDialog(walletPage)
+}
+
+// Approve the consent dialog and wait until both sides report the session
+async function pairAndApprove() {
+  const consentDialog = await startPairing()
+  await consentDialog.getByRole('button', { name: 'Connect', exact: true }).click()
+  await expect(dappPage.locator('#wiz-session-status')).toHaveText('connected', { timeout: RELAY_TIMEOUT })
+  await expect(wizSection(walletPage).getByText('Wiz Test dApp')).toBeVisible({ timeout: RELAY_TIMEOUT })
+}
+
+test.describe.serial('WizardConnect E2E', () => {
+  test.beforeAll(async ({ browser }) => {
+    const walletContext = await browser.newContext()
+    const dappContext = await browser.newContext()
+    walletPage = await walletContext.newPage()
+    dappPage = await dappContext.newPage()
+
+    // NOTE: unlike the WalletConnect suite, no fake clocks are installed here — the Nostr
+    // transport's keepalive pings and the protocol's `time`-based replay filtering rely on
+    // real time and would misbehave under a frozen clock.
+
+    // Set up a fresh HD wallet via onboarding (WizardConnect requires an HD wallet)
+    await walletPage.goto(CASHONIZE_URL)
+    await walletPage.getByRole('button', { name: 'Create new wallet' }).click()
+    await walletPage.locator('select').first().selectOption('hd')
+    await walletPage.getByRole('button', { name: 'Create wallet' }).click()
+
+    // Finish onboarding — wait for nav tabs to appear (wallet loaded)
+    await walletPage.getByRole('button', { name: 'Finish Setup' }).click()
+    await walletPage.locator('nav').waitFor({ timeout: 15_000 })
+
+    // Navigate to the connect view, wait for sessions section
+    await walletPage.locator('nav').getByText('WalletConnect').click()
+    await walletPage.getByText('Connect to Dapp').waitFor({ timeout: 15_000 })
+
+    // Open test dApp (the WizardConnect manager needs no async init)
+    await dappPage.goto(DAPP_URL)
+    await dappPage.locator('#wiz-btn-connect').waitFor({ timeout: 15_000 })
+  })
+
+  test.afterAll(async () => {
+    await walletPage?.context().close()
+    await dappPage?.context().close()
+  })
+
+  test('rejecting the consent dialog shares nothing and creates no session', async () => {
+    const consentDialog = await startPairing()
+    // The consent dialog must warn about the xpub / full address list disclosure
+    await expect(consentDialog).toContainText('address list')
+    await expect(consentDialog).toContainText('xpub')
+    await consentDialog.getByRole('button', { name: 'Cancel' }).click()
+
+    // Wallet: no session was created
+    await expect(wizSection(walletPage).getByText('No sessions currently active.')).toBeVisible()
+    // dApp: still waiting, no wallet_ready (xpubs) received
+    await expect(dappPage.locator('#wiz-session-status')).toHaveText('waiting')
+    await expect(dappPage.locator('#wiz-response')).not.toContainText('paths')
+  })
+
+  test('connect — approving the consent dialog shares the session xpubs', async () => {
+    const consentDialog = await startPairing()
+    await consentDialog.getByRole('button', { name: 'Connect', exact: true }).click()
+
+    // dApp: session established, wallet identity and the three chain xpubs received
+    await expect(dappPage.locator('#wiz-session-status')).toHaveText('connected', { timeout: RELAY_TIMEOUT })
+    const response = dappPage.locator('#wiz-response')
+    await expect(response).toContainText('Cashonize')
+    await expect(response).toContainText('receive')
+    await expect(response).toContainText('change')
+    await expect(response).toContainText('defi')
+
+    // Wallet: session card shows the dapp name and connected status
+    await expect(wizSection(walletPage).getByText('Wiz Test dApp')).toBeVisible({ timeout: RELAY_TIMEOUT })
+    await expect(wizSection(walletPage).getByText('Connected')).toBeVisible()
+  })
+
+  test('signTransaction — approve (signature VM-verified by the dapp)', async () => {
+    await dappPage.click('#wiz-btn-sign-transaction')
+
+    // Wallet: transaction approval dialog shows the dapp's user prompt
+    const txDialog = await waitForDialog(walletPage, RELAY_TIMEOUT)
+    await expect(txDialog).toContainText('Wiz test transaction')
+    await txDialog.getByRole('button', { name: 'Sign' }).click()
+
+    // dApp: response contains the signed transaction and it passes libauth VM verification
+    await expect(dappPage.locator('#wiz-response')).toContainText('signedTransaction', { timeout: RELAY_TIMEOUT })
+    await expect(dappPage.locator('#wiz-response')).toContainText('"vmVerified":true')
+
+    // Wallet: dismiss the "Transaction Signed" alert dialog
+    const alertDialog = walletPage.locator('.alertDialog')
+    await alertDialog.waitFor({ timeout: 5_000 })
+    await walletPage.keyboard.press('Escape')
+    await expect(alertDialog).not.toBeVisible({ timeout: 5_000 })
+  })
+
+  test('signTransaction — reject', async () => {
+    await dappPage.click('#wiz-btn-sign-transaction')
+
+    const txDialog = await waitForDialog(walletPage, RELAY_TIMEOUT)
+    await txDialog.getByRole('button', { name: 'Cancel' }).click()
+
+    // dApp: sign promise rejects with the wallet's error
+    await expect(dappPage.locator('#wiz-response')).toContainText('User rejected', { timeout: RELAY_TIMEOUT })
+  })
+
+  test('sign_cancel — dapp cancels a pending request and the dialog closes', async () => {
+    await dappPage.click('#wiz-btn-sign-transaction')
+
+    const txDialog = await waitForDialog(walletPage, RELAY_TIMEOUT)
+
+    // dApp: cancel the in-flight request (sends sign_cancel over the relay)
+    await dappPage.click('#wiz-btn-cancel-sign')
+
+    // Wallet: the approval dialog is dismissed
+    await expect(txDialog).not.toBeVisible({ timeout: RELAY_TIMEOUT })
+    // dApp: the sign promise was aborted
+    await expect(dappPage.locator('#wiz-response')).toContainText('Cancelled by test dApp')
+  })
+
+  test('session restore — wallet reload reconnects without re-prompting consent', async () => {
+    await walletPage.reload()
+    await walletPage.locator('nav').waitFor({ timeout: 30_000 })
+    await walletPage.locator('nav').getByText('WalletConnect').click()
+
+    // The persisted session reconnects with the same relay identity; the dapp
+    // re-announces itself (dapp_ready) so the session card regains its name.
+    // No consent dialog appears for restored sessions.
+    await expect(wizSection(walletPage).getByText('Wiz Test dApp')).toBeVisible({ timeout: RELAY_TIMEOUT })
+    await expect(walletPage.locator('.q-dialog')).not.toBeVisible()
+    await expect(dappPage.locator('#wiz-session-status')).toHaveText('connected')
+  })
+
+  test('disconnect — wallet-initiated, courtesy message reaches the dapp', async () => {
+    // exercises the patched doDisconnect: the disconnect message must be relayed
+    // before the connection is torn down, or the dapp never learns of it
+    await wizSection(walletPage).locator('.wiz-session-item-action-icon').click()
+
+    // Wallet: session removed optimistically
+    await expect(wizSection(walletPage).getByText('No sessions currently active.')).toBeVisible({ timeout: 15_000 })
+
+    // dApp: receives the disconnect (after its 8s reconnect-grace window)
+    await expect(dappPage.locator('#wiz-session-status')).toHaveText('disconnected', { timeout: RELAY_TIMEOUT })
+  })
+
+  test('disconnect — dapp-initiated removes the wallet session', async () => {
+    // Re-pair first (fresh URI, consent required again for a new pairing)
+    await pairAndApprove()
+
+    await dappPage.click('#wiz-btn-disconnect')
+    await expect(dappPage.locator('#wiz-session-status')).toHaveText('disconnected')
+
+    // Wallet: remote disconnect removes the session and notifies the user
+    await expect(wizSection(walletPage).getByText('No sessions currently active.')).toBeVisible({ timeout: RELAY_TIMEOUT })
+  })
+})

--- a/test/e2e/wizardconnect.test.ts
+++ b/test/e2e/wizardconnect.test.ts
@@ -84,7 +84,8 @@ test.describe.serial('WizardConnect E2E', () => {
 
     // Navigate to the connect view, wait for sessions section
     await walletPage.locator('nav').getByText('WalletConnect').click()
-    await walletPage.getByText('Connect to Dapp').waitFor({ timeout: 15_000 })
+    // exact: the intro text ("Connect to dApps with the...") is a case-insensitive substring match otherwise
+    await walletPage.getByText('Connect to Dapp', { exact: true }).waitFor({ timeout: 15_000 })
 
     // Open test dApp (the WizardConnect manager needs no async init)
     await dappPage.goto(DAPP_URL)

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -148,7 +148,16 @@ vi.mock('src/stores/walletconnectStore', () => ({
 // Mock cashconnectStore
 vi.mock('src/stores/cashconnectStore', () => ({
   useCashconnectStore: vi.fn(() => ({
-    initCashconnect: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+// Mock wizardconnectStore
+vi.mock('src/stores/wizardconnectStore', () => ({
+  useWizardconnectStore: vi.fn(() => ({
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
   })),
 }))
 

--- a/test/wizSigning.test.ts
+++ b/test/wizSigning.test.ts
@@ -1,0 +1,169 @@
+import {
+  binToHex,
+  hexToBin,
+  hash160,
+  secp256k1,
+  encodeLockingBytecodeP2pkh,
+  encodeTransaction,
+  decodeTransaction,
+  createVirtualMachineBch,
+  type TransactionCommon,
+} from "@bitauth/libauth";
+import type { WcSignTransactionRequest, WcSourceOutput } from "@bch-wc2/interfaces";
+import { createSignedWizTransaction, type WizInputSigningKey } from "../src/utils/wizSigning";
+
+// SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID, mandated by the WizardConnect spec
+const expectedHashType = 0x61;
+
+const makeKey = (fillByte: number): WizInputSigningKey => {
+  const privateKey = new Uint8Array(32).fill(fillByte);
+  const pubkeyCompressed = secp256k1.derivePublicKeyCompressed(privateKey);
+  if (typeof pubkeyCompressed === "string") throw new Error(pubkeyCompressed);
+  return { privateKey, pubkeyCompressed };
+};
+
+const p2pkhLockingBytecode = (key: WizInputSigningKey) =>
+  encodeLockingBytecodeP2pkh(hash160(key.pubkeyCompressed));
+
+const key0 = makeKey(0x01);
+const key1 = makeKey(0x02);
+
+const makeP2pkhRequest = (transactionForm: "object" | "hex"): WcSignTransactionRequest => {
+  const transaction: TransactionCommon = {
+    version: 2,
+    locktime: 0,
+    inputs: [
+      {
+        outpointIndex: 0,
+        outpointTransactionHash: new Uint8Array(32).fill(0xaa),
+        sequenceNumber: 0,
+        unlockingBytecode: new Uint8Array(),
+      },
+      {
+        outpointIndex: 1,
+        outpointTransactionHash: new Uint8Array(32).fill(0xbb),
+        sequenceNumber: 0,
+        unlockingBytecode: new Uint8Array(),
+      },
+    ],
+    outputs: [
+      {
+        lockingBytecode: p2pkhLockingBytecode(key0),
+        valueSatoshis: 15_000n,
+      },
+    ],
+  };
+  const sourceOutputs = [
+    {
+      outpointIndex: 0,
+      outpointTransactionHash: new Uint8Array(32).fill(0xaa),
+      sequenceNumber: 0,
+      unlockingBytecode: new Uint8Array(),
+      lockingBytecode: p2pkhLockingBytecode(key0),
+      valueSatoshis: 10_000n,
+    },
+    {
+      outpointIndex: 1,
+      outpointTransactionHash: new Uint8Array(32).fill(0xbb),
+      sequenceNumber: 0,
+      unlockingBytecode: new Uint8Array(),
+      lockingBytecode: p2pkhLockingBytecode(key1),
+      valueSatoshis: 10_000n,
+    },
+  ] as WcSourceOutput[];
+  return {
+    transaction: transactionForm === "hex" ? binToHex(encodeTransaction(transaction)) : transaction,
+    sourceOutputs,
+    broadcast: false,
+    userPrompt: "test",
+  };
+};
+
+const inputKeys = new Map<number, WizInputSigningKey>([
+  [0, key0],
+  [1, key1],
+]);
+
+describe('createSignedWizTransaction', () => {
+  it('should produce a fully valid transaction (verified by the libauth VM)', () => {
+    const request = makeP2pkhRequest("object");
+    const encodedTransaction = createSignedWizTransaction(request, inputKeys);
+    const signedTransaction = decodeTransaction(encodedTransaction);
+    expect(typeof signedTransaction).not.toBe("string");
+    if (typeof signedTransaction === "string") return;
+
+    const vm = createVirtualMachineBch(true);
+    const result = vm.verify({
+      transaction: signedTransaction,
+      sourceOutputs: request.sourceOutputs,
+    });
+    expect(result).toBe(true);
+  })
+  it('should produce the same transaction for hex-form and object-form requests', () => {
+    const encodedFromObject = createSignedWizTransaction(makeP2pkhRequest("object"), inputKeys);
+    const encodedFromHex = createSignedWizTransaction(makeP2pkhRequest("hex"), inputKeys);
+    expect(binToHex(encodedFromHex)).toBe(binToHex(encodedFromObject));
+  })
+  it('should sign every input with SIGHASH_ALL | SIGHASH_UTXOS | SIGHASH_FORKID', () => {
+    const encodedTransaction = createSignedWizTransaction(makeP2pkhRequest("object"), inputKeys);
+    const signedTransaction = decodeTransaction(encodedTransaction);
+    if (typeof signedTransaction === "string") throw new Error(signedTransaction);
+    for (const input of signedTransaction.inputs) {
+      // P2PKH unlocking bytecode: <push sig> <push pubkey>; the sig's last byte is the hashType
+      const sigPushLength = input.unlockingBytecode[0]!;
+      const signature = input.unlockingBytecode.slice(1, 1 + sigPushLength);
+      expect(signature[signature.length - 1]).toBe(expectedHashType);
+    }
+  })
+  it('should leave inputs without a signing key untouched', () => {
+    const request = makeP2pkhRequest("object");
+    const partialKeys = new Map([[0, key0]]);
+    const encodedTransaction = createSignedWizTransaction(request, partialKeys);
+    const signedTransaction = decodeTransaction(encodedTransaction);
+    if (typeof signedTransaction === "string") throw new Error(signedTransaction);
+    expect(signedTransaction.inputs[0]!.unlockingBytecode.length).toBeGreaterThan(0);
+    expect(signedTransaction.inputs[1]!.unlockingBytecode.length).toBe(0);
+  })
+  it('should replace sig and pubkey placeholders in contract inputs', () => {
+    const request = makeP2pkhRequest("object");
+    const sigPlaceholder = "41" + "00".repeat(65);
+    const pubkeyPlaceholder = "21" + "00".repeat(33);
+    const redeemScript = hexToBin("51"); // OP_1, stand-in redeem script
+    request.sourceOutputs[1] = {
+      ...request.sourceOutputs[1]!,
+      unlockingBytecode: hexToBin(sigPlaceholder + pubkeyPlaceholder),
+      contract: {
+        abiFunction: { name: "spend" },
+        redeemScript,
+        artifact: { contractName: "TestContract" },
+      },
+    } as WcSourceOutput;
+    const encodedTransaction = createSignedWizTransaction(request, inputKeys);
+    const signedTransaction = decodeTransaction(encodedTransaction);
+    if (typeof signedTransaction === "string") throw new Error(signedTransaction);
+    const unlockingBytecodeHex = binToHex(signedTransaction.inputs[1]!.unlockingBytecode);
+    expect(unlockingBytecodeHex).not.toContain("00".repeat(65));
+    expect(unlockingBytecodeHex).not.toContain("00".repeat(33));
+    // the inserted signature ends with the mandated hashType, followed by the pubkey push
+    expect(unlockingBytecodeHex).toContain(expectedHashType.toString(16) + "21" + binToHex(key1.pubkeyCompressed));
+  })
+  it('should throw for a contract input with placeholders but no signing key', () => {
+    const request = makeP2pkhRequest("object");
+    const sigPlaceholder = "41" + "00".repeat(65);
+    request.sourceOutputs[1] = {
+      ...request.sourceOutputs[1]!,
+      unlockingBytecode: hexToBin(sigPlaceholder),
+      contract: {
+        abiFunction: { name: "spend" },
+        redeemScript: hexToBin("51"),
+        artifact: { contractName: "TestContract" },
+      },
+    } as WcSourceOutput;
+    expect(() => createSignedWizTransaction(request, new Map([[0, key0]]))).toThrow(/No signing key/);
+  })
+  it('should throw on a transaction/sourceOutputs length mismatch', () => {
+    const request = makeP2pkhRequest("object");
+    request.sourceOutputs.pop();
+    expect(() => createSignedWizTransaction(request, inputKeys)).toThrow(/length mismatch/);
+  })
+})

--- a/test/wizValidation.test.ts
+++ b/test/wizValidation.test.ts
@@ -1,0 +1,110 @@
+import { WizSignTransactionRequestSchema } from "../src/utils/zodValidation";
+
+// A representative sign_transaction_request payload as produced by the WizardConnect
+// reference serializer: hex strings for bytes, "<bigint: Xn>" for amounts
+const baseRequest = {
+  action: "sign_transaction_request",
+  time: 1750000000,
+  sequence: 1,
+  inputPaths: [
+    [0, "receive", 0],
+    [1, "defi", 5],
+  ],
+  transaction: {
+    transaction: "0200000001aa00000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000160014000000000000000000000000000000000000000000000000",
+    sourceOutputs: [
+      {
+        outpointIndex: 0,
+        outpointTransactionHash: "aa".repeat(32),
+        sequenceNumber: 0,
+        unlockingBytecode: "",
+        lockingBytecode: "76a914000000000000000000000000000000000000000088ac",
+        valueSatoshis: "<bigint: 10000n>",
+      },
+    ],
+    broadcast: true,
+    userPrompt: "Test transaction",
+  },
+};
+
+// helper to tamper with a fresh copy of the request
+const tamperedRequest = (tamper: (request: typeof baseRequest) => void) => {
+  const request = structuredClone(baseRequest);
+  tamper(request);
+  return request;
+};
+
+describe('WizardConnect sign request schema validation', () => {
+  it('should accept a request in the reference wire format and transform the fields', () => {
+    const parsed = WizSignTransactionRequestSchema.parse(baseRequest);
+    expect(parsed.sequence).toBe(1);
+    const sourceOutput = parsed.transaction.sourceOutputs[0]!;
+    expect(sourceOutput.valueSatoshis).toBe(10000n);
+    expect(sourceOutput.lockingBytecode).toBeInstanceOf(Uint8Array);
+    expect(sourceOutput.outpointTransactionHash).toBeInstanceOf(Uint8Array);
+    expect(sourceOutput.outpointTransactionHash).toHaveLength(32);
+  })
+  it('should accept the extended stringified Uint8Array form', () => {
+    const request = tamperedRequest((request) => {
+      request.transaction.sourceOutputs[0]!.lockingBytecode = "<Uint8Array: 0x76a914000000000000000000000000000000000000000088ac>";
+    });
+    const parsed = WizSignTransactionRequestSchema.parse(request);
+    expect(parsed.transaction.sourceOutputs[0]!.lockingBytecode).toBeInstanceOf(Uint8Array);
+  })
+  it('should default missing nft capability and commitment on token outputs', () => {
+    const request = tamperedRequest((request) => {
+      (request.transaction.sourceOutputs[0] as Record<string, unknown>).token = {
+        category: "bb".repeat(32),
+        amount: "<bigint: 0n>",
+        nft: {},
+      };
+    });
+    const parsed = WizSignTransactionRequestSchema.parse(request);
+    const token = parsed.transaction.sourceOutputs[0]!.token!;
+    expect(token.nft!.capability).toBe("none");
+    expect(token.nft!.commitment).toBeInstanceOf(Uint8Array);
+    expect(token.nft!.commitment).toHaveLength(0);
+  })
+  it('should reject an unknown inputPaths path name', () => {
+    const request = tamperedRequest((request) => {
+      request.inputPaths[0]![1] = "stealth_scan";
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject duplicate input indices in inputPaths', () => {
+    const request = tamperedRequest((request) => {
+      request.inputPaths = [[0, "receive", 0], [0, "change", 1]];
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject an address index beyond the BIP32 non-hardened range', () => {
+    const request = tamperedRequest((request) => {
+      request.inputPaths[0]![2] = 2 ** 31;
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject odd-length hex in byte fields', () => {
+    const request = tamperedRequest((request) => {
+      request.transaction.sourceOutputs[0]!.lockingBytecode = "76a";
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject a non-32-byte outpointTransactionHash', () => {
+    const request = tamperedRequest((request) => {
+      request.transaction.sourceOutputs[0]!.outpointTransactionHash = "deadbeef";
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject a request without sourceOutputs', () => {
+    const request = tamperedRequest((request) => {
+      request.transaction.sourceOutputs = [];
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+  it('should reject a missing sequence', () => {
+    const request = tamperedRequest((request) => {
+      delete (request as Record<string, unknown>).sequence;
+    });
+    expect(() => WizSignTransactionRequestSchema.parse(request)).toThrow();
+  })
+})


### PR DESCRIPTION
Adds a third dapp connection protocol next to WalletConnect and CashConnect: WizardConnect (wiz: URIs), a nostr-relay-based protocol for BCH HD wallets where the wallet shares chain-level xpubs (receive/change/defi) and the only interactive request is transaction signing.

- wizardconnectStore: WalletConnectionManager lifecycle, WalletAdapter with seed-derived chain nodes and deterministic per-URI relay keys (HMAC(chain-8 key, uri)), sign-request queue with dapp-cancel handling, per-wallet/network session URI persistence and restore
- wizSigning: per-input key signing driven by dapp-supplied inputPaths, enforcing SIGHASH_ALL|UTXOS|FORKID per spec; contract inputs via sig/pubkey placeholder replacement (same scheme as WC2)
- zod validation of the untrusted relay payload, accepting both plain-hex and extended-JSON wire encodings per field
- WC2TransactionRequest dialog generalized to take a parsed request so both WC and WizardConnect flows share the same approval UI
- HD wallets only: single-address wallets get a clear error on pairing
- pnpm patch for @wizardconnect/wallet 0.2.2 disconnect race (cleanup ran before the courtesy disconnect message was relayed)
- unit tests: signing verified end-to-end with the libauth VM, schema tests