### PR TITLE
CashConnect: Use Nostr Transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
     "@bitjson/qr-code": "^1.0.2",
-    "@cashconnect-js/core": "1.0.0-alpha.4",
-    "@cashconnect-js/wallet": "1.0.0-alpha.4",
+    "@cashconnect-js/core": "1.0.0-alpha.17",
+    "@cashconnect-js/nostr": "1.0.0-alpha.17",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
     "@bitjson/qr-code": "^1.0.2",
-    "@cashconnect-js/core": "1.0.0-alpha.20",
-    "@cashconnect-js/nostr": "1.0.0-alpha.20",
+    "@cashconnect-js/core": "1.0.0-alpha.27",
+    "@cashconnect-js/nostr": "1.0.0-alpha.27",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
     "@bitjson/qr-code": "^1.0.2",
-    "@cashconnect-js/core": "1.0.0-alpha.29",
-    "@cashconnect-js/nostr": "1.0.0-alpha.29",
+    "@cashconnect-js/core": "1.0.0-alpha.31",
+    "@cashconnect-js/nostr": "1.0.0-alpha.31",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
     "@bitjson/qr-code": "^1.0.2",
-    "@cashconnect-js/core": "1.0.0-alpha.27",
-    "@cashconnect-js/nostr": "1.0.0-alpha.27",
+    "@cashconnect-js/core": "1.0.0-alpha.29",
+    "@cashconnect-js/nostr": "1.0.0-alpha.29",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
     "@bitjson/qr-code": "^1.0.2",
-    "@cashconnect-js/core": "1.0.0-alpha.17",
-    "@cashconnect-js/nostr": "1.0.0-alpha.17",
+    "@cashconnect-js/core": "1.0.0-alpha.20",
+    "@cashconnect-js/nostr": "1.0.0-alpha.20",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
     "@plausible-analytics/tracker": "^0.4.4",
     "@reown/walletkit": "1.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,11 +29,11 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@cashconnect-js/core':
-        specifier: 1.0.0-alpha.29
-        version: 1.0.0-alpha.29(typescript@6.0.3)
+        specifier: 1.0.0-alpha.31
+        version: 1.0.0-alpha.31
       '@cashconnect-js/nostr':
-        specifier: 1.0.0-alpha.29
-        version: 1.0.0-alpha.29(typescript@6.0.3)
+        specifier: 1.0.0-alpha.31
+        version: 1.0.0-alpha.31
       '@mainnet-cash/indexeddb-storage':
         specifier: 3.1.7
         version: 3.1.7
@@ -178,11 +178,11 @@ packages:
   '@capacitor/core@8.4.1':
     resolution: {integrity: sha512-xqhOGLbTAYeOWK+IDUNSjQJAPapQjRHrIcgk9PYp52or9zFTaaMko31uNi16N6W+CRJ8VrRram6fOYILkBG2Hg==}
 
-  '@cashconnect-js/core@1.0.0-alpha.29':
-    resolution: {integrity: sha512-qdR07iaQnLOEvtdVGXFdoE7yNl508cKQFfKDzIXh+Ru87UxyuGl6YnsgtQ/1YWeGhuoJhqc54oSGoOQ9SYgMsQ==}
+  '@cashconnect-js/core@1.0.0-alpha.31':
+    resolution: {integrity: sha512-pD0txUK0CAlec4K6KrT/YGgF+k6nEla3fFgWK/DD515yofIqZ0MD2OcSjhKLplCyXyxJ/cp61pVGHUz29f7Ggg==}
 
-  '@cashconnect-js/nostr@1.0.0-alpha.29':
-    resolution: {integrity: sha512-b1x73kqFnx9ilrUmEq504gFDdvRbyt0HrbrCuyVabnqIH1GTsAiK5tH7a+WEQf5W/Iaj1SmfEpfeTYmf43MxFQ==}
+  '@cashconnect-js/nostr@1.0.0-alpha.31':
+    resolution: {integrity: sha512-/BebQtgfXrWQyhVPF3gvCYq1SCTeKQABEMbvzKeSi0pVdPYvchMjaOCAM2B0vRlnDHMbmXoc5z47GBXHvPO22g==}
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -2703,63 +2703,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@cashconnect-js/core@1.0.0-alpha.29(typescript@6.0.3)':
+  '@cashconnect-js/core@1.0.0-alpha.31':
     dependencies:
       '@bitauth/libauth': 3.1.0-next.8
-      '@reown/walletkit': 1.5.6(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
 
-  '@cashconnect-js/nostr@1.0.0-alpha.29(typescript@6.0.3)':
+  '@cashconnect-js/nostr@1.0.0-alpha.31':
     dependencies:
       '@bitauth/libauth': 3.1.0-next.8
-      '@cashconnect-js/core': 1.0.0-alpha.29(typescript@6.0.3)
+      '@cashconnect-js/core': 1.0.0-alpha.31
       zod: 4.4.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
 
   '@clack/core@1.4.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,11 +29,11 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@cashconnect-js/core':
-        specifier: 1.0.0-alpha.4
-        version: 1.0.0-alpha.4(typescript@6.0.3)
-      '@cashconnect-js/wallet':
-        specifier: 1.0.0-alpha.4
-        version: 1.0.0-alpha.4(typescript@6.0.3)(zod@4.4.3)
+        specifier: 1.0.0-alpha.29
+        version: 1.0.0-alpha.29(typescript@6.0.3)
+      '@cashconnect-js/nostr':
+        specifier: 1.0.0-alpha.29
+        version: 1.0.0-alpha.29(typescript@6.0.3)
       '@mainnet-cash/indexeddb-storage':
         specifier: 3.1.7
         version: 3.1.7
@@ -178,11 +178,11 @@ packages:
   '@capacitor/core@8.4.1':
     resolution: {integrity: sha512-xqhOGLbTAYeOWK+IDUNSjQJAPapQjRHrIcgk9PYp52or9zFTaaMko31uNi16N6W+CRJ8VrRram6fOYILkBG2Hg==}
 
-  '@cashconnect-js/core@1.0.0-alpha.4':
-    resolution: {integrity: sha512-zFvxlvIJYtthSB5PD84huyyEhC6TgvB7VGkgKJccqNmWYPD5Zkk3aw+qStrPAQ30SS5IIQb9h/fOPSfOui5XEg==}
+  '@cashconnect-js/core@1.0.0-alpha.29':
+    resolution: {integrity: sha512-qdR07iaQnLOEvtdVGXFdoE7yNl508cKQFfKDzIXh+Ru87UxyuGl6YnsgtQ/1YWeGhuoJhqc54oSGoOQ9SYgMsQ==}
 
-  '@cashconnect-js/wallet@1.0.0-alpha.4':
-    resolution: {integrity: sha512-txn5XS8IqmPV2AnyzcgSsl7EBoNOXyvdue1qvwCMc0hlFakzo1LA2JZYBtXZ87DQHkC66LPsNzPxHvqklsLVnA==}
+  '@cashconnect-js/nostr@1.0.0-alpha.29':
+    resolution: {integrity: sha512-b1x73kqFnx9ilrUmEq504gFDdvRbyt0HrbrCuyVabnqIH1GTsAiK5tH7a+WEQf5W/Iaj1SmfEpfeTYmf43MxFQ==}
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -2703,7 +2703,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@cashconnect-js/core@1.0.0-alpha.4(typescript@6.0.3)':
+  '@cashconnect-js/core@1.0.0-alpha.29(typescript@6.0.3)':
     dependencies:
       '@bitauth/libauth': 3.1.0-next.8
       '@reown/walletkit': 1.5.6(typescript@6.0.3)(zod@4.4.3)
@@ -2732,14 +2732,11 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@cashconnect-js/wallet@1.0.0-alpha.4(typescript@6.0.3)(zod@4.4.3)':
+  '@cashconnect-js/nostr@1.0.0-alpha.29(typescript@6.0.3)':
     dependencies:
       '@bitauth/libauth': 3.1.0-next.8
-      '@cashconnect-js/core': 1.0.0-alpha.4(typescript@6.0.3)
-      '@reown/walletkit': 1.5.6(typescript@6.0.3)(zod@4.4.3)
-      '@walletconnect/core': 2.23.9(typescript@6.0.3)(zod@4.4.3)
-      '@walletconnect/sign-client': 2.23.10(typescript@6.0.3)(zod@4.4.3)
-      '@walletconnect/utils': 2.23.10(typescript@6.0.3)(zod@4.4.3)
+      '@cashconnect-js/core': 1.0.0-alpha.29(typescript@6.0.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -2763,7 +2760,6 @@ snapshots:
       - typescript
       - uploadthing
       - utf-8-validate
-      - zod
 
   '@clack/core@1.4.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,8 @@
 # in Quasar's build tooling (e.g. v3.0.1 www-folder clean fix). Dev-only, not shipped.
 minimumReleaseAgeExclude:
   - '@quasar/app-vite'
+  - '@cashconnect-js/core@1.0.0-alpha.29'
+  - '@cashconnect-js/nostr@1.0.0-alpha.29'
 
 # Enforce the "engines" field (node / pnpm) instead of just warning.
 engineStrict: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,8 @@
 # in Quasar's build tooling (e.g. v3.0.1 www-folder clean fix). Dev-only, not shipped.
 minimumReleaseAgeExclude:
   - '@quasar/app-vite'
-  - '@cashconnect-js/core@1.0.0-alpha.29'
-  - '@cashconnect-js/nostr@1.0.0-alpha.29'
+  - '@cashconnect-js/core@1.0.0-alpha.31'
+  - '@cashconnect-js/nostr@1.0.0-alpha.31'
 
 # Enforce the "engines" field (node / pnpm) instead of just warning.
 engineStrict: true

--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
                 <data android:scheme="bitcoincash" />
                 <data android:scheme="bch-wif" />
                 <data android:scheme="wc" />
-                <data android:scheme="cc" />
+                <data android:scheme="bch-cc-v1" />
             </intent-filter>
 
         </activity>

--- a/src/boot/deepLinking.ts
+++ b/src/boot/deepLinking.ts
@@ -2,7 +2,7 @@ import { defineBoot } from '#q-app'
 import { App, type URLOpenListenerEvent } from '@capacitor/app';
 import { Platform } from 'quasar'
 
-// Deep linking on mobile: handles URIs like bitcoincash:, wc:, cc:, bch-wif:
+// Deep linking on mobile: handles URIs like bitcoincash:, wc:, bch-cc-v1:, bch-wif:
 // These arrive via two paths depending on whether the app was already running:
 //   - "warm start": app is in background, appUrlOpen event fires
 //   - "cold start": app was not running, the launch URL is retrieved after startup

--- a/src/components/cashconnect/CCErrorDialog.vue
+++ b/src/components/cashconnect/CCErrorDialog.vue
@@ -2,6 +2,7 @@
 import { useDialogPluginComponent } from 'quasar'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
+import { getRootCause } from '@cashconnect-js/core/templates';
 
 defineProps<{
   error: Error
@@ -12,6 +13,8 @@ defineEmits([
 ])
 
 const { dialogRef, onDialogHide, onDialogOK } = useDialogPluginComponent()
+
+
 </script>
 
 <template>
@@ -20,7 +23,7 @@ const { dialogRef, onDialogHide, onDialogOK } = useDialogPluginComponent()
       <fieldset class="cc-modal-fieldset" style="width:1024px">
         <legend class="cc-modal-fieldset-legend">{{ t('cashConnect.error.title') }}</legend>
 
-        <div v-if="error.message">{{ error.message }}</div>
+        <div v-if="error.message">{{ getRootCause(error) }}</div>
 
         <template v-if="error.stack">
           <q-expansion-item :label="t('cashConnect.error.stackTrace')" class="q-mt-md">

--- a/src/components/cashconnect/CCErrorDialog.vue
+++ b/src/components/cashconnect/CCErrorDialog.vue
@@ -13,8 +13,6 @@ defineEmits([
 ])
 
 const { dialogRef, onDialogHide, onDialogOK } = useDialogPluginComponent()
-
-
 </script>
 
 <template>

--- a/src/components/cashconnect/CCExecuteActionDialog.vue
+++ b/src/components/cashconnect/CCExecuteActionDialog.vue
@@ -1,30 +1,27 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { useDialogPluginComponent } from 'quasar'
-import { type BchSession, type ExecuteActionPayload, type TemplateSegment } from '@cashconnect-js/core';
+import { type TemplateSegment } from '@cashconnect-js/core';
 import { encodeExtendedJson } from '@cashconnect-js/core/primitives';
-import { formatSegment, formatOraclePrice, formatOracleNumeratorUnitCode, formatOracleDenominatorUnitCode } from '@cashconnect-js/wallet';
+import { type ExecuteActionRequest, type ExecuteActionResponse } from '@cashconnect-js/nostr';
+import { type WalletSession, formatSegment, formatOraclePrice, formatOracleNumeratorUnitCode, formatOracleDenominatorUnitCode } from '@cashconnect-js/nostr/wallet';
 import { CurrencySymbols } from 'src/interfaces/interfaces';
-
-import { convertToCurrency, sanitizeUrl } from 'src/utils/utils';
+import { convertToCurrency, sanitizeUrl, satsToBch } from 'src/utils/utils';
 import { useStore } from 'src/stores/store';
 import { useSettingsStore } from 'src/stores/settingsStore';
 import { caughtErrorToString } from 'src/utils/errorHandling';
 import { type BcmrTokenResponse } from 'src/utils/zodValidation';
-import { useI18n } from 'vue-i18n'
+import { useI18n } from 'vue-i18n';
 const { t } = useI18n()
-
-// Components.
 import CCExpansionItem from './CCExpansionItem.vue';
 
 const store = useStore()
 const settingsStore = useSettingsStore()
 
 const props = defineProps<{
-  session: BchSession,
-  request: ExecuteActionPayload['request']['params'],
-  response: ExecuteActionPayload['response'],
-  exchangeRate: number,
+  session: WalletSession,
+  request: ExecuteActionRequest,
+  response: ExecuteActionResponse,
 }>()
 
 defineEmits([
@@ -33,15 +30,8 @@ defineEmits([
 
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 
-const safeUrl = sanitizeUrl(props.session.peer.metadata.url);
-
-const title = computed(() => {
-  return props.response.meta?.title || [props.request.action];
-});
-
-const description = computed(() => {
-  return props.response.meta?.description || ['No description for this action available.']
-})
+const safeUrl = sanitizeUrl(props.session.dapp.url);
+const exchangeRate = store.exchangeRate;
 
 //-----------------------------------------------------------------------------
 // Tokens
@@ -77,7 +67,7 @@ async function fetchAndSetTokenInfo(tokenId: string) {
     console.error(errorMessage);
   }
 }
-const allowedTokens = props.session.sessionProperties.allowedTokens ?? [];
+const allowedTokens = props.session.allowedTokens ?? [];
 // fire-and-forget promises
 for (const tokenId of allowedTokens) {
   void fetchAndSetTokenInfo(tokenId);
@@ -111,10 +101,6 @@ function addSignPrefixToNumber(value: number | bigint): string {
   if (Number(value) === 0) return formatted;
   return Number(value) > 0 ? `+ ${formatted}` : `- ${Number(-(value)).toLocaleString("en-US")}`;
 };
-
-function satsToBCH(satoshis: bigint) {
-  return Number(satoshis) / 100_000_000;
-};
 </script>
 
 <template>
@@ -122,7 +108,7 @@ function satsToBCH(satoshis: bigint) {
     <q-card>
       <fieldset class="cc-modal-fieldset">
         <legend class="cc-modal-fieldset-legend">
-          <span v-for="(segment, i) in title" :key="i">
+          <span v-for="(segment, i) in response.meta?.title" :key="i">
             {{ formatSegmentCustom(segment) }}
           </span>
         </legend>
@@ -130,12 +116,12 @@ function satsToBCH(satoshis: bigint) {
         <!-- Origin -->
         <q-item>
           <q-item-section avatar>
-            <q-img :src="session.peer.metadata.icons[0] ?? ''" style="max-width:64px; max-height:64px;" />
+            <q-img :src="session.dapp.icon ?? ''" style="max-width:64px; max-height:64px;" />
           </q-item-section>
           <q-item-section>
-            <q-item-label>{{ session.peer.metadata.name }}</q-item-label>
+            <q-item-label>{{ session.dapp.name }}</q-item-label>
             <q-item-label>
-              <a v-if="safeUrl" :href="safeUrl" target="_blank">{{ session.peer.metadata.url }}</a>
+              <a v-if="safeUrl" :href="safeUrl" target="_blank">{{ session.dapp.url }}</a>
               <span v-else style="color: var(--color-error);">{{ t('common.unsafeUrl') }}</span>
             </q-item-label>
           </q-item-section>
@@ -144,7 +130,7 @@ function satsToBCH(satoshis: bigint) {
         <hr style="margin-top:1em; margin-bottom: 1em" />
 
         <div class="wrapping-pre" style="font-size: medium;">
-          <template v-for="(segment, i) in description" :key="i">
+          <template v-for="(segment, i) in response.meta?.description" :key="i">
             <span v-if="typeof segment === 'string'">{{ segment }}</span>
             <span v-else class="green" style="font-weight:bold">{{ formatSegmentCustom(segment) }}</span>
           </template>
@@ -155,8 +141,11 @@ function satsToBCH(satoshis: bigint) {
         <div class="cc-modal-heading" style="margin-top: 1rem;">{{ t('cashConnect.executeAction.balanceChange') }}</div>
         <div v-for="(amount, category) of props.response.balanceChanges" :key="category">
           <div v-if="(category === 'sats')">
-            {{ addSignPrefixToNumber(satsToBCH(amount)) + ' BCH ' }}
-            ({{ convertToCurrency(amount, props.exchangeRate) + ` ${CurrencySymbols[settingsStore.currency]}`}})
+            {{ addSignPrefixToNumber(satsToBch(amount)) + ' BCH ' }}
+            <!-- Only show fiat equivalent if an exchange rate is available. -->
+            <template v-if="exchangeRate">
+              ({{ convertToCurrency(amount, exchangeRate) + ` ${CurrencySymbols[settingsStore.currency]}`}})
+            </template>
           </div>
           <div v-else>
             <span>{{ addSignPrefixToNumber(amount) }} <span>{{ getTokenName(category) }} <q-tooltip>{{ category }}</q-tooltip></span></span>

--- a/src/components/cashconnect/CCExecuteActionDialog.vue
+++ b/src/components/cashconnect/CCExecuteActionDialog.vue
@@ -175,7 +175,7 @@ function addSignPrefixToNumber(value: number | bigint): string {
               <pre class="wrapping-pre">{{ encodeExtendedJson(request.params, 2) }}</pre>
             </CCExpansionItem>
 
-            <!-- NOTE: Eventually we will show Instructions/Resolutions too, but the payload for this is not yet finalized. -->
+            <!-- NOTE: Eventually we will show Instructions/Resolutions too, but the payload for this is still WIP. -->
 
             <CCExpansionItem :title="t('cashConnect.executeAction.returnedData')" :caption="t('cashConnect.executeAction.returnedDataCaption')">
               <pre class="wrapping-pre">{{ encodeExtendedJson({ data: response.data, transactions: response.transactions }, 2) }}</pre>

--- a/src/components/cashconnect/CCExecuteActionDialog.vue
+++ b/src/components/cashconnect/CCExecuteActionDialog.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useDialogPluginComponent } from 'quasar'
-import { type TemplateSegment } from '@cashconnect-js/core';
 import { encodeExtendedJson } from '@cashconnect-js/core/primitives';
+import { type TemplateSegment } from '@cashconnect-js/core/templates';
 import { type ExecuteActionRequest, type ExecuteActionResponse } from '@cashconnect-js/nostr';
 import { type WalletSession, formatSegment, formatOraclePrice, formatOracleNumeratorUnitCode, formatOracleDenominatorUnitCode } from '@cashconnect-js/nostr/wallet';
 import { CurrencySymbols } from 'src/interfaces/interfaces';

--- a/src/components/cashconnect/CCExecuteActionDialog.vue
+++ b/src/components/cashconnect/CCExecuteActionDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useDialogPluginComponent } from 'quasar'
 import { encodeExtendedJson } from '@cashconnect-js/core/primitives';
 import { type TemplateSegment } from '@cashconnect-js/core/templates';
@@ -31,7 +31,7 @@ defineEmits([
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 
 const safeUrl = sanitizeUrl(props.session.dapp.url);
-const exchangeRate = store.exchangeRate;
+const exchangeRate = computed(() => store.exchangeRate);
 
 //-----------------------------------------------------------------------------
 // Tokens
@@ -108,9 +108,16 @@ function addSignPrefixToNumber(value: number | bigint): string {
     <q-card>
       <fieldset class="cc-modal-fieldset">
         <legend class="cc-modal-fieldset-legend">
-          <span v-for="(segment, i) in response.meta?.title" :key="i">
-            {{ formatSegmentCustom(segment) }}
-          </span>
+          <!-- Render title if available -->
+          <template v-if="response.meta?.title">
+            <span v-for="(segment, i) in response.meta?.title" :key="i">
+              {{ formatSegmentCustom(segment) }}
+            </span>
+          </template>
+          <!-- Otherwise show "Untitled Action" -->
+          <template v-else>
+            Untitled Action
+          </template>
         </legend>
 
         <!-- Origin -->
@@ -130,9 +137,16 @@ function addSignPrefixToNumber(value: number | bigint): string {
         <hr style="margin-top:1em; margin-bottom: 1em" />
 
         <div class="wrapping-pre" style="font-size: medium;">
-          <template v-for="(segment, i) in response.meta?.description" :key="i">
-            <span v-if="typeof segment === 'string'">{{ segment }}</span>
-            <span v-else class="green" style="font-weight:bold">{{ formatSegmentCustom(segment) }}</span>
+          <!-- Render Description if available -->
+          <template v-if="response.meta?.description">
+            <template v-for="(segment, i) in response.meta?.description" :key="i">
+              <span v-if="typeof segment === 'string'">{{ segment }}</span>
+              <span v-else class="green" style="font-weight:bold">{{ formatSegmentCustom(segment) }}</span>
+            </template>
+          </template>
+          <!-- Otherwise show "No description available" -->
+          <template v-else>
+            No description available.
           </template>
         </div>
 

--- a/src/components/cashconnect/CCSessionProposalDialog.vue
+++ b/src/components/cashconnect/CCSessionProposalDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useQuasar, useDialogPluginComponent } from 'quasar'
-import type { BchSessionProposal } from '@cashconnect-js/core';
+import type { SessionProposalResponse } from '@cashconnect-js/nostr';
 
 import { useStore } from 'src/stores/store';
 import { useSettingsStore } from 'src/stores/settingsStore';
@@ -18,7 +18,7 @@ const store = useStore();
 const settingsStore = useSettingsStore();
 
 const props = defineProps<{
-  session: BchSessionProposal<true>
+  session: SessionProposalResponse
 }>()
 
 defineEmits([
@@ -31,7 +31,7 @@ function viewTemplate() {
   $q.dialog({
     component: CCViewTemplateDialog,
     componentProps: {
-      template: props.session.params.sessionProperties.template,
+      template: props.session.template,
     },
   });
 }
@@ -95,9 +95,8 @@ async function fetchAndSetTokenInfo(tokenId: string) {
   }
 }
 
-const peerMetadata = props.session.params.proposer.metadata;
-const safeUrl = sanitizeUrl(peerMetadata.url);
-const allowedTokens = props.session.params.sessionProperties.allowedTokens ?? [];
+const safeUrl = sanitizeUrl(props.session.dapp.url);
+const allowedTokens = props.session.allowedTokens ?? [];
 
 // fire-and-forget promises
 for (const tokenId of allowedTokens) {
@@ -116,17 +115,17 @@ for (const tokenId of allowedTokens) {
           <div style="display: flex; align-items: center; flex-direction: row; gap: 10px; padding: 7px;">
             <!-- App Icon -->
             <div style="display: flex; align-items: center; height: 64px; width: 64px;">
-              <q-img :src="peerMetadata.icons[0]" />
+              <q-img :src="props.session.dapp.icon" />
             </div>
 
             <!-- Metadata -->
             <div style="display: flex; flex-direction: column; width: 100%;">
-              <div>{{ peerMetadata.name }}</div>
+              <div>{{ props.session.dapp.name }}</div>
               <div>
-                <a v-if="safeUrl" :href="safeUrl" target="_blank">{{ peerMetadata.url }}</a>
+                <a v-if="safeUrl" :href="safeUrl" target="_blank">{{ props.session.dapp.url }}</a>
                 <span v-else style="color: var(--color-error);">{{ t('common.unsafeUrl') }}</span>
               </div>
-              <div>{{ peerMetadata.description }}</div>
+              <div>{{ props.session.dapp.description }}</div>
             </div>
           </div>
 
@@ -135,14 +134,14 @@ for (const tokenId of allowedTokens) {
             <!-- Template -->
             <div class="cc-modal-section">
               <div class="cc-modal-heading">{{ t('cashConnect.sessionProposal.template') }}</div>
-              <a @click="viewTemplate()" class="cursor-pointer">{{ session.params.sessionProperties.template.name }}</a> {{ t('cashConnect.sessionProposal.untrusted') }}
+              <a @click="viewTemplate()" class="cursor-pointer">{{ session.template.name }}</a> {{ t('cashConnect.sessionProposal.untrusted') }}
             </div>
 
             <!-- Allowed Tokens -->
             <div class="cc-modal-section">
               <div class="cc-modal-heading">{{ t('cashConnect.sessionProposal.willSeeTokens') }}</div>
               <ul>
-                <li v-for="(allowedToken, i) of session.params.sessionProperties.allowedTokens" :key="i" class="q-mb-xs">
+                <li v-for="(allowedToken, i) of session.allowedTokens" :key="i" class="q-mb-xs">
                   <q-avatar size="18px" class="q-mr-xs">
                     <q-img :src="getTokenIcon(allowedToken)" />
                   </q-avatar>
@@ -158,8 +157,8 @@ for (const tokenId of allowedTokens) {
             <div class="cc-modal-section">
               <div class="cc-modal-heading">{{ t('cashConnect.sessionProposal.willInvokeMethods') }}</div>
               <ul>
-                <li v-for="(method, i) of session.params.optionalNamespaces?.bch?.methods" :key="i">{{ method }}</li>
-                <li v-for="(event, i) of session.params.optionalNamespaces?.bch?.events" :key="i">{{ event }}</li>
+                <li v-for="(method, i) of session.methods" :key="i">{{ method }}</li>
+                <li v-for="(event, i) of session.events" :key="i">{{ event }}</li>
               </ul>
             </div>
           </div>

--- a/src/components/cashconnect/CCSessions.vue
+++ b/src/components/cashconnect/CCSessions.vue
@@ -43,14 +43,14 @@
         <!-- Iterate over active sessions -->
         <template v-for="(session, topic) of cashconnectStore.sessions" :key="topic">
           <div class="cc-session-item">
-            <div class="cc-session-item-app-icon"><img :src="session.peer.metadata.icons[0] ?? ''" /></div>
+            <div class="cc-session-item-app-icon"><img :src="session.dapp.icon ?? ''" /></div>
             <div class="cc-session-item-details-container">
-              <div>{{ session.peer.metadata.name }}</div>
+              <div>{{ session.dapp.name }}</div>
               <div>
-                <a v-if="sanitizeUrl(session.peer.metadata.url)" :href="sanitizeUrl(session.peer.metadata.url)" target="_blank">{{ session.peer.metadata.url }}</a>
+                <a v-if="sanitizeUrl(session.dapp.url)" :href="sanitizeUrl(session.dapp.url)" target="_blank">{{ session.dapp.url }}</a>
                 <span v-else style="color: var(--color-error);">{{ t('common.unsafeUrl') }}</span>
               </div>
-              <div>{{ session.peer.metadata.description }}</div>
+              <div>{{ session.dapp.description }}</div>
             </div>
             <div class="cc-session-item-action-container">
               <div class="cc-session-item-action-icon" @click="cashconnectStore.disconnectSession(topic)">

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -76,8 +76,8 @@
         await walletconnectRef.value?.connectDappUriInput(dappUri);
       }
 
-      // Otherwise, if the URI begins with "cc:" (cashconnect)...
-      else if (dappUri.startsWith('cc:')) {
+      // Otherwise, if the URI begins with "bch-cc-v1:" (cashconnect v1)...
+      else if (dappUri.startsWith('bch-cc-v1:')) {
         await cashconnectRef.value?.connectDappUriInput(dappUri);
       }
 

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -52,7 +52,7 @@
         console.error("Error pairing URI:", error);
       }
     }
-    if(props.dappUriUrlParam?.startsWith('cc:')){
+    if(props.dappUriUrlParam?.startsWith('bch-cc-v1:')){
       const { isWcAndCcInitialized } = storeToRefs(store);
       await waitForInitialized(isWcAndCcInitialized);
       await cashconnectStore?.pair(props.dappUriUrlParam);
@@ -104,7 +104,7 @@
   }
   const qrFilter = (content: string) => {
     const matchWalletConnect = String(content).match(/^wc:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
-    const matchCashConnect = String(content).match(/^cc:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
+    const matchCashConnect = String(content).match(/^bch-cc-v1:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
 
     if (!matchWalletConnect && !matchCashConnect) {
       return t('dapp.errors.notValidUri');

--- a/src/components/connectDapp.vue
+++ b/src/components/connectDapp.vue
@@ -8,6 +8,7 @@
   import { useCashconnectStore } from 'src/stores/cashconnectStore';
   import { waitForInitialized } from 'src/utils/utils'
   import QrCodeDialog from './qr/qrCodeScanDialog.vue';
+  import { PROTOCOL_HANDLER as CASHCONNECT_PROTOCOL_HANDLER } from '@cashconnect-js/nostr';
 
   // Components.
   import WCSessions from 'src/components/walletconnect/WCSessions.vue'
@@ -52,10 +53,21 @@
         console.error("Error pairing URI:", error);
       }
     }
-    if(props.dappUriUrlParam?.startsWith('bch-cc-v1:')){
-      const { isWcAndCcInitialized } = storeToRefs(store);
-      await waitForInitialized(isWcAndCcInitialized);
-      await cashconnectStore?.pair(props.dappUriUrlParam);
+    if(props.dappUriUrlParam?.startsWith(CASHCONNECT_PROTOCOL_HANDLER)){
+      // NOTE: This
+      try {
+        const { isWcAndCcInitialized } = storeToRefs(store);
+        await waitForInitialized(isWcAndCcInitialized);
+        await cashconnectStore?.pair(props.dappUriUrlParam);
+      } catch(error) {
+        const errorMessage = caughtErrorToString(error);
+        console.error(errorMessage);
+        $q.notify({
+          message: errorMessage,
+          icon: 'warning',
+          color: 'negative'
+        });
+      }
     }
   }
   // Check for dappUriUrlParam on component mount and watch for changes.
@@ -77,7 +89,7 @@
       }
 
       // Otherwise, if the URI begins with "bch-cc-v1:" (cashconnect v1)...
-      else if (dappUri.startsWith('bch-cc-v1:')) {
+      else if (dappUri.startsWith(CASHCONNECT_PROTOCOL_HANDLER)) {
         await cashconnectRef.value?.connectDappUriInput(dappUri);
       }
 
@@ -104,7 +116,7 @@
   }
   const qrFilter = (content: string) => {
     const matchWalletConnect = String(content).match(/^wc:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
-    const matchCashConnect = String(content).match(/^bch-cc-v1:([0-9a-fA-F]{64})@(\d+)\?([a-zA-Z0-9\-._~%!$&'()*+,;=:@/?=&]*)$/i);
+    const matchCashConnect = content.startsWith(CASHCONNECT_PROTOCOL_HANDLER);
 
     if (!matchWalletConnect && !matchCashConnect) {
       return t('dapp.errors.notValidUri');

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -719,7 +719,6 @@
       "notStarted": "CashConnect is not started.",
       "privateKeyNotFound": "Private key could not be found for address: {address}",
       "failedToConvertCashAddr": "Failed to convert CashAddr to Locking Bytecode",
-      "invalidDerivationPath": "Invalid derivation path for CashConnect: expected at least 4 components, got {length}.",
       "failedToDeriveHdNode": "Failed to derive HDNode from seed",
       "walletTypeNotSupported": "WalletType not supported: Must be a Single Address Wallet or HDWallet."
     }

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { ref, shallowRef } from "vue";
 import { defineStore } from "pinia";
 import { Dialog, Notify } from "quasar";
 
@@ -14,7 +14,7 @@ import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
 import {
   type SpendableUTXO,
-} from "@cashconnect-js/core";
+} from "@cashconnect-js/core/templates";
 import {
   type ExecuteActionRequest,
   type ExecuteActionResponse,
@@ -51,7 +51,7 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
   // NOTE: This reactive state is synced with CashConnect via the onSessionsUpdated hook.
   const sessions = ref<Record<string, WalletSession>>({});
   // The CashConnect Wallet instance.
-  const cashConnectWallet = ref<Wallet | undefined>();
+  const cashConnectWallet = shallowRef<Wallet | undefined>();
   async function start() {
     // Make sure we don't start CC more than once.
     // Otherwise, we'll register multiple handlers and end up with multiple dialogs.
@@ -98,12 +98,8 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     if(!cashConnectWallet.value) {
       throw new Error(t('cashConnect.notifications.notStarted'));
     }
-    try {
-      // Pair with the service.
-      await cashConnectWallet.value.pair(wcUri);
-    } catch (error) {
-      console.error(error);
-    }
+    // Pair with the service.
+    await cashConnectWallet.value.pair(wcUri);
   }
   async function disconnectSession(topicId: string) {
     if(!cashConnectWallet.value) {
@@ -125,12 +121,13 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     //       So we use the networkPrefix property to determine which chain we are currently on.
     const currentChain = mainStore.wallet.networkPrefix;
     const targetChain = proposal.chain;
-    // Cashonize expects network to be either mainnet or chipnet.
+    // Cashonize uses an LibAuth's CashAddressNetworkPrefix enum, so we have to cast the value (strings/enums cannot be compared directly).
     const targetChainCashonizeFormat: CashAddressNetworkPrefix = targetChain === "bitcoincash" ? CashAddressNetworkPrefix.mainnet : CashAddressNetworkPrefix.testnet;
     // Check if the current chain is the target chain.
     if (currentChain !== targetChainCashonizeFormat) {
+      // Cashonize UI uses "Mainnet" and "Chipnet" to identify networks.
       throw new Error(
-        t('cashConnect.notifications.networkMismatch', { network: targetChainCashonizeFormat })
+        t('cashConnect.notifications.networkMismatch', { network: (targetChain === 'bitcoincash') ? 'Mainnet' : 'Chipnet' })
       );
     }
     return await new Promise<SessionCreateRequest>((resolve, reject) => {

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -77,7 +77,7 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
       },
     });
 
-    // Start CashConnect (WC Core) service.
+    // Start CashConnect service.
     await cashConnectWallet.value.start();
   }
   async function stop() {

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -91,8 +91,8 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     //       And the `start()` call thinks that the existing instance still exists.
     const cashConnectPrevInstance = cashConnectWallet.value;
     cashConnectWallet.value = undefined;
-    // Disconnect all sessions and stop the previous instance.
-    await cashConnectPrevInstance.disconnectAllSessions();
+    // Stop the CashConnect Wallet service.
+    await cashConnectPrevInstance.stop();
   }
   async function pair(wcUri: string) {
     if(!cashConnectWallet.value) {

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -24,6 +24,8 @@ import {
 import {
   type WalletSession,
   Wallet,
+  derivationPathToCashConnectPath,
+  doesActionRequireApproval,
 } from "@cashconnect-js/nostr/wallet";
 
 // Import Libauth.
@@ -61,7 +63,6 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     // Instantiate CashConnect.
     cashConnectWallet.value = new Wallet({
       cashConnectPrivateKey: cashConnectPrivateKey,
-      relayUrl: 'wss://nos.lol',
       eventCallbacks: {
         onSessionsUpdated,
         onSessionProposal,
@@ -162,7 +163,7 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     response: ExecuteActionResponse,
     cancelled: AbortSignal
   ): Promise<void> {
-    // If this is not a request that DOES NOT require approval...
+    // If this is a request that DOES NOT require approval...
     if (!doesActionRequireApproval(session, request.action)) {
       return;
     }
@@ -207,15 +208,6 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
         },
       }).onDismiss(resolve);
     });
-  }
-  function doesActionRequireApproval(session: WalletSession, actionName: string) {
-    // Get the action being executed from the session:template.
-    const action = session.template.actions[actionName];
-    // Check to see if it contains any instructions that should require approval.
-    // NOTE: Currently, only actions involving transactions require approval.
-    //       In future once we have auditing infrastructure, wallets can define their own policies.
-    //       For example, if a given template is unaudited, all actions could be set to require approval.
-    return action?.instructions?.some((instruction) => instruction.type === 'transaction');
   }
   //-----------------------------------------------------------------------------
   // Network/Wallet Hooks
@@ -368,17 +360,6 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
         console.error('Failed to reconnect:', error);
       }
     }
-  }
-  function derivationPathToCashConnectPath(derivationPath: string, purpose = 5001) {
-      // Replace the "purpose" in the derivation path with "5001" (CashConnect).
-      const parts = derivationPath.split('/');
-      if (parts.length < 4) {
-          throw new Error(
-            t('cashConnect.notifications.invalidDerivationPath', { length: parts.length })
-          )
-      }
-      parts[1] = `${purpose}'`;
-      return parts.join('/');
   }
   function getCashConnectPrivateKeyForWallet(wallet: WalletType) {
     // If this is a single address (WIF) wallet, we just use the WIF's Private Key.

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -8,25 +8,28 @@ import CCExecuteActionDialogVue from "src/components/cashconnect/CCExecuteAction
 import CCErrorDialogVue from "src/components/cashconnect/CCErrorDialog.vue";
 
 // Import MainnetJs and CashConnect
-import { convert } from "mainnet-js";
 import type { WalletType } from "src/interfaces/interfaces"
 import { useStore } from "./store"
 import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
 import {
-  type BchSession,
-  type BchSessionProposal,
-  type Payloads,
   type SpendableUTXO,
-  type WalletProperties,
 } from "@cashconnect-js/core";
 import {
-  CashConnectWallet,
-} from "@cashconnect-js/wallet";
+  type ExecuteActionRequest,
+  type ExecuteActionResponse,
+  type SessionProposalResponse,
+  type SessionCreateRequest,
+} from '@cashconnect-js/nostr';
+import {
+  type WalletSession,
+  Wallet,
+} from "@cashconnect-js/nostr/wallet";
 
 // Import Libauth.
 import {
   type Output,
+  CashAddressNetworkPrefix,
   binToHex,
   hexToBin,
   cashAddressToLockingBytecode,
@@ -36,10 +39,7 @@ import {
   walletTemplateP2pkhNonHd,
   walletTemplateToCompilerBch,
 } from "@bitauth/libauth";
-import { useSettingsStore } from 'src/stores/settingsStore';
 import { type ElectrumRawTransactionVout } from "src/interfaces/interfaces";
-import { walletConnectProjectId, walletConnectMetadata } from "./constants";
-const settingsStore = useSettingsStore()
 
 export const useCashconnectStore = defineStore("cashconnectStore", () => {
   // Accesses the wallet reactively via cross-store ref (mainStore.wallet) inside defineStore setup,
@@ -47,43 +47,35 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
   const mainStore = useStore();
   // List of CashConnect sessions.
   // NOTE: This reactive state is synced with CashConnect via the onSessionsUpdated hook.
-  const sessions = ref<Record<string, BchSession>>({});
+  const sessions = ref<Record<string, WalletSession>>({});
   // The CashConnect Wallet instance.
-  const cashConnectWallet = ref<CashConnectWallet | undefined>();
+  const cashConnectWallet = ref<Wallet | undefined>();
   async function start() {
     // Make sure we don't start CC more than once.
     // Otherwise, we'll register multiple handlers and end up with multiple dialogs.
     if (cashConnectWallet.value) {
       return;
     }
-    // Get the Master Private Key to use for CashConnect.
-    const masterPrivateKey = getMasterPrivateKeyForWallet(mainStore.wallet as WalletType);
+    // Get the Private Key to use for CashConnect.
+    const cashConnectPrivateKey = getCashConnectPrivateKeyForWallet(mainStore.wallet as WalletType);
     // Instantiate CashConnect.
-    cashConnectWallet.value = new CashConnectWallet(
-      // The master private key for use with CashConnect.
-      masterPrivateKey,
-      // Project ID.
-      walletConnectProjectId,
-      // Metadata.
-      walletConnectMetadata,
-      // Event Callbacks.
-      {
-        // Session State Callbacks.
+    cashConnectWallet.value = new Wallet({
+      cashConnectPrivateKey: cashConnectPrivateKey,
+      relayUrl: 'wss://nos.lol',
+      eventCallbacks: {
         onSessionsUpdated,
         onSessionProposal,
         onSessionDelete,
-        onRPCRequest,
+        onExecuteAction,
         onError,
       },
-      // Execution Context Data.
-      {
-        // Blockchain.
+      contextCallbacks: {
         getSourceOutput,
-        // Wallet.
         getSpendableUTXOs,
         getChangeTemplateDirective,
-      }
-    )
+      },
+    });
+
     // Start CashConnect (WC Core) service.
     await cashConnectWallet.value.start();
   }
@@ -98,8 +90,6 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
     //       And the `start()` call thinks that the existing instance still exists.
     const cashConnectPrevInstance = cashConnectWallet.value;
     cashConnectWallet.value = undefined;
-    // Stop the previous instance.
-    await cashConnectPrevInstance.stop();
     // Disconnect all sessions and stop the previous instance.
     await cashConnectPrevInstance.disconnectAllSessions();
   }
@@ -124,39 +114,35 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
   // Session Hooks
   //-----------------------------------------------------------------------------
   function onSessionsUpdated(
-    updatedSessions: Record<string, BchSession>
+    updatedSessions: Record<string, WalletSession>
   ) {
     sessions.value = updatedSessions;
   }
-  async function onSessionProposal(sessionProposal: BchSessionProposal) {
+  async function onSessionProposal(proposal: SessionProposalResponse): Promise<SessionCreateRequest> {
     // Check the network and prompt user to switch if incorrect.
     // NOTE: The walletClass.network property appears to return quirky values (e.g. undefined).
     //       So we use the networkPrefix property to determine which chain we are currently on.
     const currentChain = mainStore.wallet.networkPrefix;
-    const targetChain =
-      sessionProposal.params.optionalNamespaces?.bch?.chains?.[0]?.replace(
-        "bch:",
-        ""
-      );
+    const targetChain = proposal.chain;
     // Cashonize expects network to be either mainnet or chipnet.
-    const targetChainCashonizeFormat = targetChain === "bitcoincash" ? "mainnet" : "chipnet";
+    const targetChainCashonizeFormat: CashAddressNetworkPrefix = targetChain === "bitcoincash" ? CashAddressNetworkPrefix.mainnet : CashAddressNetworkPrefix.testnet;
     // Check if the current chain is the target chain.
-    if (currentChain !== targetChain) {
+    if (currentChain !== targetChainCashonizeFormat) {
       throw new Error(
         t('cashConnect.notifications.networkMismatch', { network: targetChainCashonizeFormat })
       );
     }
-    return await new Promise<WalletProperties>((resolve, reject) => {
+    return await new Promise<SessionCreateRequest>((resolve, reject) => {
       Dialog.create({
         component: CCSessionProposalDialogVue,
         componentProps: {
-          session: sessionProposal,
+          session: proposal,
         },
       })
         .onOk(() => {
           resolve({
-            // NOTE: This is kept for future compatibility and will indicate to Client/Dapp which prompts can be backgrounded.
-            autoApprove: [],
+            // NOTE: Not currently used.
+            allowedTokens: proposal.allowedTokens,
           });
           Notify.create({
             color: "positive",
@@ -167,53 +153,50 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
         .onDismiss(reject);
     });
   }
-  function onSessionDelete() {
-    console.log("Session deleted");
+  function onSessionDelete(dappPubkey: string) {
+    console.log("Session deleted", dappPubkey);
   }
-  async function onRPCRequest(
-    session: BchSession,
-    request: Payloads["request"],
-    response: Payloads["response"]
+  async function onExecuteAction(
+    session: WalletSession,
+    request: ExecuteActionRequest,
+    response: ExecuteActionResponse,
+    cancelled: AbortSignal
   ): Promise<void> {
-    if(request.method === 'executeAction') {
-      // If this is not a request that DOES NOT require approval...
-      if (!doesActionRequireApproval(session, request.params.action)) {
-        return;
-      }
-      // Get the BCH exchange rate, falling back to the last known rate. Without any rate we
-      // can't display the fiat impact, so reject the request instead of showing the dialog.
-      let exchangeRate: number | undefined;
-      try {
-        exchangeRate = await convert(1, "bch", settingsStore.currency);
-      } catch {
-        exchangeRate = mainStore.exchangeRate;
-      }
-      if (exchangeRate === undefined) {
-        Notify.create({ color: "negative", message: t('common.errors.exchangeRateUnavailable') });
-        throw new Error(t('common.errors.exchangeRateUnavailable'));
-      }
-      // Show a dialog, prompting the user for approval.
-      return await new Promise<void>((resolve, reject) => {
-        Dialog.create({
-          component: CCExecuteActionDialogVue,
-          componentProps: {
-            session,
-            request: request.params,
-            response,
-            exchangeRate
-          },
-        })
-          .onOk(() => {
-            resolve();
-            Notify.create({
-              color: "positive",
-              message: t('cashConnect.notifications.successfullySignedTransaction'),
-            });
-          })
-        .onCancel(reject)
-        .onDismiss(reject);
-      });
+    // If this is not a request that DOES NOT require approval...
+    if (!doesActionRequireApproval(session, request.action)) {
+      return;
     }
+
+    // Show a dialog, prompting the user for approval.
+    return await new Promise<void>((resolve, reject) => {
+      const dialog = Dialog.create({
+        component: CCExecuteActionDialogVue,
+        componentProps: {
+          session,
+          request,
+          response,
+        },
+      })
+        .onOk(() => {
+          resolve();
+          Notify.create({
+            color: "positive",
+            message: t('cashConnect.notifications.successfullySignedTransaction'),
+          });
+        })
+        .onCancel(() => {
+          reject(new Error('User cancelled'));
+        })
+        .onDismiss(() => {
+          reject(new Error('User dismissed'));
+        });
+
+      // If request is cancelled on the Dapp, hide the dialog.
+      cancelled.addEventListener('abort', () => {
+        dialog.hide();
+        reject(new Error(typeof cancelled.reason === 'string' ? cancelled.reason : 'Dapp cancelled the request'));
+      });
+    });
   }
   async function onError(error: Error): Promise<void> {
     return await new Promise<void>((resolve) => {
@@ -225,9 +208,9 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
       }).onDismiss(resolve);
     });
   }
-  function doesActionRequireApproval(session: BchSession, actionName: string) {
+  function doesActionRequireApproval(session: WalletSession, actionName: string) {
     // Get the action being executed from the session:template.
-    const action = session.sessionProperties.template.actions[actionName];
+    const action = session.template.actions[actionName];
     // Check to see if it contains any instructions that should require approval.
     // NOTE: Currently, only actions involving transactions require approval.
     //       In future once we have auditing infrastructure, wallets can define their own policies.
@@ -397,7 +380,7 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
       parts[1] = `${purpose}'`;
       return parts.join('/');
   }
-  function getMasterPrivateKeyForWallet(wallet: WalletType) {
+  function getCashConnectPrivateKeyForWallet(wallet: WalletType) {
     // If this is a single address (WIF) wallet, we just use the WIF's Private Key.
     if('privateKey' in wallet) {
       return wallet.privateKey;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -645,12 +645,12 @@ export const useStore = defineStore('store', () => {
       // Monitor the wallet for balance changes and notify CashConnect to refresh wallet state.
       cancelWatchBchBalanceCashConnect = await wallet.value.watchBalance(() => {
         // Convert the network into WC format,
-        const chainIdFormatted = wallet.value.network === NetworkType.Mainnet ? 'bch:bitcoincash' : 'bch:bchtest';
+        // const chainIdFormatted = wallet.value.network === NetworkType.Mainnet ? 'bch:bitcoincash' : 'bch:bchtest';
 
         // Invoke wallet state has changed so that CashConnect can retrieve fresh UTXOs (and token balances).
         // fire-and-forget promise
         if(cashconnectWallet.cashConnectWallet) {
-          void cashconnectWallet.cashConnectWallet.walletStateHasChanged(chainIdFormatted);
+          void cashconnectWallet.cashConnectWallet.notifyBalancesChanged();
         }
       });
     } catch (error) {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -644,9 +644,6 @@ export const useStore = defineStore('store', () => {
 
       // Monitor the wallet for balance changes and notify CashConnect to refresh wallet state.
       cancelWatchBchBalanceCashConnect = await wallet.value.watchBalance(() => {
-        // Convert the network into WC format,
-        // const chainIdFormatted = wallet.value.network === NetworkType.Mainnet ? 'bch:bitcoincash' : 'bch:bchtest';
-
         // Invoke wallet state has changed so that CashConnect can retrieve fresh UTXOs (and token balances).
         // fire-and-forget promise
         if(cashconnectWallet.cashConnectWallet) {


### PR DESCRIPTION
This MR implements the new CashConnect Nostr Transport.

Changes:

1. Adapted existing hooks to new CashConnect format.
2. Renamed properties for new CashConnect typing (simpler/less-nested than previous WalletConnect typings).
3. Exchange Rate made more robust (if exchange rate not available, simply does not show in UI).
4. External dependencies now trimmed to just `@bitauth/libauth` and `zod`. `@cashconnect-js` packages weigh in at ~104KB currently (but will grow slightly). WalletConnect bloat removed as dependency (advise WalletConnect implementations switch to WizardConnect which looks like a near drop-in replacement).
5. Minor other simplifications/fixes.

NOTE: There will likely be another MR within the next few weeks that improves robustness of the underlying Nostr Transport. Changes to Cashonize will likely be minimal (likely just a package version bump).