### PR TITLE
add cashconnect e2e tests over the nostr transport

### DIFF
--- a/test/e2e/cashconnect.test.ts
+++ b/test/e2e/cashconnect.test.ts
@@ -1,0 +1,181 @@
+// CashConnect (Nostr transport) E2E tests for Cashonize Wallet.
+// If a seed phrase is provided in the E2E_SEED_PHRASE environment variable or top level .env file,
+// the test will import that wallet. Otherwise a new wallet will be created; the transaction
+// (approval-dialog) tests require a funded chipnet wallet and are skipped without a seed phrase.
+//
+// Both sides talk over the library's default public Nostr relay: Cashonize passes no relayUrl to
+// its CashConnect Wallet, and Wallet.pair() rejects invites whose relay differs from its own, so
+// the test dapp must simply use the same default (it omits relayUrl too).
+
+import { test, expect, type Page } from '@playwright/test'
+import { DAPP_URL, SEED_PHRASE, waitForDialog, setupWalletOnChipnet } from './helpers'
+
+let walletPage: Page
+let dappPage: Page
+// The wallet's own deposit address — the send tests pay back to the wallet itself so
+// no funds leave the test wallet even if a transaction is broadcast later.
+let walletAddress: string
+
+// Paste the current invite URI from the dapp into the wallet's URI input and click Connect.
+async function pairFromDapp() {
+  await expect(dappPage.locator('#cc-pairing-uri')).toContainText('bch-cc-v1:', { timeout: 15_000 })
+  const uri = await dappPage.textContent('#cc-pairing-uri')
+
+  await walletPage.getByPlaceholder('Wallet Connect URI').fill(uri!)
+  await walletPage.locator('input.primaryButton[value*="Connect"]').click()
+}
+
+test.describe.serial('CashConnect E2E', () => {
+  test.beforeAll(async ({ browser }) => {
+    const walletContext = await browser.newContext()
+    const dappContext = await browser.newContext()
+    walletPage = await walletContext.newPage()
+    dappPage = await dappContext.newPage()
+
+    // Set up wallet via onboarding and switch to chipnet
+    await setupWalletOnChipnet(walletPage)
+
+    // Read the wallet's deposit address from the wallet tab (used as send recipient)
+    walletAddress = (await walletPage.locator('.depositAddr').first().textContent() ?? '').trim()
+    expect(walletAddress).toContain('bchtest:')
+
+    // Navigate to WalletConnect tab (hosts the shared URI input and the CashConnect sessions list)
+    await walletPage.locator('nav').getByText('WalletConnect').click()
+    await walletPage.getByText('Connect to Dapp').waitFor({ timeout: 15_000 })
+
+    // Open test dApp
+    await dappPage.goto(DAPP_URL)
+    await dappPage.locator('#cc-btn-connect:not([disabled])').waitFor({ timeout: 15_000 })
+  })
+
+  test.afterAll(async () => {
+    await walletPage?.context().close()
+    await dappPage?.context().close()
+  })
+
+  test('network mismatch — no session proposal shown', async () => {
+    // dApp: request a mainnet session while the wallet is on chipnet
+    await dappPage.check('#cc-radio-mainnet')
+    await dappPage.click('#cc-btn-connect')
+    await pairFromDapp()
+
+    // Wallet: rejects the proposal before any dialog — pair() rethrows the mismatch
+    // error and the sessions component surfaces it as an error notification.
+    await expect(walletPage.locator('.q-notification').getByText(/requires wallet to be on Mainnet/))
+      .toBeVisible({ timeout: 15_000 })
+    await expect(walletPage.locator('.q-dialog:visible')).toHaveCount(0)
+
+    // dApp: pairing is left pending — a rejected proposal is not signalled to the dapp
+    await expect(dappPage.locator('#cc-session-status')).toHaveText('pairing')
+
+    // Reset for the next test
+    await dappPage.check('#cc-radio-chipnet')
+  })
+
+  test('connect', async () => {
+    // dApp: Connect on chipnet (abandons the mismatched pairing attempt)
+    await dappPage.click('#cc-btn-connect')
+    await pairFromDapp()
+
+    // Wallet: Approve session proposal (shows dapp metadata and template name)
+    const proposalDialog = await waitForDialog(walletPage)
+    await expect(proposalDialog).toContainText('BCH CC Test dApp')
+    await expect(proposalDialog).toContainText('Cashonize E2E Test Template')
+    await proposalDialog.getByRole('button', { name: 'Approve' }).click()
+
+    // dApp: Assert connected
+    await expect(dappPage.locator('#cc-session-status')).toHaveText('connected', { timeout: 20_000 })
+
+    // Wallet: Session appears in the CashConnect sessions list
+    await expect(walletPage
+      .locator('fieldset:has(legend:has-text("CashConnect"))').getByText('BCH CC Test dApp'))
+      .toBeVisible({ timeout: 15_000 })
+  })
+
+  test('executeAction — resolve action auto-responds without a dialog', async () => {
+    await dappPage.click('#cc-btn-ping')
+
+    // Resolve-only actions don't require approval, so no dialog opens in the wallet
+    await expect(dappPage.locator('#cc-response')).toContainText('echoed', { timeout: 15_000 })
+    await expect(dappPage.locator('#cc-response')).not.toContainText('error')
+    await expect(walletPage.locator('.q-dialog:visible')).toHaveCount(0)
+  })
+
+  test('getBalances and getTokens auto-respond', async () => {
+    await dappPage.click('#cc-btn-get-balances')
+    await expect(dappPage.locator('#cc-response')).toContainText('balances', { timeout: 15_000 })
+    await expect(dappPage.locator('#cc-response')).not.toContainText('error')
+
+    await dappPage.click('#cc-btn-get-tokens')
+    await expect(dappPage.locator('#cc-response')).toContainText('tokens', { timeout: 15_000 })
+    await expect(dappPage.locator('#cc-response')).not.toContainText('error')
+  })
+
+  test('executeAction — transaction, approve', async () => {
+    test.skip(!SEED_PHRASE, 'requires a funded chipnet wallet (E2E_SEED_PHRASE)')
+
+    // dApp: Execute the send action, paying 1000 sats back to the wallet itself
+    await dappPage.fill('#cc-input-address', walletAddress)
+    await dappPage.click('#cc-btn-send')
+
+    // Wallet: Approval dialog renders the action's meta segments
+    const txDialog = await waitForDialog(walletPage, 30_000)
+    await expect(txDialog).toContainText('Send')
+    await expect(txDialog).toContainText('Balance Change')
+    await txDialog.getByRole('button', { name: 'Approve' }).click()
+
+    // dApp: Response contains the signed transaction(s). The dapp is responsible for
+    // broadcasting in CashConnect; the test does not broadcast, keeping UTXOs stable.
+    await expect(dappPage.locator('#cc-response')).toContainText('txHash', { timeout: 15_000 })
+    await expect(dappPage.locator('#cc-response')).toContainText('transactions')
+
+    // Wallet: Success notification
+    await expect(walletPage.locator('.q-notification').getByText('Successfully signed transaction'))
+      .toBeVisible({ timeout: 5_000 })
+  })
+
+  test('executeAction — transaction, reject', async () => {
+    test.skip(!SEED_PHRASE, 'requires a funded chipnet wallet (E2E_SEED_PHRASE)')
+
+    await dappPage.fill('#cc-input-address', walletAddress)
+    await dappPage.click('#cc-btn-send')
+
+    // Wallet: Reject in the approval dialog
+    const txDialog = await waitForDialog(walletPage, 30_000)
+    await txDialog.getByRole('button', { name: 'Reject' }).click()
+
+    // dApp: Receives the wallet's rejection
+    await expect(dappPage.locator('#cc-response')).toContainText('error', { timeout: 15_000 })
+  })
+
+  test('executeAction — transaction, cancelled from the dapp', async () => {
+    test.skip(!SEED_PHRASE, 'requires a funded chipnet wallet (E2E_SEED_PHRASE)')
+
+    await dappPage.fill('#cc-input-address', walletAddress)
+    await dappPage.click('#cc-btn-send')
+
+    // Wallet: Wait for the approval dialog
+    const txDialog = await waitForDialog(walletPage, 30_000)
+
+    // dApp: Abort the request — the cancellation notification travels over Nostr
+    await dappPage.click('#cc-btn-cancel')
+
+    // Wallet: Dialog is dismissed by the request's abort signal
+    await expect(txDialog).not.toBeVisible({ timeout: 15_000 })
+
+    // dApp: Sees its own cancellation
+    await expect(dappPage.locator('#cc-response')).toContainText('cancelled', { timeout: 15_000 })
+  })
+
+  test('disconnect', async () => {
+    await dappPage.click('#cc-btn-disconnect')
+
+    // dApp: Assert disconnected
+    await expect(dappPage.locator('#cc-session-status')).toHaveText('disconnected', { timeout: 15_000 })
+
+    // Wallet: Assert no active CashConnect sessions
+    await expect(walletPage
+      .locator('fieldset:has(legend:has-text("CashConnect"))').getByText('No sessions currently active.'))
+      .toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -1,0 +1,52 @@
+// Shared helpers for the Cashonize E2E suites (walletconnect.test.ts, cashconnect.test.ts).
+
+import { expect, type Page } from '@playwright/test'
+
+export const CASHONIZE_URL = 'http://localhost:9000'
+export const DAPP_URL = 'http://localhost:5188'
+export const SEED_PHRASE = process.env.E2E_SEED_PHRASE
+
+// Resolve the currently-open Quasar dialog, scoped to the newest visible one, and wait
+// until it is shown. Dialogs animate in/out with a scale transition, so a closing dialog
+// and a freshly-opened one can briefly coexist in the DOM. A bare '.q-dialog' locator
+// resolves the first match — which may be the stale, detaching dialog — so a subsequent
+// click races its removal ("element was detached from the DOM, retrying"). Scoping to
+// ':visible' + last() targets the new dialog; the caller's click auto-waits for stability.
+export async function waitForDialog(page: Page, timeout = 15_000) {
+  const dialog = page.locator('.q-dialog:visible').last()
+  await dialog.waitFor({ state: 'visible', timeout })
+  return dialog
+}
+
+// Run the wallet onboarding (importing E2E_SEED_PHRASE when set, creating a fresh wallet
+// otherwise) and switch the wallet to chipnet. Leaves the wallet on the BchWallet tab.
+export async function setupWalletOnChipnet(walletPage: Page) {
+  await walletPage.goto(CASHONIZE_URL)
+
+  if (SEED_PHRASE) {
+    // Import funded wallet
+    await walletPage.getByRole('button', { name: 'Import wallet' }).click()
+
+    // Paste seed phrase — onWordInput distributes words across all 12 fields
+    const firstSeedInput = walletPage.locator('.seed-words-grid input').first()
+    await firstSeedInput.fill(SEED_PHRASE)
+    await firstSeedInput.dispatchEvent('input')
+
+    await walletPage.getByRole('button', { name: 'Import wallet' }).click()
+  } else {
+    // Create a new wallet (no funds)
+    await walletPage.getByRole('button', { name: 'Create new wallet' }).click()
+    await walletPage.getByRole('button', { name: 'Create wallet' }).click()
+  }
+
+  // Finish onboarding — wait for nav tabs to appear (wallet loaded)
+  await walletPage.getByRole('button', { name: 'Finish Setup' }).click()
+  await walletPage.locator('nav').waitFor({ timeout: 15_000 })
+
+  // Switch to chipnet: Settings → Developer settings → change network
+  await walletPage.locator('nav img[src*="settings"]').click()
+  await walletPage.getByText('Developer settings').click()
+  await walletPage.locator('select').first().selectOption('chipnet')
+  // Wait for network switch to complete. It resets the active view back to the wallet tab.
+  await expect(walletPage.locator('nav').getByText('BchWallet')).toHaveClass(/active/, { timeout: 15_000 })
+}

--- a/test/e2e/test-dapp/package.json
+++ b/test/e2e/test-dapp/package.json
@@ -8,6 +8,8 @@
     "start": "vite preview"
   },
   "dependencies": {
+    "@cashconnect-js/core": "1.0.0-alpha.31",
+    "@cashconnect-js/nostr": "1.0.0-alpha.31",
     "@walletconnect/sign-client": "2.23.9",
     "vue": "^3.5.35"
   },

--- a/test/e2e/test-dapp/pnpm-lock.yaml
+++ b/test/e2e/test-dapp/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
 
   .:
     dependencies:
+      '@cashconnect-js/core':
+        specifier: 1.0.0-alpha.31
+        version: 1.0.0-alpha.31
+      '@cashconnect-js/nostr':
+        specifier: 1.0.0-alpha.31
+        version: 1.0.0-alpha.31
       '@walletconnect/sign-client':
         specifier: 2.23.9
-        version: 2.23.9
+        version: 2.23.9(zod@4.4.3)
       vue:
         specifier: ^3.5.35
         version: 3.5.39
@@ -46,6 +52,16 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bitauth/libauth@3.1.0-next.8':
+    resolution: {integrity: sha512-Pm+Ju+YP3JeBLLTiVrBnia2wwE4G17r4XqpvPRMcklElJTe8J6x3JgKRg1by0Xm3ZY6UFxACkEAoSA+x419/zA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  '@cashconnect-js/core@1.0.0-alpha.31':
+    resolution: {integrity: sha512-pD0txUK0CAlec4K6KrT/YGgF+k6nEla3fFgWK/DD515yofIqZ0MD2OcSjhKLplCyXyxJ/cp61pVGHUz29f7Ggg==}
+
+  '@cashconnect-js/nostr@1.0.0-alpha.31':
+    resolution: {integrity: sha512-/BebQtgfXrWQyhVPF3gvCYq1SCTeKQABEMbvzKeSi0pVdPYvchMjaOCAM2B0vRlnDHMbmXoc5z47GBXHvPO22g==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -722,6 +738,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
@@ -738,6 +757,19 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bitauth/libauth@3.1.0-next.8': {}
+
+  '@cashconnect-js/core@1.0.0-alpha.31':
+    dependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+      zod: 4.4.3
+
+  '@cashconnect-js/nostr@1.0.0-alpha.31':
+    dependencies:
+      '@bitauth/libauth': 3.1.0-next.8
+      '@cashconnect-js/core': 1.0.0-alpha.31
+      zod: 4.4.3
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -915,7 +947,7 @@ snapshots:
 
   '@vue/shared@3.5.39': {}
 
-  '@walletconnect/core@2.23.9':
+  '@walletconnect/core@2.23.9(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -929,7 +961,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9
+      '@walletconnect/utils': 2.23.9(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -1047,16 +1079,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.9':
+  '@walletconnect/sign-client@2.23.9(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.23.9
+      '@walletconnect/core': 2.23.9(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9
+      '@walletconnect/utils': 2.23.9(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -1116,7 +1148,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/utils@2.23.9':
+  '@walletconnect/utils@2.23.9(zod@4.4.3)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
       '@noble/ciphers': 1.3.0
@@ -1135,7 +1167,7 @@ snapshots:
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1
       detect-browser: 5.3.0
-      ox: 0.9.3
+      ox: 0.9.3(zod@4.4.3)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -1169,7 +1201,9 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  abitype@1.2.4: {}
+  abitype@1.2.4(zod@4.4.3):
+    optionalDependencies:
+      zod: 4.4.3
 
   anymatch@3.1.3:
     dependencies:
@@ -1308,7 +1342,7 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
-  ox@0.9.3:
+  ox@0.9.3(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -1316,7 +1350,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.4
+      abitype: 1.2.4(zod@4.4.3)
       eventemitter3: 5.0.1
     transitivePeerDependencies:
       - zod
@@ -1450,3 +1484,5 @@ snapshots:
       '@vue/shared': 3.5.39
 
   ws@7.5.11: {}
+
+  zod@4.4.3: {}

--- a/test/e2e/test-dapp/pnpm-workspace.yaml
+++ b/test/e2e/test-dapp/pnpm-workspace.yaml
@@ -7,3 +7,7 @@ overrides:
 
 allowBuilds:
   esbuild: true
+
+minimumReleaseAgeExclude:
+  - '@cashconnect-js/core@1.0.0-alpha.31'
+  - '@cashconnect-js/nostr@1.0.0-alpha.31'

--- a/test/e2e/test-dapp/src/App.vue
+++ b/test/e2e/test-dapp/src/App.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, shallowRef } from 'vue'
 import SignClient from '@walletconnect/sign-client'
 import type { SessionTypes } from '@walletconnect/types'
+import CashConnect from './CashConnect.vue'
 
 const client = shallowRef<InstanceType<typeof SignClient> | null>(null)
 const session = shallowRef<SessionTypes.Struct | null>(null)
@@ -264,5 +265,7 @@ async function disconnect() {
       <label>Response:</label>
       <pre id="response" style="padding: 0.5rem; background: #f0f0f0; min-height: 2rem; white-space: pre-wrap; word-break: break-all;">{{ response }}</pre>
     </div>
+
+    <CashConnect />
   </div>
 </template>

--- a/test/e2e/test-dapp/src/CashConnect.vue
+++ b/test/e2e/test-dapp/src/CashConnect.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+import { ref, shallowRef, computed } from 'vue'
+import { Dapp } from '@cashconnect-js/nostr/dapp'
+import { MemoryStore } from '@cashconnect-js/nostr'
+import { Address, Bytes, encodeExtendedJson } from '@cashconnect-js/core/primitives'
+import type { Template } from '@cashconnect-js/core/templates'
+
+// Raw-JSON equivalent of the "Simple Send" template from the CashConnect tutorial
+// (https://cashconnect.developers.cash/docs/tutorials/1-first-template.html), plus a
+// resolve-only action. Written without the @cashconnect-js/templates-sdk helpers so the
+// test dapp only depends on the exact alpha versions pinned in the main app.
+const CC_TEMPLATE = {
+  name: 'Cashonize E2E Test Template',
+  description: 'Template for Cashonize CashConnect E2E tests',
+  actions: {
+    // Resolve-only action: does not contain a transaction instruction, so the wallet
+    // auto-responds without showing an approval dialog.
+    ping: {
+      params: {
+        someString: { name: 'Some String', type: 'string' },
+      },
+      instructions: [
+        {
+          type: 'resolve',
+          payload: {
+            echoed: '<someString>',
+            fixed: '<123>',
+          },
+        },
+      ],
+      returns: {
+        echoed: { name: 'Echoed String', type: 'string' },
+        fixed: { name: 'The number 123', type: 'number' },
+      },
+    },
+    // Transaction action: requires approval in the wallet and spends real wallet UTXOs.
+    send: {
+      meta: {
+        title: 'Send',
+        description: 'Send {{ <recipientSatsAmount> | satoshis }} to {{ <recipientLockingBytecode> | address }}',
+      },
+      params: {
+        recipientLockingBytecode: { name: 'Recipient Locking Bytecode', type: 'address' },
+        recipientSatsAmount: { name: 'Amount to send (Sats)', type: 'satoshis' },
+      },
+      instructions: [
+        {
+          type: 'transaction',
+          payload: {
+            name: 'tx',
+            version: 2,
+            locktime: 0,
+            // Use any available inputs from the parent wallet.
+            inputs: ['*'],
+            outputs: [
+              {
+                lockingBytecode: '<recipientLockingBytecode>',
+                valueSatoshis: '<recipientSatsAmount>',
+              },
+              // Append any change outputs to the parent wallet.
+              '*',
+            ],
+            validate: true,
+          },
+        },
+      ],
+      returns: {
+        txHash: { name: 'Transaction Hash', type: 'transactionHash' },
+      },
+    },
+  },
+  scripts: {},
+} as const satisfies Template
+
+const dapp = shallowRef<Dapp<typeof CC_TEMPLATE> | null>(null)
+const sessionStatus = ref('disconnected')
+const inviteUri = ref('')
+const response = ref('')
+const recipientAddress = ref('')
+const loading = ref(false)
+const network = ref<'mainnet' | 'chipnet'>('chipnet')
+const chain = computed(() => network.value === 'mainnet' ? 'bitcoincash' as const : 'bchtest' as const)
+
+// Abort controller for the in-flight send request (dapp-side cancel test)
+let sendAbortController: AbortController | null = null
+
+// Only the most recently initiated request writes to the response box
+let responseGeneration = 0
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'object' && error !== null) return JSON.stringify(error)
+  return String(error)
+}
+
+function copyUri() {
+  void navigator.clipboard.writeText(inviteUri.value)
+}
+
+async function connect() {
+  // Abandon any previous instance — its pair() may still be pending (a rejected pairing
+  // is not signalled to the dapp; it just keeps waiting).
+  if (dapp.value) {
+    await dapp.value.stop().catch(() => undefined)
+    dapp.value = null
+  }
+  response.value = ''
+  inviteUri.value = ''
+  sessionStatus.value = 'connecting'
+  try {
+    const newDapp = new Dapp({
+      info: {
+        name: 'BCH CC Test dApp',
+        description: 'CashConnect test dApp for Cashonize E2E tests',
+        url: window.location.origin,
+        icon: `${window.location.origin}/icon.png`,
+      },
+      chain: chain.value,
+      template: CC_TEMPLATE,
+      allowedTokens: [],
+      // In-memory store so repeated connect attempts (e.g. after an abandoned pairing)
+      // don't share dapp identity/session state through localStorage.
+      store: new MemoryStore(),
+    })
+    newDapp.on('sessionDeleted', () => {
+      if (dapp.value !== newDapp) return
+      sessionStatus.value = 'disconnected'
+      response.value = JSON.stringify({ event: 'sessionDeleted' })
+    })
+    await newDapp.start()
+    dapp.value = newDapp
+    inviteUri.value = newDapp.createInviteUrl()
+    sessionStatus.value = 'pairing'
+
+    const result = await newDapp.pair()
+    if (dapp.value !== newDapp) return // superseded by a newer connect attempt
+    sessionStatus.value = 'connected'
+    inviteUri.value = ''
+    response.value = encodeExtendedJson({ connected: true, walletPubkey: result.walletPubkey })
+  } catch (error: unknown) {
+    sessionStatus.value = 'disconnected'
+    response.value = JSON.stringify({ error: errorMessage(error) })
+  }
+}
+
+async function ping() {
+  if (!dapp.value) return
+  const owned = ++responseGeneration
+  response.value = ''
+  loading.value = true
+  try {
+    const result = await dapp.value.executeAction('ping', {
+      someString: Bytes.fromUtf8('hello cashonize'),
+    })
+    if (owned === responseGeneration) response.value = encodeExtendedJson(result)
+  } catch (error: unknown) {
+    if (owned === responseGeneration) response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    if (owned === responseGeneration) loading.value = false
+  }
+}
+
+async function send() {
+  if (!dapp.value) return
+  const owned = ++responseGeneration
+  response.value = ''
+  loading.value = true
+  sendAbortController = new AbortController()
+  try {
+    const result = await dapp.value.executeAction('send', {
+      recipientLockingBytecode: Address.from(recipientAddress.value).toLockscriptBytes(),
+      recipientSatsAmount: Bytes.fromBigInt(1000n),
+    }, { signal: sendAbortController.signal })
+    if (owned === responseGeneration) response.value = encodeExtendedJson(result)
+  } catch (error: unknown) {
+    if (owned === responseGeneration) response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    sendAbortController = null
+    if (owned === responseGeneration) loading.value = false
+  }
+}
+
+function cancelSend() {
+  sendAbortController?.abort()
+}
+
+async function getBalances() {
+  if (!dapp.value) return
+  const owned = ++responseGeneration
+  response.value = ''
+  loading.value = true
+  try {
+    const result = await dapp.value.getBalances()
+    if (owned === responseGeneration) response.value = encodeExtendedJson({ balances: result })
+  } catch (error: unknown) {
+    if (owned === responseGeneration) response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    if (owned === responseGeneration) loading.value = false
+  }
+}
+
+async function getTokens() {
+  if (!dapp.value) return
+  const owned = ++responseGeneration
+  response.value = ''
+  loading.value = true
+  try {
+    const result = await dapp.value.getTokens()
+    if (owned === responseGeneration) response.value = encodeExtendedJson({ tokens: result })
+  } catch (error: unknown) {
+    if (owned === responseGeneration) response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    if (owned === responseGeneration) loading.value = false
+  }
+}
+
+async function disconnect() {
+  if (!dapp.value) return
+  const owned = ++responseGeneration
+  response.value = ''
+  loading.value = true
+  try {
+    await dapp.value.forgetSession('User disconnected')
+    sessionStatus.value = 'disconnected'
+    if (owned === responseGeneration) response.value = JSON.stringify({ disconnected: true })
+  } catch (error: unknown) {
+    if (owned === responseGeneration) response.value = JSON.stringify({ error: errorMessage(error) })
+  } finally {
+    if (owned === responseGeneration) loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div style="margin-top: 2rem;">
+    <h2>Bitcoin Cash CashConnect Test dApp</h2>
+
+    <div style="margin-bottom: 1rem; display: flex; align-items: center; gap: 1rem;">
+      <label style="cursor: pointer;">
+        <input type="radio" id="cc-radio-chipnet" name="cc-network" value="chipnet" v-model="network" :disabled="sessionStatus === 'connected'"> chipnet
+      </label>
+      <label style="cursor: pointer;">
+        <input type="radio" id="cc-radio-mainnet" name="cc-network" value="mainnet" v-model="network" :disabled="sessionStatus === 'connected'"> mainnet
+      </label>
+      <span>Status: <strong id="cc-session-status">{{ sessionStatus }}</strong></span>
+      <span v-if="loading"> (loading...)</span>
+    </div>
+
+    <div style="margin-bottom: 1rem;">
+      <label>Recipient address (for Send):</label>
+      <input id="cc-input-address" v-model="recipientAddress" style="width: 100%; font-size: 0.75rem;" placeholder="bchtest:...">
+    </div>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem;">
+      <button id="cc-btn-connect" @click="connect" :disabled="sessionStatus === 'connected'">Connect</button>
+      <button id="cc-btn-ping" @click="ping" :disabled="sessionStatus !== 'connected' || loading">Ping (resolve)</button>
+      <button id="cc-btn-send" @click="send" :disabled="sessionStatus !== 'connected' || loading">Send (transaction)</button>
+      <button id="cc-btn-cancel" @click="cancelSend" :disabled="sessionStatus !== 'connected'">Cancel Send</button>
+      <button id="cc-btn-get-balances" @click="getBalances" :disabled="sessionStatus !== 'connected' || loading">Get Balances</button>
+      <button id="cc-btn-get-tokens" @click="getTokens" :disabled="sessionStatus !== 'connected' || loading">Get Tokens</button>
+      <button id="cc-btn-disconnect" @click="disconnect" :disabled="sessionStatus !== 'connected' || loading">Disconnect</button>
+    </div>
+
+    <div v-if="inviteUri" style="margin-bottom: 1rem;">
+      <label>Invite URI:</label>
+      <div id="cc-pairing-uri" style="word-break: break-all; padding: 0.5rem; background: #f0f0f0; font-size: 0.75rem;">{{ inviteUri }}</div>
+      <button id="cc-btn-copy-uri" @click="copyUri" style="margin-top: 0.25rem; font-size: 0.75rem;">Copy</button>
+    </div>
+
+    <div>
+      <label>Response:</label>
+      <pre id="cc-response" style="padding: 0.5rem; background: #f0f0f0; min-height: 2rem; white-space: pre-wrap; word-break: break-all;">{{ response }}</pre>
+    </div>
+  </div>
+</template>

--- a/test/e2e/walletconnect.test.ts
+++ b/test/e2e/walletconnect.test.ts
@@ -3,25 +3,10 @@
 // the test will import that wallet. Otherwise a new wallet will be created.
 
 import { test, expect, type Page } from '@playwright/test'
-
-const CASHONIZE_URL = 'http://localhost:9000'
-const DAPP_URL = 'http://localhost:5188'
-const SEED_PHRASE = process.env.E2E_SEED_PHRASE
+import { DAPP_URL, waitForDialog, setupWalletOnChipnet } from './helpers'
 
 let walletPage: Page
 let dappPage: Page
-
-// Resolve the currently-open Quasar dialog, scoped to the newest visible one, and wait
-// until it is shown. Dialogs animate in/out with a scale transition, so a closing dialog
-// and a freshly-opened one can briefly coexist in the DOM. A bare '.q-dialog' locator
-// resolves the first match — which may be the stale, detaching dialog — so a subsequent
-// click races its removal ("element was detached from the DOM, retrying"). Scoping to
-// ':visible' + last() targets the new dialog; the caller's click auto-waits for stability.
-async function waitForDialog(page: Page, timeout = 15_000) {
-  const dialog = page.locator('.q-dialog:visible').last()
-  await dialog.waitFor({ state: 'visible', timeout })
-  return dialog
-}
 
 test.describe.serial('WalletConnect E2E', () => {
   test.beforeAll(async ({ browser }) => {
@@ -34,35 +19,8 @@ test.describe.serial('WalletConnect E2E', () => {
     await walletPage.clock.install()
     await dappPage.clock.install()
 
-    // Set up wallet via onboarding
-    await walletPage.goto(CASHONIZE_URL)
-
-    if (SEED_PHRASE) {
-      // Import funded wallet
-      await walletPage.getByRole('button', { name: 'Import wallet' }).click()
-
-      // Paste seed phrase — onWordInput distributes words across all 12 fields
-      const firstSeedInput = walletPage.locator('.seed-words-grid input').first()
-      await firstSeedInput.fill(SEED_PHRASE)
-      await firstSeedInput.dispatchEvent('input')
-
-      await walletPage.getByRole('button', { name: 'Import wallet' }).click()
-    } else {
-      // Create a new wallet (no funds)
-      await walletPage.getByRole('button', { name: 'Create new wallet' }).click()
-      await walletPage.getByRole('button', { name: 'Create wallet' }).click()
-    }
-
-    // Finish onboarding — wait for nav tabs to appear (wallet loaded)
-    await walletPage.getByRole('button', { name: 'Finish Setup' }).click()
-    await walletPage.locator('nav').waitFor({ timeout: 15_000 })
-
-    // Switch to chipnet: Settings → Developer settings → change network
-    await walletPage.locator('nav img[src*="settings"]').click()
-    await walletPage.getByText('Developer settings').click()
-    await walletPage.locator('select').first().selectOption('chipnet')
-    // Wait for network switch to complete. It resets the active view back to the wallet tab.
-    await expect(walletPage.locator('nav').getByText('BchWallet')).toHaveClass(/active/, { timeout: 15_000 })
+    // Set up wallet via onboarding and switch to chipnet
+    await setupWalletOnChipnet(walletPage)
 
     // Navigate to WalletConnect tab, wait for sessions section
     await walletPage.locator('nav').getByText('WalletConnect').click()


### PR DESCRIPTION
Extends the e2e test dapp with a CashConnect section using @cashconnect-js/nostr (plain Dapp client, default relay to match the wallet's single-relay constraint) and an inlined raw-JSON template: a resolve-only action plus the tutorial's simple-send transaction action. New cashconnect.test.ts covers pairing approval, auto-responding requests, transaction approve/reject, dapp-side cancellation, network mismatch and disconnect; transaction tests require E2E_SEED_PHRASE. Shared wallet-onboarding helpers extracted from walletconnect.test.ts.