### PR TITLE
Redesign history, addresses and tokens pages

### DIFF
--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -273,7 +273,7 @@
       <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" slot="icon" /> <!-- eslint-disable-line -->
     </qr-code>
     <div style="text-align: center;">
-      <div class="switchAddressButton icon" @click="switchAddressTypeQr()">⇄
+      <div class="switchAddressButton icon" :class="{ flipped: !displayBchQr }" @click="switchAddressTypeQr()">⇄
       </div>
     </div>
     <div>
@@ -325,5 +325,10 @@
   padding: 5px;
   cursor: pointer;
   user-select: none;
+  transition: transform 0.3s;
+}
+/* the glyph is symmetric so it lands looking identical, the half turn conveys the swap */
+.switchAddressButton.flipped {
+  transform: rotate(180deg);
 }
 </style>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -23,6 +23,7 @@
   const showFiatValue = ref(settingsStore.showFiatValueHistory)
   const hideBalance = ref(settingsStore.hideBalanceColumn)
   const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions");
+  const directionFilter = ref("all" as "all" | "incoming" | "outgoing");
   const dateFrom = ref("");
   const dateTo = ref("");
   const searchQuery = ref("");
@@ -43,10 +44,10 @@
     searchInputRef.value?.focus();
   }
 
-  const filterOptions = [
-    { value: "allTransactions", label: "history.filter.all" },
-    { value: "bchTransactions", label: "history.filter.bchTxs" },
-    { value: "tokenTransactions", label: "history.filter.tokenTxs" },
+  const directionOptions = [
+    { value: "all", label: "history.directionFilter.all" },
+    { value: "incoming", label: "history.directionFilter.incoming" },
+    { value: "outgoing", label: "history.directionFilter.outgoing" },
   ] as const;
 
   const currentPage = ref(1)
@@ -79,6 +80,8 @@
     let history = store.walletHistory;
     if (selectedFilter.value === "bchTransactions") history = history?.filter(tx => !tx.tokenAmountChanges.length);
     if (selectedFilter.value === "tokenTransactions") history = history?.filter(tx => tx.tokenAmountChanges.length);
+    if (directionFilter.value === "incoming") history = history?.filter(tx => isIncoming(tx));
+    if (directionFilter.value === "outgoing") history = history?.filter(tx => !isIncoming(tx));
     const fromTimestamp = dateFrom.value ? localDayStart(dateFrom.value) : undefined;
     const untilTimestamp = dateTo.value ? localDayStart(dateTo.value, 1) : undefined;
     if (fromTimestamp !== undefined || untilTimestamp !== undefined) {
@@ -111,7 +114,7 @@
     return selectedHistory.value?.filter(tx => txMatchesSearch(tx, query));
   });
 
-  watch([selectedFilter, dateFrom, dateTo, searchQuery], () => { currentPage.value = 1 });
+  watch([selectedFilter, directionFilter, dateFrom, dateTo, searchQuery], () => { currentPage.value = 1 });
 
   const transactionCount = computed(() => searchedHistory.value?.length);
 
@@ -232,10 +235,10 @@
       <div class="control-row">
         <div class="type-filter">
           <button
-            v-for="option in filterOptions"
+            v-for="option in directionOptions"
             :key="option.value"
-            :class="{ active: selectedFilter === option.value }"
-            @click="selectedFilter = option.value"
+            :class="{ active: directionFilter === option.value }"
+            @click="directionFilter = option.value"
           >{{ t(option.label) }}</button>
         </div>
         <input v-if="!isMobile || showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
@@ -248,6 +251,14 @@
       </div>
 
       <div v-if="showOptions" class="options-panel" :class="{ dark: settingsStore.darkMode }">
+        <div class="option-item">
+          <label for="filterTransactions">{{ t('history.filter.label') }}</label>
+          <select v-model="selectedFilter" name="filterTransactions">
+            <option value="allTransactions">{{ t('history.filter.all') }}</option>
+            <option value="bchTransactions">{{ t('history.filter.bchTxs') }}</option>
+            <option value="tokenTransactions">{{ t('history.filter.tokenTxs') }}</option>
+          </select>
+        </div>
         <div class="option-item date-range">
           <label for="dateFrom">{{ t('history.filter.dateRange') }}</label>
           <div class="date-inputs">
@@ -378,7 +389,7 @@
   margin-left: auto;
 }
 
-/* segmented pill bar for the transaction type filter */
+/* segmented pill bar for the transaction direction filter */
 .type-filter {
   display: inline-flex;
   background-color: rgba(128, 128, 128, 0.12);
@@ -422,6 +433,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.option-item select {
+  width: 100px;
+  padding: 2px 8px;
 }
 
 .option-item input[type="date"] {

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -40,6 +40,7 @@
       return;
     }
     showSearch.value = true;
+    // the input is behind a v-if, wait for the DOM update before focusing it
     await nextTick();
     searchInputRef.value?.focus();
   }
@@ -58,6 +59,7 @@
     if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
       event.preventDefault();
       showSearch.value = true;
+      // the input is behind a v-if, wait for the DOM update before focusing it
       void nextTick().then(() => searchInputRef.value?.focus());
     }
   }

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useStore } from 'src/stores/store'
-  import { computed, ref, watch, onActivated, onDeactivated } from 'vue';
+  import { computed, ref, watch, nextTick, onActivated, onDeactivated } from 'vue';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
   import { formatTime, formatFiatAmount } from 'src/utils/utils';
@@ -26,6 +26,19 @@
   const dateTo = ref("");
   const searchQuery = ref("");
   const searchInputRef = ref<HTMLInputElement | null>(null);
+  // The search input hides behind a search icon until toggled open
+  const showSearch = ref(false);
+
+  async function toggleSearch() {
+    if (showSearch.value) {
+      showSearch.value = false;
+      searchQuery.value = "";
+      return;
+    }
+    showSearch.value = true;
+    await nextTick();
+    searchInputRef.value?.focus();
+  }
 
   const filterOptions = [
     { value: "allTransactions", label: "history.filter.all" },
@@ -40,7 +53,8 @@
   function handleCtrlF(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
       event.preventDefault();
-      searchInputRef.value?.focus();
+      showSearch.value = true;
+      void nextTick().then(() => searchInputRef.value?.focus());
     }
   }
 
@@ -212,27 +226,22 @@
     <fieldset class="item" v-if="store.walletHistory?.length">
       <legend>{{ t('history.title') }}</legend>
 
-      <div class="filter-row">
-        <div v-if="store.isHistoryPartial">{{ t('history.transactionCountPartial', { count: transactionCount?.toLocaleString("en-US") }) }}</div>
-        <div v-else>{{ t('history.transactionCount', { count: transactionCount?.toLocaleString("en-US") }) }}</div>
-        <span class="options-toggle" @click="toggleOptions">
-          {{ t('history.options') }}
-          <img
-            class="icon"
-            :class="{ 'expanded': showOptions }"
-            :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'"
-          >
+      <div class="control-row">
+        <div class="type-filter">
+          <button
+            v-for="option in filterOptions"
+            :key="option.value"
+            :class="{ active: selectedFilter === option.value }"
+            @click="selectedFilter = option.value"
+          >{{ t(option.label) }}</button>
+        </div>
+        <input v-if="showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
+        <span class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
+          <q-icon name="search" size="22px" />
         </span>
-        <input ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
-      </div>
-
-      <div class="type-filter">
-        <button
-          v-for="option in filterOptions"
-          :key="option.value"
-          :class="{ active: selectedFilter === option.value }"
-          @click="selectedFilter = option.value"
-        >{{ t(option.label) }}</button>
+        <span class="options-toggle" :class="{ active: showOptions }" :title="t('history.options')" @click="toggleOptions">
+          <q-icon name="tune" size="22px" />
+        </span>
       </div>
 
       <div v-if="showOptions" class="options-panel" :class="{ dark: settingsStore.darkMode }">
@@ -266,25 +275,12 @@
             :key="transaction.hash"
             @click="() => selectedTransaction = transaction"
           >
-            <div class="tx-main">
-              <div class="tx-direction" :class="[isIncoming(transaction) ? 'received' : 'sent', { pending: !transaction.timestamp }]">
-                <q-icon :name="isIncoming(transaction) ? 'arrow_downward' : 'arrow_upward'" size="20px" />
-              </div>
-              <div class="tx-info">
-                <div class="tx-type">{{ isIncoming(transaction) ? t('history.received') : t('history.sent') }}</div>
-                <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
-              </div>
-              <div class="tx-amounts">
-                <div class="tx-bch" :class="transaction.valueChange < 0 ? 'negative' : 'positive'">
-                  {{ formatBchAmount(transaction.valueChange, true) }} {{ bchDisplayUnit }}
-                </div>
-                <div class="tx-fiat" v-if="settingsStore.showFiatValueHistory && store.exchangeRate !== undefined">
-                  {{ `${transaction.valueChange > 0 ? '+' : ''}` + formatFiatAmount(store.exchangeRate * transaction.valueChange / 100_000_000, settingsStore.currency) }}
-                </div>
-                <div class="tx-balance" v-if="!hideBalance">
-                  {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
-                </div>
-              </div>
+            <div class="tx-direction" :class="[isIncoming(transaction) ? 'received' : 'sent', { pending: !transaction.timestamp }]">
+              <q-icon :name="isIncoming(transaction) ? 'arrow_downward' : 'arrow_upward'" size="20px" />
+            </div>
+            <div class="tx-info">
+              <div class="tx-type">{{ isIncoming(transaction) ? t('history.received') : t('history.sent') }}</div>
+              <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
             </div>
             <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
               <div class="token-chip" v-for="chip in tokenChangeChips(transaction)" :key="chip.key">
@@ -297,8 +293,26 @@
                 <span class="chip-symbol">{{ chip.symbol }}</span>
               </div>
             </div>
+            <div class="tx-amounts">
+              <div class="tx-amount-line">
+                <div class="tx-bch" :class="transaction.valueChange < 0 ? 'negative' : 'positive'">
+                  {{ formatBchAmount(transaction.valueChange, true) }} {{ bchDisplayUnit }}
+                </div>
+                <div class="tx-fiat" v-if="settingsStore.showFiatValueHistory && store.exchangeRate !== undefined">
+                  ({{ `${transaction.valueChange > 0 ? '+' : ''}` + formatFiatAmount(store.exchangeRate * transaction.valueChange / 100_000_000, settingsStore.currency) }})
+                </div>
+              </div>
+              <div class="tx-balance" v-if="!hideBalance">
+                {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
+              </div>
+            </div>
           </div>
         </template>
+      </div>
+
+      <div class="tx-count">
+        <span v-if="store.isHistoryPartial">{{ t('history.transactionCountPartial', { count: transactionCount?.toLocaleString("en-US") }) }}</span>
+        <span v-else>{{ t('history.transactionCount', { count: transactionCount?.toLocaleString("en-US") }) }}</span>
       </div>
 
       <q-pagination
@@ -327,26 +341,31 @@
   padding: 15px 0;
 }
 
-.filter-row {
+.control-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 10px 20px;
+  gap: 10px 12px;
   margin: 10px 0;
 }
 
-.options-toggle {
+.options-toggle,
+.search-toggle {
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.8;
 }
 
-.expanded {
-  transform: rotate(180deg);
+.options-toggle.active,
+.search-toggle.active {
+  color: var(--color-primary);
+  opacity: 1;
 }
 
 .search-input {
-  width: 180px;
+  width: 220px;
   padding: 4px 10px;
   margin-left: auto;
 }
@@ -440,6 +459,10 @@
 
 /* neutral grey alphas keep the cards theme-agnostic: no separate dark mode rules needed */
 .tx-item {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
   border: 1px solid rgba(128, 128, 128, 0.2);
   background-color: rgba(128, 128, 128, 0.06);
   border-radius: 12px;
@@ -451,12 +474,6 @@
 
 .tx-item:hover {
   background-color: rgba(128, 128, 128, 0.14);
-}
-
-.tx-main {
-  display: flex;
-  align-items: center;
-  gap: 12px;
 }
 
 .tx-direction {
@@ -502,6 +519,13 @@
   text-align: right;
 }
 
+.tx-amount-line {
+  display: flex;
+  justify-content: flex-end;
+  align-items: baseline;
+  gap: 6px;
+}
+
 .tx-bch {
   font-family: monospace;
   white-space: nowrap;
@@ -510,6 +534,7 @@
 .tx-fiat {
   font-size: 0.85em;
   opacity: 0.75;
+  white-space: nowrap;
 }
 
 .tx-balance {
@@ -534,13 +559,17 @@ body.dark .negative {
   color: #ef9a9a;
 }
 
-/* token changes render as wrapping chips so any number of tokens per transaction lays out cleanly */
+/* token changes render as wrapping chips on their own line below the main row, so any
+   number of tokens per transaction lays out cleanly; order moves them after the amounts,
+   which sit in the main row despite coming later in the DOM */
 .tx-tokens {
+  order: 5;
+  flex-basis: 100%;
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
-  margin-top: 8px;
-  margin-left: 48px;
+  margin-right: 2px;
 }
 
 .token-chip {
@@ -558,24 +587,44 @@ body.dark .negative {
   word-break: break-word;
 }
 
+.tx-count {
+  text-align: center;
+  font-size: 0.85em;
+  opacity: 0.6;
+  margin: 10px 0 4px;
+}
+
+@media only screen and (max-width: 600px) {
+  /* search moves to its own full-width line, the options toggle stays beside the pills */
+  .search-input {
+    order: 5;
+    flex-basis: 100%;
+    width: 100%;
+    margin-left: 0;
+  }
+  .search-toggle {
+    margin-left: auto;
+  }
+  .type-filter button {
+    padding: 4px 12px;
+    font-size: 0.85em;
+  }
+  .tx-amount-line {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0;
+  }
+  .tx-item {
+    padding: 8px 10px;
+  }
+}
+
 @media only screen and (max-width: 500px) {
   fieldset {
     padding: .5rem .5rem;
   }
-  .filter-row {
-    margin-left: 0.5rem;
-  }
   legend {
     margin-left: 0.5rem;
-  }
-  .search-input {
-    width: 140px;
-  }
-  .tx-tokens {
-    margin-left: 0;
-  }
-  .tx-item {
-    padding: 8px 10px;
   }
 }
 </style>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -2,6 +2,7 @@
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useStore } from 'src/stores/store'
   import { computed, ref, watch, nextTick, onActivated, onDeactivated } from 'vue';
+  import { useWindowSize } from 'src/utils/composables';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
   import { formatTime, formatFiatAmount } from 'src/utils/utils';
@@ -26,7 +27,9 @@
   const dateTo = ref("");
   const searchQuery = ref("");
   const searchInputRef = ref<HTMLInputElement | null>(null);
-  // The search input hides behind a search icon until toggled open
+  const { width } = useWindowSize();
+  const isMobile = computed(() => width.value <= 600);
+  // On mobile the search input hides behind a search icon until toggled open
   const showSearch = ref(false);
 
   async function toggleSearch() {
@@ -235,8 +238,8 @@
             @click="selectedFilter = option.value"
           >{{ t(option.label) }}</button>
         </div>
-        <input v-if="showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
-        <span class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
+        <input v-if="!isMobile || showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
+        <span v-if="isMobile" class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
           <q-icon name="search" size="22px" />
         </span>
         <span class="options-toggle" :class="{ active: showOptions }" :title="t('history.options')" @click="toggleOptions">
@@ -343,7 +346,7 @@
 
 .control-row {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   flex-wrap: wrap;
   gap: 10px 12px;
   margin: 10px 0;
@@ -353,9 +356,14 @@
 .search-toggle {
   cursor: pointer;
   user-select: none;
-  display: inline-flex;
-  align-items: center;
   opacity: 0.8;
+}
+
+/* icons are taller than the lowercase text, drop them slightly below the
+   baseline so they read as vertically centered next to it */
+.options-toggle .q-icon,
+.search-toggle .q-icon {
+  vertical-align: -0.2em;
 }
 
 .options-toggle.active,
@@ -365,7 +373,7 @@
 }
 
 .search-input {
-  width: 220px;
+  width: 180px;
   padding: 4px 10px;
   margin-left: auto;
 }

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useStore } from 'src/stores/store'
-  import { computed, ref, watch } from 'vue';
-  import { useWindowSize } from 'src/utils/composables';
+  import { computed, ref, watch, onActivated, onDeactivated } from 'vue';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
-  import EmojiItem from '../general/emojiItem.vue';
-  import { formatTimestamp, formatTime, formatFiatAmount } from 'src/utils/utils';
+  import { formatTime, formatFiatAmount } from 'src/utils/utils';
   import { historyToCsv } from 'src/utils/csvUtils';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
@@ -18,9 +16,6 @@
   const $q = useQuasar()
   const isCapacitor = import.meta.env.QUASAR_CAPACITOR_MODE;
   const itemsPerPage = 100
-  const { width } = useWindowSize();
-  const isMobile = computed(() => width.value <= 600)
-  const hideUnit = computed(() => width.value <= 500)
 
   // state options menu
   const showOptions = ref(false)
@@ -29,14 +24,29 @@
   const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions");
   const dateFrom = ref("");
   const dateTo = ref("");
+  const searchQuery = ref("");
+  const searchInputRef = ref<HTMLInputElement | null>(null);
+
+  const filterOptions = [
+    { value: "allTransactions", label: "history.filter.all" },
+    { value: "bchTransactions", label: "history.filter.bchTxs" },
+    { value: "tokenTransactions", label: "history.filter.tokenTxs" },
+  ] as const;
 
   const currentPage = ref(1)
   const selectedTransaction = ref(undefined as TransactionHistoryItem | undefined);
 
-  // Auto-hide balance column on small screens
-  watch(() => width.value <= 450, (isSmallScreen) => {
-    if (isSmallScreen) hideBalance.value = true
-  }, { immediate: true })
+  // Override Ctrl+F to focus the search input.
+  function handleCtrlF(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+      event.preventDefault();
+      searchInputRef.value?.focus();
+    }
+  }
+
+  // Listener added/removed on KeepAlive activate/deactivate so it only applies while this view is active.
+  onActivated(() => document.addEventListener('keydown', handleCtrlF));
+  onDeactivated(() => document.removeEventListener('keydown', handleCtrlF));
 
   const bchDisplayUnit = computed(() => {
     return store.network === "mainnet" ? "BCH" : "tBCH";
@@ -66,15 +76,112 @@
     return history;
   });
 
-  watch([selectedFilter, dateFrom, dateTo], () => { currentPage.value = 1 });
+  function txMatchesSearch(tx: TransactionHistoryItem, query: string): boolean {
+    if (tx.hash.toLowerCase().includes(query)) return true;
+    return tx.tokenAmountChanges.some(tokenChange => {
+      if (tokenChange.category.toLowerCase().includes(query)) return true;
+      const metadata = store.bcmrRegistries?.[tokenChange.category];
+      if (!metadata) return false;
+      if (metadata.name.toLowerCase().includes(query)) return true;
+      if (metadata.token.symbol.toLowerCase().includes(query)) return true;
+      return false;
+    });
+  }
 
-  const transactionCount = computed(() => selectedHistory.value?.length);
+  const searchedHistory = computed(() => {
+    const query = searchQuery.value.toLowerCase().trim();
+    if (!query) return selectedHistory.value;
+    return selectedHistory.value?.filter(tx => txMatchesSearch(tx, query));
+  });
+
+  watch([selectedFilter, dateFrom, dateTo, searchQuery], () => { currentPage.value = 1 });
+
+  const transactionCount = computed(() => searchedHistory.value?.length);
 
   const paginatedHistory = computed(() => {
     const start = (currentPage.value - 1) * itemsPerPage
-    return selectedHistory.value?.slice(start, start + itemsPerPage)
+    return searchedHistory.value?.slice(start, start + itemsPerPage)
   })
-  const totalPages = computed(() => Math.ceil((selectedHistory.value?.length ?? 0) / itemsPerPage))
+  const totalPages = computed(() => Math.ceil((searchedHistory.value?.length ?? 0) / itemsPerPage))
+
+  // Group consecutive transactions by calendar day (history is sorted newest first).
+  // Pending transactions have no timestamp and group under their own header.
+  function dayLabel(timestamp: number | undefined): string {
+    if (!timestamp) return t('history.pending');
+    const date = new Date(timestamp * 1000);
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+    if (date.toDateString() === today.toDateString()) return t('history.today');
+    if (date.toDateString() === yesterday.toDateString()) return t('history.yesterday');
+    return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+  }
+
+  const groupedHistory = computed(() => {
+    const groups: { label: string; transactions: TransactionHistoryItem[] }[] = [];
+    for (const transaction of paginatedHistory.value ?? []) {
+      const label = dayLabel(transaction.timestamp);
+      let lastGroup = groups[groups.length - 1];
+      if (lastGroup?.label !== label) {
+        lastGroup = { label, transactions: [] };
+        groups.push(lastGroup);
+      }
+      lastGroup.transactions.push(transaction);
+    }
+    return groups;
+  });
+
+  // Direction is derived from the net BCH change: receiving (BCH or tokens) always adds
+  // value, while a wallet-authored transaction always pays the fee so its net is negative
+  function isIncoming(transaction: TransactionHistoryItem): boolean {
+    return transaction.valueChange >= 0;
+  }
+
+  interface TokenChangeChip {
+    key: string;
+    category: string;
+    amountText: string;
+    symbol: string;
+    negative: boolean;
+  }
+
+  // Tokens like BADGER have both fungibles and NFTs with the same category in user wallets,
+  // so one token change can yield both a fungible chip and an NFT chip
+  function tokenChangeChips(transaction: TransactionHistoryItem): TokenChangeChip[] {
+    const chips: TokenChangeChip[] = [];
+    for (const tokenChange of transaction.tokenAmountChanges) {
+      const tokenMetadata = store.bcmrRegistries?.[tokenChange.category]?.token;
+      const symbol = tokenMetadata?.symbol ?? tokenChange.category.slice(0, 8);
+      const decimals = tokenMetadata?.decimals ?? 0;
+      // Show the fungible change for any nonzero amount. When there is no NFT change either,
+      // still show it (as "0") so a token change never renders without a chip.
+      if (tokenChange.amount !== 0n || tokenChange.nftAmount === 0n) {
+        const amount = Number(tokenChange.amount) / 10 ** decimals;
+        chips.push({
+          key: tokenChange.category + "-ft",
+          category: tokenChange.category,
+          amountText: `${amount > 0 ? '+' : ''}${amount.toLocaleString("en-US", { maximumFractionDigits: decimals })}`,
+          symbol,
+          negative: amount < 0,
+        });
+      }
+      if (tokenChange.nftAmount !== 0n) {
+        chips.push({
+          key: tokenChange.category + "-nft",
+          category: tokenChange.category,
+          amountText: `${tokenChange.nftAmount > 0n ? '+' : ''}${tokenChange.nftAmount}`,
+          symbol: `${symbol} NFT`,
+          negative: tokenChange.nftAmount < 0n,
+        });
+      }
+    }
+    return chips;
+  }
+
+  function formatBchAmount(satoshis: number, signed = false): string {
+    const amount = (satoshis / 100_000_000).toLocaleString("en-US", { minimumFractionDigits: 5, maximumFractionDigits: 5 });
+    return signed && satoshis > 0 ? `+${amount}` : amount;
+  }
 
   function toggleOptions() {
     showOptions.value = !showOptions.value
@@ -91,7 +198,7 @@
   }
 
   function exportCsv() {
-    const csvContent = historyToCsv(selectedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value);
+    const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value);
     const status = exportFile("cashonize-tx-history.csv", csvContent, { mimeType: "text/csv" });
     if (status !== true) $q.notify({ message: t('history.exportFailed'), icon: 'warning', color: "red" });
   }
@@ -116,17 +223,19 @@
             :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'"
           >
         </span>
+        <input ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input">
+      </div>
+
+      <div class="type-filter">
+        <button
+          v-for="option in filterOptions"
+          :key="option.value"
+          :class="{ active: selectedFilter === option.value }"
+          @click="selectedFilter = option.value"
+        >{{ t(option.label) }}</button>
       </div>
 
       <div v-if="showOptions" class="options-panel" :class="{ dark: settingsStore.darkMode }">
-        <div class="option-item">
-          <label for="filterTransactions">{{ t('history.filter.label') }}</label>
-          <select v-model="selectedFilter" name="filterTransactions">
-            <option value="allTransactions">{{ t('history.filter.all') }}</option>
-            <option value="bchTransactions">{{ t('history.filter.bchTxs') }}</option>
-            <option value="tokenTransactions">{{ t('history.filter.tokenTxs') }}</option>
-          </select>
-        </div>
         <div class="option-item date-range">
           <label for="dateFrom">{{ t('history.filter.dateRange') }}</label>
           <div class="date-inputs">
@@ -146,89 +255,52 @@
         </div>
       </div>
 
-      <!-- CSS Grid table: provides fixed column widths unaffected by content like images -->
-      <div class="tx-table" :class="{ 'hide-balance': hideBalance }">
-        <div class="tx-header tx-row">
-          <div class="tx-cell"></div>
-          <div class="tx-cell">{{ t('history.columns.date') }}</div>
-          <div class="tx-cell">{{ t('history.columns.amount') }}</div>
-          <div class="tx-cell balance-header" v-if="!hideBalance">{{ t('history.columns.balance') }}</div>
-          <div class="tx-cell tokens-header">{{ t('history.columns.tokens') }}</div>
-        </div>
-        <div class="tx-body">
+      <div v-if="searchedHistory?.length === 0" style="text-align: center; padding: 20px 0;">{{ t('history.noMatch') }}</div>
+
+      <div class="tx-list">
+        <template v-for="group in groupedHistory" :key="group.transactions[0]?.hash">
+          <div class="date-header">{{ group.label }}</div>
           <div
-            class="tx-row"
-            v-for="(transaction, index) in paginatedHistory"
+            class="tx-item"
+            v-for="transaction in group.transactions"
             :key="transaction.hash"
             @click="() => selectedTransaction = transaction"
-            :class="[settingsStore.darkMode ? 'dark' : '', index % 2 === 1 ? 'even' : '']"
           >
-
-            <div class="tx-cell status-cell"><EmojiItem :emoji="transaction.timestamp ? '✅' : '⏳'" :size-px="isMobile ? 14 : 16" style="vertical-align: sub;"/> </div>
-
-            <div class="tx-cell" v-if="isMobile">
-              <div v-if="transaction.timestamp" style="line-height: 1.3">
-                <div>{{ formatTimestamp(transaction.timestamp, settingsStore.dateFormat, true) }}</div>
-                <div>{{ formatTime(transaction.timestamp) }}</div>
+            <div class="tx-main">
+              <div class="tx-direction" :class="[isIncoming(transaction) ? 'received' : 'sent', { pending: !transaction.timestamp }]">
+                <q-icon :name="isIncoming(transaction) ? 'arrow_downward' : 'arrow_upward'" size="20px" />
               </div>
-              <div v-else>{{ t('history.pending') }}</div>
-            </div>
-            <div class="tx-cell" v-else>{{ formatTimestamp(transaction.timestamp, settingsStore.dateFormat) }}</div>
-
-            <div class="tx-cell value" :class="{ 'negative': transaction.valueChange < 0 }">
-              {{ `${transaction.valueChange > 0 ? '+' : '' }${(transaction.valueChange / 100_000_000).toLocaleString("en-US", {minimumFractionDigits: 5, maximumFractionDigits: 5})}`}}
-              {{ hideUnit ? "" : bchDisplayUnit }}
-              <div v-if="settingsStore.showFiatValueHistory && store.exchangeRate !== undefined">
-                ({{`${transaction.valueChange > 0 ? '+' : '' }` + formatFiatAmount(store.exchangeRate * transaction.valueChange / 100_000_000, settingsStore.currency)}})
+              <div class="tx-info">
+                <div class="tx-type">{{ isIncoming(transaction) ? t('history.received') : t('history.sent') }}</div>
+                <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
               </div>
-            </div>
-
-            <div class="tx-cell value" v-if="!hideBalance">
-              {{ (transaction.balance / 100_000_000).toLocaleString("en-US", {minimumFractionDigits: 5, maximumFractionDigits: 5}) }}
-              {{ hideUnit ? "" : bchDisplayUnit }}
-              <div v-if="settingsStore.showFiatValueHistory && store.exchangeRate !== undefined">
-                ~{{formatFiatAmount(store.exchangeRate * transaction.balance / 100_000_000, settingsStore.currency) }}
+              <div class="tx-amounts">
+                <div class="tx-bch" :class="transaction.valueChange < 0 ? 'negative' : 'positive'">
+                  {{ formatBchAmount(transaction.valueChange, true) }} {{ bchDisplayUnit }}
+                </div>
+                <div class="tx-fiat" v-if="settingsStore.showFiatValueHistory && store.exchangeRate !== undefined">
+                  {{ `${transaction.valueChange > 0 ? '+' : ''}` + formatFiatAmount(store.exchangeRate * transaction.valueChange / 100_000_000, settingsStore.currency) }}
+                </div>
+                <div class="tx-balance" v-if="!hideBalance">
+                  {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
+                </div>
               </div>
             </div>
-
-            <div class="tx-cell tokenChange">
-               <!-- Tokens like BADGER have both fungibles and NFTs with the same category in user wallets -->
-              <div class="tokenChangeItem" v-for="tokenChange in transaction.tokenAmountChanges" :key="tokenChange.category">
-                <span v-if="tokenChange.amount !== 0n || tokenChange.nftAmount == 0n">
-                  <span v-if="tokenChange.amount > 0n" class="value">+{{
-                    (Number(tokenChange.amount) / 10**(store.bcmrRegistries?.[tokenChange.category]?.token.decimals ?? 0)).toLocaleString("en-US") }}
-                  </span>
-                  <span v-else class="value negative">
-                    {{ (Number(tokenChange.amount) / 10**(store.bcmrRegistries?.[tokenChange.category]?.token.decimals ?? 0)).toLocaleString("en-US") }}
-                  </span>
-                  <span> {{ " " + (store.bcmrRegistries?.[tokenChange.category]?.token?.symbol ?? tokenChange.category.slice(0, 8)) }}</span>
-                  <TokenIcon
-                    v-if="tokenChange.amount"
-                    class="historyTokenIcon"
-                    :token-id="tokenChange.category"
-                    :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(tokenChange.category) : undefined"
-                    :size="28"
-                  />
-                </span>
-                <span v-if="tokenChange.nftAmount" class="nftChange">
-                  <span v-if="tokenChange.nftAmount > 0n" class="value">+{{ tokenChange.nftAmount }}</span>
-                  <span v-else class="value negative">{{ tokenChange.nftAmount }}</span>
-                  <span>
-                    {{ " " + (store.bcmrRegistries?.[tokenChange.category]?.token?.symbol ?? tokenChange.category.slice(0, 8)) }} NFT
-                  </span>
-                  <TokenIcon
-                    v-if="tokenChange.nftAmount"
-                    class="historyTokenIcon"
-                    :token-id="tokenChange.category"
-                    :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(tokenChange.category) : undefined"
-                    :size="28"
-                  />
-                </span>
+            <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
+              <div class="token-chip" v-for="chip in tokenChangeChips(transaction)" :key="chip.key">
+                <TokenIcon
+                  :token-id="chip.category"
+                  :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(chip.category) : undefined"
+                  :size="22"
+                />
+                <span class="value" :class="{ negative: chip.negative, positive: !chip.negative }">{{ chip.amountText }}</span>
+                <span class="chip-symbol">{{ chip.symbol }}</span>
               </div>
             </div>
           </div>
-        </div>
+        </template>
       </div>
+
       <q-pagination
         v-if="totalPages > 1"
         v-model="currentPage"
@@ -258,17 +330,50 @@
 .filter-row {
   display: flex;
   align-items: baseline;
-  gap: 20px;
+  flex-wrap: wrap;
+  gap: 10px 20px;
   margin: 10px 0;
 }
 
 .options-toggle {
   cursor: pointer;
   user-select: none;
+  white-space: nowrap;
 }
 
 .expanded {
   transform: rotate(180deg);
+}
+
+.search-input {
+  width: 180px;
+  padding: 4px 10px;
+  margin-left: auto;
+}
+
+/* segmented pill bar for the transaction type filter */
+.type-filter {
+  display: inline-flex;
+  background-color: rgba(128, 128, 128, 0.12);
+  border-radius: 20px;
+  padding: 3px;
+  margin-bottom: 10px;
+}
+
+.type-filter button {
+  border: none;
+  margin: 0;
+  background: transparent;
+  color: inherit;
+  border-radius: 17px;
+  padding: 4px 16px;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+
+.type-filter button.active {
+  background-color: var(--color-primary);
+  color: white;
 }
 
 .options-panel {
@@ -290,11 +395,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.option-item select {
-  width: 100px;
-  padding: 2px 8px;
 }
 
 .option-item input[type="date"] {
@@ -329,72 +429,104 @@
   font-size: 0.9em;
 }
 
-.tx-table {
-  width: 100%;
-  overflow-x: auto;
+.date-header {
+  text-transform: uppercase;
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  opacity: 0.6;
+  margin: 14px 2px 6px;
 }
 
-/* each row is its own grid, so column tracks must be content-independent (px or fr)
-   to stay aligned across rows: date and tokens get fixed widths sized to their content,
-   the flexible space goes to the amount and balance columns */
-.tx-row {
-  display: grid;
-  grid-template-columns: 45px 130px 1fr 1fr 200px;
-  column-gap: 8px;
-  min-width: 550px;
-  align-items: center;
+/* neutral grey alphas keep the cards theme-agnostic: no separate dark mode rules needed */
+.tx-item {
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background-color: rgba(128, 128, 128, 0.06);
+  border-radius: 12px;
+  padding: 10px 14px;
+  margin-bottom: 8px;
   cursor: pointer;
+  transition: background-color 0.2s;
 }
 
-.hide-balance .tx-row {
-  grid-template-columns: 45px 1fr minmax(100px, 150px) minmax(150px, 1fr);
-  min-width: 400px;
+.tx-item:hover {
+  background-color: rgba(128, 128, 128, 0.14);
 }
 
-.hide-balance .tx-cell.value,
-.hide-balance .tx-header .tx-cell:nth-child(3) {
-  text-align: center;
+.tx-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-.tx-header {
-  font-weight: bold;
-  cursor: default;
-  border-bottom: 1px solid var(--color-border);
+.tx-direction {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.tx-cell.tokens-header {
-  text-align: right;
-  padding-right: 40px;
+.tx-direction.received {
+  background-color: rgba(10, 193, 143, 0.15);
+  color: var(--color-primary);
 }
 
-.tx-body .tx-row.even {
-  background-color: var(--color-background-soft);
-}
-.tx-body .tx-row.dark.even {
-  background-color: #232326;
+.tx-direction.sent {
+  background-color: rgba(128, 128, 128, 0.15);
+  color: var(--color-grey);
 }
 
-.tx-body {
-  font-size: smaller;
+.tx-direction.pending {
+  background-color: rgba(230, 162, 60, 0.18);
+  color: #e6a23c;
 }
 
-.tx-body .tx-row {
-  min-height: 67px;
-}
-
-.tx-cell {
-  padding: 12px 2px;
+.tx-info {
   min-width: 0;
 }
 
-.tx-cell.status-cell {
-  padding-left: 10px;
+.tx-type {
+  font-weight: 600;
+}
+
+.tx-time {
+  font-size: 0.85em;
+  opacity: 0.65;
+}
+
+.tx-amounts {
+  margin-left: auto;
+  text-align: right;
+}
+
+.tx-bch {
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+.tx-fiat {
+  font-size: 0.85em;
+  opacity: 0.75;
+}
+
+.tx-balance {
+  font-size: 0.8em;
+  opacity: 0.6;
+  white-space: nowrap;
 }
 
 .value {
   font-family: monospace;
   white-space: nowrap;
 }
+
+.positive {
+  color: var(--color-primary);
+}
+
 .negative {
   color: rgb(188, 30, 30);
 }
@@ -402,64 +534,33 @@ body.dark .negative {
   color: #ef9a9a;
 }
 
-.tokenChange {
+/* token changes render as wrapping chips so any number of tokens per transaction lays out cleanly */
+.tx-tokens {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  justify-content: center;
-  text-align: end;
-  gap: 4px;
-  padding-right: 6px;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  margin-left: 48px;
 }
-.tokenChangeItem {
-  text-align: center;
+
+.token-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  background-color: rgba(128, 128, 128, 0.08);
+  border-radius: 14px;
+  padding: 2px 10px 2px 4px;
+  font-size: 0.85em;
+}
+
+.chip-symbol {
   word-break: break-word;
-}
-.nftChange {
-  display: block;
-}
-
-.historyTokenIcon {
-  margin-left: 5px;
-  vertical-align: middle;
-}
-
-@media only screen and (max-width: 600px) {
-  .tokens-header {
-    text-align: center;
-    padding-right: 0;
-  }
-  .tokenChange {
-    align-items: center;
-  }
-  .tx-row {
-    grid-template-columns: 34px 66px 1fr 1fr 132px;
-    column-gap: 4px;
-    min-width: 330px;
-  }
-  .hide-balance .tx-row {
-    grid-template-columns: 34px 66px 1fr 1fr;
-    min-width: 260px;
-  }
-  .tx-body {
-    font-size: small;
-  }
-  .historyTokenIcon {
-    display: block;
-    width: fit-content;
-    margin: 4px auto 0;
-  }
 }
 
 @media only screen and (max-width: 500px) {
   fieldset {
     padding: .5rem .5rem;
-  }
-  .tx-row {
-    grid-template-columns: 31px 62px minmax(70px, 1fr) minmax(70px, 1fr) 110px;
-  }
-  .hide-balance .tx-row {
-    grid-template-columns: 31px 62px 1fr 1fr;
   }
   .filter-row {
     margin-left: 0.5rem;
@@ -467,14 +568,14 @@ body.dark .negative {
   legend {
     margin-left: 0.5rem;
   }
-}
-
-@media only screen and (max-width: 400px) {
-  .tx-row {
-    grid-template-columns: 27px 62px minmax(70px, 1fr) minmax(70px, 1fr) 110px;
+  .search-input {
+    width: 140px;
   }
-  .hide-balance .tx-row {
-    grid-template-columns: 27px 62px 1fr 1fr;
+  .tx-tokens {
+    margin-left: 0;
+  }
+  .tx-item {
+    padding: 8px 10px;
   }
 }
 </style>

--- a/src/components/myTokens.vue
+++ b/src/components/myTokens.vue
@@ -1,11 +1,12 @@
 
 <script setup lang="ts">
-  import { ref, computed, onActivated, onDeactivated } from 'vue'
+  import { ref, computed, nextTick, onActivated, onDeactivated } from 'vue'
   import { useI18n } from 'vue-i18n'
   import tokenItemNFT from './tokenItems/tokenItemNFT.vue'
   import tokenItemFT from './tokenItems/tokenItemFT.vue'
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore'
+  import { useWindowSize } from 'src/utils/composables'
 
   const store = useStore()
   const settingsStore = useSettingsStore()
@@ -14,12 +15,28 @@
   const showOptions = ref(false)
   const searchQuery = ref('')
   const searchInputRef = ref<HTMLInputElement | null>(null)
+  const { width } = useWindowSize()
+  const isMobile = computed(() => width.value <= 600)
+  // On mobile the search input hides behind a search icon until toggled open
+  const showSearch = ref(false)
+
+  async function toggleSearch() {
+    if (showSearch.value) {
+      showSearch.value = false;
+      searchQuery.value = "";
+      return;
+    }
+    showSearch.value = true;
+    await nextTick();
+    searchInputRef.value?.focus();
+  }
 
   // Override Ctrl+F to focus the search input.
   function handleCtrlF(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
       event.preventDefault();
-      searchInputRef.value?.focus();
+      showSearch.value = true;
+      void nextTick().then(() => searchInputRef.value?.focus());
     }
   }
 
@@ -27,10 +44,26 @@
   onActivated(() => document.addEventListener('keydown', handleCtrlF));
   onDeactivated(() => document.removeEventListener('keydown', handleCtrlF));
 
-  const isSearchActive = computed(() => searchQuery.value.trim().length > 0);
+  const selectedTypeFilter = ref("all" as "all" | "fungibles" | "nfts");
+
+  const typeFilterOptions = [
+    { value: "all", label: "tokens.typeFilter.all" },
+    { value: "fungibles", label: "tokens.typeFilter.fungibles" },
+    { value: "nfts", label: "tokens.typeFilter.nfts" },
+  ] as const;
+
+  // Categories holding both fungibles and NFTs have a separate list entry for each,
+  // so filtering on the entry kind cleanly splits them across the two views
+  const typeFilteredTokenList = computed(() => {
+    const tokens = store.filteredTokenList;
+    if (!tokens) return null;
+    if (selectedTypeFilter.value === "fungibles") return tokens.filter(tokenData => 'amount' in tokenData);
+    if (selectedTypeFilter.value === "nfts") return tokens.filter(tokenData => 'nfts' in tokenData);
+    return tokens;
+  });
 
   const searchFilteredTokenList = computed(() => {
-    const tokens = store.filteredTokenList;
+    const tokens = typeFilteredTokenList.value;
     if (!tokens) return null;
     const query = searchQuery.value.toLowerCase().trim();
     if (!query) return tokens;
@@ -55,24 +88,22 @@
 
   <div v-else>
     <!-- Options toggle row -->
-    <div v-if="store.tokenList?.length" class="filter-row">
-      <span :class="{ 'hide-mobile': isSearchActive }">
-        <span v-if="settingsStore.tokenDisplayFilter === 'favoritesOnly'">{{ t('tokens.favoriteCount', { count: store.filteredTokenList?.length ?? 0 }) }}</span>
-        <span v-else-if="settingsStore.tokenDisplayFilter === 'hiddenOnly'">{{ t('tokens.hiddenCount', { count: store.filteredTokenList?.length ?? 0 }) }}</span>
-        <span v-else-if="settingsStore.tokenDisplayFilter === 'all'">{{ t('tokens.totalCount', { count: store.filteredTokenList?.length ?? 0 }) }}</span>
-        <span v-else>{{ t('tokens.count', { count: store.filteredTokenList?.length ?? 0 }) }}</span>
-        <span v-if="isSearchActive" class="search-match-suffix"> ({{ t('tokens.searchMatches', { count: searchFilteredTokenList?.length ?? 0 }) }})</span>
+    <div v-if="store.tokenList?.length" class="control-row">
+      <div class="type-filter">
+        <button
+          v-for="option in typeFilterOptions"
+          :key="option.value"
+          :class="{ active: selectedTypeFilter === option.value }"
+          @click="selectedTypeFilter = option.value"
+        >{{ t(option.label) }}</button>
+      </div>
+      <input v-if="!isMobile || showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('tokens.searchPlaceholder')" class="search-input">
+      <span v-if="isMobile" class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
+        <q-icon name="search" size="22px" />
       </span>
-      <span v-if="isSearchActive" class="search-match-mobile">{{ t('tokens.searchMatches', { count: searchFilteredTokenList?.length ?? 0 }) }}</span>
-      <span class="options-toggle" @click="showOptions = !showOptions">
-        {{ t('tokens.options') }}
-        <img
-          class="icon"
-          :class="{ 'expanded': showOptions }"
-          :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'"
-        >
+      <span class="options-toggle" :class="{ active: showOptions }" :title="t('tokens.options')" @click="showOptions = !showOptions">
+        <q-icon name="tune" size="22px" />
       </span>
-      <input ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('tokens.searchPlaceholder')" class="search-input">
     </div>
 
     <!-- Options panel (collapsed by default) -->
@@ -102,25 +133,45 @@
       <tokenItemFT v-if="'amount' in tokenData" :tokenData="tokenData"/>
       <tokenItemNFT v-else :tokenData="tokenData"/>
     </div>
+
+    <div v-if="searchFilteredTokenList?.length" class="token-count">
+      <!-- the curation labels only apply to the unnarrowed list, show a plain count when searching or type-filtering -->
+      <span v-if="searchQuery.trim() || selectedTypeFilter !== 'all'">{{ t('tokens.count', { count: searchFilteredTokenList.length }) }}</span>
+      <span v-else-if="settingsStore.tokenDisplayFilter === 'favoritesOnly'">{{ t('tokens.favoriteCount', { count: searchFilteredTokenList.length }) }}</span>
+      <span v-else-if="settingsStore.tokenDisplayFilter === 'hiddenOnly'">{{ t('tokens.hiddenCount', { count: searchFilteredTokenList.length }) }}</span>
+      <span v-else-if="settingsStore.tokenDisplayFilter === 'all'">{{ t('tokens.totalCount', { count: searchFilteredTokenList.length }) }}</span>
+      <span v-else>{{ t('tokens.count', { count: searchFilteredTokenList.length }) }}</span>
+    </div>
   </div>
 </template>
 
 <style scoped>
-.filter-row {
+.control-row {
   display: flex;
   align-items: baseline;
-  gap: 20px;
+  flex-wrap: wrap;
+  gap: 10px 12px;
   margin: 10px;
 }
 
-.options-toggle {
+.options-toggle,
+.search-toggle {
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
+  opacity: 0.8;
 }
 
-.expanded {
-  transform: rotate(180deg);
+/* icons are taller than the lowercase text, drop them slightly below the
+   baseline so they read as vertically centered next to it */
+.options-toggle .q-icon,
+.search-toggle .q-icon {
+  vertical-align: -0.2em;
+}
+
+.options-toggle.active,
+.search-toggle.active {
+  color: var(--color-primary);
+  opacity: 1;
 }
 
 .options-panel {
@@ -149,28 +200,57 @@
   padding: 2px 8px;
 }
 
-.search-match-mobile {
-  display: none;
+/* segmented pill bar for the token type filter */
+.type-filter {
+  display: inline-flex;
+  background-color: rgba(128, 128, 128, 0.12);
+  border-radius: 20px;
+  padding: 3px;
+}
+
+.type-filter button {
+  border: none;
+  margin: 0;
+  background: transparent;
+  color: inherit;
+  border-radius: 17px;
+  padding: 4px 16px;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+
+.type-filter button.active {
+  background-color: var(--color-primary);
+  color: white;
 }
 
 .search-input {
-  width: 160px;
+  width: 180px;
   padding: 4px 10px;
   margin-left: auto;
 }
 
-@media (max-width: 450px) {
-  .hide-mobile {
-    display: none;
-  }
+.token-count {
+  text-align: center;
+  font-size: 0.85em;
+  opacity: 0.6;
+  margin: 10px 0 4px;
+}
 
-  .search-match-mobile {
-    display: inline;
-  }
-
+@media (max-width: 600px) {
+  /* search moves to its own full-width line, the icons stay beside the pills */
   .search-input {
-    width: 140px;
-    padding: 2px 10px;
+    order: 5;
+    flex-basis: 100%;
+    width: 100%;
+    margin-left: 0;
+  }
+  .search-toggle {
+    margin-left: auto;
+  }
+  .type-filter button {
+    padding: 4px 12px;
+    font-size: 0.85em;
   }
 }
 </style>

--- a/src/components/myTokens.vue
+++ b/src/components/myTokens.vue
@@ -27,6 +27,7 @@
       return;
     }
     showSearch.value = true;
+    // the input is behind a v-if, wait for the DOM update before focusing it
     await nextTick();
     searchInputRef.value?.focus();
   }
@@ -36,6 +37,7 @@
     if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
       event.preventDefault();
       showSearch.value = true;
+      // the input is behind a v-if, wait for the DOM update before focusing it
       void nextTick().then(() => searchInputRef.value?.focus());
     }
   }

--- a/src/components/myTokens.vue
+++ b/src/components/myTokens.vue
@@ -129,7 +129,10 @@
     <div v-else-if="searchFilteredTokenList?.length == 0" style="text-align: center;">
       {{ t('tokens.noMatch') }}
     </div>
-    <div v-for="tokenData in searchFilteredTokenList" :key="tokenData.category">
+    <!-- categories holding both fungibles and NFTs have two list entries, so the
+      category alone is not a unique key: duplicate keys break the keyed list diff
+      and leave stale items behind when filtering -->
+    <div v-for="tokenData in searchFilteredTokenList" :key="tokenData.category + ('amount' in tokenData ? '-ft' : '-nft')">
       <tokenItemFT v-if="'amount' in tokenData" :tokenData="tokenData"/>
       <tokenItemNFT v-else :tokenData="tokenData"/>
     </div>

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -333,6 +333,11 @@
   background-color: rgba(128, 128, 128, 0.14);
 }
 
+/* the whole card is the copy target, so pressing it anywhere plays the copy effect */
+.address-item:active .copyIcon {
+  transform: scale(1.2);
+}
+
 .address-item.current {
   border-color: rgba(10, 193, 143, 0.5);
 }

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -6,6 +6,7 @@
   import { useI18n } from 'vue-i18n'
   import { HDWallet, type TestNetHDWallet, GAP_SIZE } from 'mainnet-js';
   import { useWindowSize } from 'src/utils/composables'
+  import InfoPopup from 'src/components/general/InfoPopup.vue'
 
   const store = useStore()
   const settingsStore = useSettingsStore()
@@ -24,6 +25,7 @@
 
   const receivingAddresses = ref<AddressRow[]>([]);
   const changeAddresses = ref<AddressRow[]>([]);
+  const currentDepositIndex = ref(0);
   const selectedChain = ref("receiving" as "receiving" | "change");
   const showOptions = ref(false);
   const hideZeroBalances = ref(false);
@@ -73,6 +75,11 @@
     return showTokenAddresses.value ? row.tokenAddress : row.address;
   }
 
+  // The address the wallet page QR currently hands out
+  function isCurrentAddress(row: AddressRow): boolean {
+    return selectedChain.value === "receiving" && row.index === currentDepositIndex.value;
+  }
+
   // On desktop show the address prefix (bitcoincash: / bchtest:), it makes the
   // format explicit and recognizable; mobile only has room for the truncated body
   function truncateAddress(address: string) {
@@ -113,6 +120,7 @@
     if (!(hdWallet instanceof HDWallet)) return;
     receivingAddresses.value = buildAddressRows(hdWallet, hdWallet.depositIndex, false);
     changeAddresses.value = buildAddressRows(hdWallet, hdWallet.changeIndex, true);
+    currentDepositIndex.value = hdWallet.depositIndex;
   });
 </script>
 
@@ -143,6 +151,16 @@
       </div>
     </div>
 
+    <div class="intro">
+      {{ t('hdAddresses.intro') }}
+      <InfoPopup>
+        <div style="max-width: 320px;">
+          <div>{{ t('hdAddresses.infoReceivingChange') }}</div>
+          <div class="info-popup-note">{{ t('hdAddresses.infoPrivacyNote') }}</div>
+        </div>
+      </InfoPopup>
+    </div>
+
     <div v-if="!addressGroups.length" class="description">{{ t('hdAddresses.noAddresses') }}</div>
 
     <template v-for="group in addressGroups" :key="group.key">
@@ -153,6 +171,7 @@
       <template v-if="!collapsedGroups[group.key]">
         <div
           class="address-item"
+          :class="{ current: isCurrentAddress(row) }"
           v-for="row in group.rows"
           :key="row.index"
           :title="displayAddress(row)"
@@ -163,6 +182,7 @@
             <div class="address-text mono">
               {{ truncateAddress(displayAddress(row)) }}
               <img class="copyIcon" src="images/copyGrey.svg">
+              <span v-if="isCurrentAddress(row)" class="current-tag">{{ t('hdAddresses.currentTag') }}</span>
             </div>
             <div class="address-sub">
               {{ t('hdAddresses.txCount', { count: row.txCount }) }} ·
@@ -194,6 +214,10 @@
 </template>
 
 <style scoped>
+.intro {
+  margin: 10px 0;
+}
+
 .control-row {
   display: flex;
   align-items: baseline;
@@ -307,6 +331,18 @@
 
 .address-item:hover {
   background-color: rgba(128, 128, 128, 0.14);
+}
+
+.address-item.current {
+  border-color: rgba(10, 193, 143, 0.5);
+}
+
+.current-tag {
+  background-color: rgba(10, 193, 143, 0.15);
+  color: var(--color-primary);
+  border-radius: 10px;
+  padding: 0 8px;
+  margin-left: 2px;
 }
 
 .index-badge {

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-  import { ref, computed, watch, watchEffect } from 'vue';
-  import { copyToClipboard, satsToBch } from 'src/utils/utils';
+  import { ref, computed, watchEffect } from 'vue';
+  import { copyToClipboard, satsToBch, formatFiatAmount } from 'src/utils/utils';
   import { useStore } from 'src/stores/store'
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useI18n } from 'vue-i18n'
@@ -24,18 +24,25 @@
 
   const receivingAddresses = ref<AddressRow[]>([]);
   const changeAddresses = ref<AddressRow[]>([]);
-  const showUsedReceiving = ref(false);
-  const showUsedChange = ref(false);
+  const selectedChain = ref("receiving" as "receiving" | "change");
+  const showOptions = ref(false);
   const hideZeroBalances = ref(false);
   const showTokenAddresses = ref(false);
-  const changeDetailsOpen = ref(false);
+  const collapsedGroups = ref({ unused: false, used: false });
+  const showQrDialog = ref(false);
+  const qrDialogAddress = ref("");
 
-  watch(hideZeroBalances, (newVal) => {
-    if (newVal) {
-      showUsedReceiving.value = true;
-      showUsedChange.value = true;
-      changeDetailsOpen.value = true;
-    }
+  function toggleGroup(key: "unused" | "used") {
+    collapsedGroups.value[key] = !collapsedGroups.value[key];
+  }
+
+  function openQrDialog(row: AddressRow) {
+    qrDialogAddress.value = displayAddress(row);
+    showQrDialog.value = true;
+  }
+
+  const bchDisplayUnit = computed(() => {
+    return store.network === "mainnet" ? "BCH" : "tBCH";
   });
 
   function applyBalanceFilter(rows: AddressRow[]) {
@@ -51,14 +58,27 @@
   const filteredReceivingCount = computed(() => usedReceivingAddresses.value.length + unusedReceivingAddresses.value.length);
   const filteredChangeCount = computed(() => usedChangeAddresses.value.length + unusedChangeAddresses.value.length);
 
+  // Fresh addresses first: handing out an unused address is the main use of this page
+  const addressGroups = computed(() => {
+    const isReceiving = selectedChain.value === "receiving";
+    const unused = isReceiving ? unusedReceivingAddresses.value : unusedChangeAddresses.value;
+    const used = isReceiving ? usedReceivingAddresses.value : usedChangeAddresses.value;
+    const groups: { key: "unused" | "used"; label: string; rows: AddressRow[] }[] = [];
+    if (unused.length) groups.push({ key: "unused", label: t('hdAddresses.unusedAddresses'), rows: unused });
+    if (used.length) groups.push({ key: "used", label: t('hdAddresses.usedAddresses'), rows: used });
+    return groups;
+  });
+
   function displayAddress(row: AddressRow) {
     return showTokenAddresses.value ? row.tokenAddress : row.address;
   }
 
+  // On desktop show the address prefix (bitcoincash: / bchtest:), it makes the
+  // format explicit and recognizable; mobile only has room for the truncated body
   function truncateAddress(address: string) {
-    const body = address.split(':')[1] ?? "";
-    const chars = isMobile.value ? 5 : 8;
-    return body.slice(0, chars) + '...' + body.slice(-chars);
+    const [prefix, body = ""] = address.split(':');
+    if (isMobile.value) return body.slice(0, 5) + '...' + body.slice(-5);
+    return prefix + ':' + body.slice(0, 8) + '...' + body.slice(-8);
   }
 
   function getAddressBalance(utxos: { satoshis: bigint }[]): bigint {
@@ -97,237 +117,272 @@
 </script>
 
 <template>
-  <fieldset class="item" :class="{ dark: settingsStore.darkMode }">
+  <fieldset class="item">
     <legend>{{ t('hdAddresses.title') }}</legend>
 
-    <div class="filter-toggles">
-      <div class="filter-toggle">
+    <div class="control-row">
+      <div class="type-filter">
+        <button :class="{ active: selectedChain === 'receiving' }" @click="selectedChain = 'receiving'">
+          {{ t('hdAddresses.receiving') }} ({{ filteredReceivingCount }})
+        </button>
+        <button :class="{ active: selectedChain === 'change' }" @click="selectedChain = 'change'">
+          {{ t('hdAddresses.change') }} ({{ filteredChangeCount }})
+        </button>
+      </div>
+      <span class="options-toggle" :class="{ active: showOptions }" :title="t('hdAddresses.options')" @click="showOptions = !showOptions">
+        <q-icon name="tune" size="22px" />
+      </span>
+    </div>
+
+    <div v-if="showOptions" class="options-panel" :class="{ dark: settingsStore.darkMode }">
+      <div class="option-item">
         {{ t('hdAddresses.hideZeroBalances') }} <q-toggle v-model="hideZeroBalances" dense />
       </div>
-      <div class="filter-toggle">
+      <div class="option-item">
         {{ t('hdAddresses.showTokenAddresses') }} <q-toggle v-model="showTokenAddresses" dense />
       </div>
     </div>
 
-    <!-- Receiving Addresses -->
-    <details class="collapsible-section" open>
-      <summary>
-        <strong>{{ t('hdAddresses.receivingAddresses') }}</strong> ({{ filteredReceivingCount }})
-        <img class="icon" :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'">
-      </summary>
-      <table v-if="filteredReceivingCount" class="address-table">
-        <thead>
-          <tr>
-            <th>{{ t('hdAddresses.columns.index') }}</th>
-            <th>{{ t('hdAddresses.columns.address') }}</th>
-            <th>{{ t('hdAddresses.columns.balance') }}</th>
-            <th>{{ t('hdAddresses.columns.txs') }}</th>
-          </tr>
-        </thead>
-        <!-- Used receiving addresses (collapsible) -->
-        <tbody v-if="usedReceivingAddresses.length">
-          <tr class="section-toggle" @click="showUsedReceiving = !showUsedReceiving">
-            <td colspan="4">
-              {{ t('hdAddresses.usedAddresses') }} ({{ usedReceivingAddresses.length }})
-              <img class="icon" :class="{ open: showUsedReceiving }" :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'">
-            </td>
-          </tr>
-        </tbody>
-        <tbody v-if="showUsedReceiving" class="used-addresses">
-          <tr v-for="row in usedReceivingAddresses" :key="row.index">
-            <td class="mono">{{ row.index }}</td>
-            <td @click="copyToClipboard(displayAddress(row))" class="address-cell" :title="displayAddress(row)">
-              <span class="mono">{{ truncateAddress(displayAddress(row)) }}</span>
-              <img class="copyIcon" src="images/copyGrey.svg">
-            </td>
-            <td class="mono">{{ satsToBch(row.balance) }}</td>
-            <td>{{ row.txCount }}</td>
-          </tr>
-        </tbody>
-        <!-- Unused receiving addresses -->
-        <tbody>
-          <tr v-for="row in unusedReceivingAddresses" :key="row.index">
-            <td class="mono">{{ row.index }}</td>
-            <td @click="copyToClipboard(displayAddress(row))" class="address-cell" :title="displayAddress(row)">
-              <span class="mono">{{ truncateAddress(displayAddress(row)) }}</span>
-              <img class="copyIcon" src="images/copyGrey.svg">
-            </td>
-            <td class="mono">{{ satsToBch(row.balance) }}</td>
-            <td>{{ row.txCount }}</td>
-          </tr>
-        </tbody>
-      </table>
-      <div v-else class="description">{{ t('hdAddresses.noAddresses') }}</div>
-    </details>
+    <div v-if="!addressGroups.length" class="description">{{ t('hdAddresses.noAddresses') }}</div>
 
-    <!-- Change Addresses -->
-    <details class="collapsible-section" :open="changeDetailsOpen || undefined">
-      <summary>
-        <strong>{{ t('hdAddresses.changeAddresses') }}</strong> ({{ filteredChangeCount }})
-        <img class="icon" :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'">
-      </summary>
-      <table v-if="filteredChangeCount" class="address-table">
-        <thead>
-          <tr>
-            <th>{{ t('hdAddresses.columns.index') }}</th>
-            <th>{{ t('hdAddresses.columns.address') }}</th>
-            <th>{{ t('hdAddresses.columns.balance') }}</th>
-            <th>{{ t('hdAddresses.columns.txs') }}</th>
-          </tr>
-        </thead>
-        <!-- Used change addresses (collapsible) -->
-        <tbody v-if="usedChangeAddresses.length">
-          <tr class="section-toggle" @click="showUsedChange = !showUsedChange">
-            <td colspan="4">
-              {{ t('hdAddresses.usedAddresses') }} ({{ usedChangeAddresses.length }})
-              <img class="icon" :class="{ open: showUsedChange }" :src="settingsStore.darkMode ? 'images/chevron-square-down-lightGrey.svg' : 'images/chevron-square-down.svg'">
-            </td>
-          </tr>
-        </tbody>
-        <tbody v-if="showUsedChange" class="used-addresses">
-          <tr v-for="row in usedChangeAddresses" :key="row.index">
-            <td class="mono">{{ row.index }}</td>
-            <td @click="copyToClipboard(displayAddress(row))" class="address-cell" :title="displayAddress(row)">
-              <span class="mono">{{ truncateAddress(displayAddress(row)) }}</span>
+    <template v-for="group in addressGroups" :key="group.key">
+      <div class="group-header" @click="toggleGroup(group.key)">
+        {{ group.label }} ({{ group.rows.length }})
+        <q-icon name="expand_more" class="chevron" :class="{ collapsed: collapsedGroups[group.key] }" />
+      </div>
+      <template v-if="!collapsedGroups[group.key]">
+        <div
+          class="address-item"
+          v-for="row in group.rows"
+          :key="row.index"
+          :title="displayAddress(row)"
+          @click="copyToClipboard(displayAddress(row))"
+        >
+          <div class="index-badge mono">{{ row.index }}</div>
+          <div class="address-info">
+            <div class="address-text mono">
+              {{ truncateAddress(displayAddress(row)) }}
               <img class="copyIcon" src="images/copyGrey.svg">
-            </td>
-            <td class="mono">{{ satsToBch(row.balance) }}</td>
-            <td>{{ row.txCount }}</td>
-          </tr>
-        </tbody>
-        <!-- Unused change addresses -->
-        <tbody>
-          <tr v-for="row in unusedChangeAddresses" :key="row.index">
-            <td class="mono">{{ row.index }}</td>
-            <td @click="copyToClipboard(displayAddress(row))" class="address-cell" :title="displayAddress(row)">
-              <span class="mono">{{ truncateAddress(displayAddress(row)) }}</span>
-              <img class="copyIcon" src="images/copyGrey.svg">
-            </td>
-            <td class="mono">{{ satsToBch(row.balance) }}</td>
-            <td>{{ row.txCount }}</td>
-          </tr>
-        </tbody>
-      </table>
-      <div v-else class="description">{{ t('hdAddresses.noAddresses') }}</div>
-    </details>
+            </div>
+            <div class="address-sub">
+              {{ t('hdAddresses.txCount', { count: row.txCount }) }} ·
+              <span class="mono">{{ satsToBch(row.balance) }} {{ bchDisplayUnit }}</span>
+              <span v-if="row.balance && store.exchangeRate !== undefined">
+                ({{ formatFiatAmount(satsToBch(row.balance) * store.exchangeRate, settingsStore.currency) }})
+              </span>
+            </div>
+          </div>
+          <span class="qr-button" @click.stop="openQrDialog(row)">
+            <q-icon name="qr_code_2" size="22px" />
+          </span>
+        </div>
+      </template>
+    </template>
   </fieldset>
+
+  <q-dialog v-model="showQrDialog" transition-show="scale" transition-hide="scale">
+    <q-card class="qr-card">
+      <qr-code :contents="qrDialogAddress" class="qr-code" @click="copyToClipboard(qrDialogAddress)">
+        <img :src="showTokenAddresses ? 'images/tokenicon.png' : 'images/bch-icon.png'" slot="icon" /> <!-- eslint-disable-line -->
+      </qr-code>
+      <div class="full-address mono" @click="copyToClipboard(qrDialogAddress)">
+        {{ qrDialogAddress }}
+        <img class="copyIcon" src="images/copyGrey.svg">
+      </div>
+    </q-card>
+  </q-dialog>
 </template>
 
 <style scoped>
-.filter-toggles {
+.control-row {
   display: flex;
+  align-items: baseline;
   flex-wrap: wrap;
-  gap: 10px 20px;
-  margin-bottom: 10px;
+  gap: 10px 12px;
+  margin: 10px 0;
 }
 
-.filter-toggle {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.collapsible-section {
-  margin-bottom: 15px;
-}
-
-.collapsible-section summary {
+.options-toggle {
   cursor: pointer;
   user-select: none;
+  opacity: 0.8;
+  margin-left: auto;
+}
+
+/* icons are taller than the lowercase text, drop them slightly below the
+   baseline so they read as vertically centered next to it */
+.options-toggle .q-icon {
+  vertical-align: -0.2em;
+}
+
+.options-toggle.active {
+  color: var(--color-primary);
+  opacity: 1;
+}
+
+/* segmented pill bar for the receiving/change chain filter */
+.type-filter {
+  display: inline-flex;
+  background-color: rgba(128, 128, 128, 0.12);
+  border-radius: 20px;
+  padding: 3px;
+}
+
+.type-filter button {
+  border: none;
+  margin: 0;
+  background: transparent;
+  color: inherit;
+  border-radius: 17px;
+  padding: 4px 16px;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+
+.type-filter button.active {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.options-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px 25px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  background-color: var(--color-background-soft);
+  border-radius: 6px;
+}
+
+.options-panel.dark {
+  background-color: #232326;
+}
+
+.option-item {
+  margin-top: -5px;
   display: flex;
   align-items: center;
-  gap: 5px;
-  margin-bottom: 5px;
-}
-
-.collapsible-section summary::-webkit-details-marker {
-  display: none;
-}
-
-.collapsible-section summary::marker {
-  display: none;
-  content: '';
-}
-
-.collapsible-section[open] > summary .icon {
-  transform: rotate(180deg);
+  gap: 8px;
 }
 
 .description {
-  color: #888;
+  opacity: 0.6;
   margin: 5px 0 10px 0;
 }
 
-.address-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 10px;
-  font-size: 13px;
+.group-header {
+  text-transform: uppercase;
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  opacity: 0.6;
+  margin: 14px 2px 6px;
+  cursor: pointer;
+  user-select: none;
 }
 
-.address-table th,
-.address-table td {
-  padding: 3px 6px;
-  text-align: left;
-  border-bottom: 1px solid var(--color-border, #ddd);
+.group-header .chevron {
+  vertical-align: -0.2em;
+  transition: transform 0.2s;
 }
 
-.address-table th {
-  color: #888;
+.group-header .chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+/* neutral grey alphas keep the cards theme-agnostic: no separate dark mode rules needed */
+.address-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background-color: rgba(128, 128, 128, 0.06);
+  border-radius: 12px;
+  padding: 8px 14px;
+  margin-bottom: 6px;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.address-item:hover {
+  background-color: rgba(128, 128, 128, 0.14);
+}
+
+.index-badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(128, 128, 128, 0.15);
+}
+
+.qr-button {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.6;
+}
+
+.qr-button:hover {
+  opacity: 1;
+}
+
+.address-info {
+  min-width: 0;
+}
+
+.address-text {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.address-sub {
+  font-size: 0.85em;
+  opacity: 0.65;
 }
 
 .mono {
   font-family: monospace;
 }
 
-.address-cell {
+.qr-card {
+  padding: 1.5rem;
+  background-color: #fff;
+}
+body.dark .qr-card {
+  background-color: #050a14;
+}
+
+/* the qr-code needs a white background to stay scannable in dark mode */
+.qr-code {
+  display: block;
+  width: 230px;
+  height: 225px;
+  margin: 0 auto;
+  background-color: #fff;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
-.section-toggle {
+.full-address {
+  max-width: 260px;
+  margin-top: 1rem;
+  text-align: center;
+  word-break: break-all;
   cursor: pointer;
-  user-select: none;
 }
 
-.section-toggle td {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  color: #888;
-}
-
-.section-toggle .icon.open {
-  transform: rotate(180deg);
-}
-
-.icon {
-  width: 16px;
-  height: 16px;
-}
-
-.used-addresses tr {
-  border-left: 3px solid #888;
-}
-
-.used-addresses tr td:first-child {
-  padding-left: 2rem;
-}
-
-.dark .used-addresses tr {
-  border-left-color: #555;
-}
-
-/* Dark mode */
-.dark .description,
-.dark .address-table th {
-  color: #aaa;
-}
-
-.dark .address-table th,
-.dark .address-table td {
-  border-bottom-color: #444;
+@media only screen and (max-width: 600px) {
+  .type-filter button {
+    padding: 4px 12px;
+    font-size: 0.85em;
+  }
+  .address-item {
+    padding: 8px 10px;
+  }
 }
 </style>

--- a/src/components/tokenItems/tokenItemFT.vue
+++ b/src/components/tokenItems/tokenItemFT.vue
@@ -35,6 +35,12 @@
   const reservedSupplyInput = ref("")
   const tokenMetaData = ref(undefined as (BcmrTokenMetadata | undefined));
   const activeAction = ref<TokenActionType | null>(null);
+  const starAnimating = ref(false);
+
+  function toggleFavorite() {
+    store.toggleFavorite(tokenData.value.category);
+    starAnimating.value = true;
+  }
 
   tokenMetaData.value = store.bcmrRegistries?.[tokenData.value.category];
 
@@ -287,8 +293,8 @@
             ? (settingsStore.darkMode ? 'images/eye-off-outline-lightGrey.svg' : 'images/eye-off-outline.svg')
             : (settingsStore.darkMode ? 'images/eye-outline-lightGrey.svg' : 'images/eye-outline.svg')">
         </span>
-        <span @click="store.toggleFavorite(tokenData.category)" class="boxStarIcon" :title="settingsStore.featuredTokens.includes(tokenData.category) ? t('tokenItem.visibility.unfavoriteToken') : t('tokenItem.visibility.favoriteToken')">
-          <img :src="settingsStore.featuredTokens.includes(tokenData.category) ? 'images/star-full.svg' :
+        <span @click="toggleFavorite" class="boxStarIcon" :title="settingsStore.featuredTokens.includes(tokenData.category) ? t('tokenItem.visibility.unfavoriteToken') : t('tokenItem.visibility.favoriteToken')">
+          <img :class="{ 'star-pop': starAnimating }" @animationend="starAnimating = false" :src="settingsStore.featuredTokens.includes(tokenData.category) ? 'images/star-full.svg' :
             settingsStore.darkMode? 'images/star-empty-grey.svg' : 'images/star-empty.svg'">
         </span>
       </div>

--- a/src/components/tokenItems/tokenItemNFT.vue
+++ b/src/components/tokenItems/tokenItemNFT.vue
@@ -43,6 +43,12 @@
   const selectedNfts = ref(new Set<string>());
   const activeAction = ref<TokenActionType | null>(null);
   const imageLoadFailed = ref(false);
+  const starAnimating = ref(false);
+
+  function toggleFavorite() {
+    store.toggleFavorite(tokenData.value.category);
+    starAnimating.value = true;
+  }
 
   let fetchedMetadataChildren = false
 
@@ -408,8 +414,8 @@
             ? (settingsStore.darkMode ? 'images/eye-off-outline-lightGrey.svg' : 'images/eye-off-outline.svg')
             : (settingsStore.darkMode ? 'images/eye-outline-lightGrey.svg' : 'images/eye-outline.svg')">
         </span>
-        <span @click="store.toggleFavorite(tokenData.category)" class="boxStarIcon" :title="settingsStore.featuredTokens.includes(tokenData.category) ? t('tokenItem.visibility.unfavoriteToken') : t('tokenItem.visibility.favoriteToken')">
-          <img :src="settingsStore.featuredTokens.includes(tokenData.category) ? 'images/star-full.svg' :
+        <span @click="toggleFavorite" class="boxStarIcon" :title="settingsStore.featuredTokens.includes(tokenData.category) ? t('tokenItem.visibility.unfavoriteToken') : t('tokenItem.visibility.favoriteToken')">
+          <img :class="{ 'star-pop': starAnimating }" @animationend="starAnimating = false" :src="settingsStore.featuredTokens.includes(tokenData.category) ? 'images/star-full.svg' :
             settingsStore.darkMode? 'images/star-empty-grey.svg' : 'images/star-empty.svg'">
         </span>
       </div>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -145,6 +145,31 @@ input[type='number'] {
   justify-content: center;
   align-items: center;
 }
+.boxStarIcon img {
+  transition: transform 0.15s;
+}
+@media (hover: hover) {
+  .boxStarIcon:hover img {
+    transform: scale(1.15);
+  }
+}
+.star-pop {
+  animation: star-pop 0.35s ease;
+}
+@keyframes star-pop {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.4) rotate(-12deg);
+  }
+  70% {
+    transform: scale(0.9);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
 .tokenBaseInfo1 {
   width: 370px;
   display: block;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -60,6 +60,26 @@ img {
   background-color: var(--color-primary);
   border-radius: 50%;
 }
+/* two gentle pulse rings when the dot appears, then rest */
+.notification-dot::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background-color: var(--color-primary);
+  opacity: 0;
+  animation: notification-pulse 1.6s ease-out 2;
+}
+@keyframes notification-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(3);
+    opacity: 0;
+  }
+}
 
 .primaryButton {
   background-color: var(--color-primary);
@@ -75,9 +95,16 @@ img {
   vertical-align: text-bottom;
   margin-bottom: 1px;
   margin-left: 5px;
+  transition: transform 0.15s;
 }
 .copyIcon:hover {
   cursor: pointer;
+}
+/* single pop on click: grows while pressed, settles on release; the parent rule
+   also plays the effect when the copy target is the text next to the icon */
+.copyIcon:active,
+:active > .copyIcon {
+  transform: scale(1.2);
 }
 .depositAddr,
 .category {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -664,19 +664,15 @@
   },
   "hdAddresses": {
     "title": "HD Wallet Adressen",
-    "receivingAddresses": "Empfangsadressen",
-    "changeAddresses": "Wechseladressen",
+    "receiving": "Empfang",
+    "change": "Wechselgeld",
     "usedAddresses": "Verwendet",
     "unusedAddresses": "Unbenutzt",
     "noAddresses": "Noch keine Adressen gescannt",
+    "options": "Optionen",
     "hideZeroBalances": "Null-Guthaben ausblenden",
     "showTokenAddresses": "Adressen im Token-Format anzeigen",
-    "columns": {
-      "index": "Index",
-      "address": "Adresse",
-      "balance": "Guthaben",
-      "txs": "Txs"
-    }
+    "txCount": "{count} Txs"
   },
   "sweepPrivateKey": {
     "title": "Privaten Schlüssel sweepen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -387,10 +387,16 @@
     "transactionCount": "{count} Transaktionen",
     "options": "Optionen",
     "filter": {
+      "label": "Anzeigen:",
       "all": "Alle",
       "bchTxs": "BCH-Txs",
       "tokenTxs": "Token-Txs",
       "dateRange": "Zeitraum:"
+    },
+    "directionFilter": {
+      "all": "Alle",
+      "incoming": "Eingehend",
+      "outgoing": "Ausgehend"
     },
     "showFiatValue": "Fiat-Wert anzeigen",
     "hideBalanceColumn": "Guthaben ausblenden",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -664,6 +664,10 @@
   },
   "hdAddresses": {
     "title": "HD Wallet Adressen",
+    "intro": "Eine Übersicht aller Adressen des Wallets, gruppiert nach verwendet und unbenutzt.",
+    "infoReceivingChange": "Empfangsadressen werden geteilt, um Zahlungen zu empfangen. Wechseladressen werden intern verwendet: Beim Senden einer Transaktion schickt das Wallet das restliche Wechselgeld an eine neue eigene Wechseladresse zurück.",
+    "infoPrivacyNote": "Eine neue Adresse für jede Zahlung hilft, die Privatsphäre zu schützen.",
+    "currentTag": "aktuell",
     "receiving": "Empfang",
     "change": "Wechselgeld",
     "usedAddresses": "Verwendet",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -175,9 +175,13 @@
       "all": "Alle Tokens",
       "hiddenOnly": "Nur versteckte"
     },
+    "typeFilter": {
+      "all": "Alle",
+      "fungibles": "Fungible",
+      "nfts": "NFTs"
+    },
     "editVisibility": "Sichtbarkeit bearbeiten",
-    "searchPlaceholder": "Tokens suchen...",
-    "searchMatches": "{count} Suchergebnisse"
+    "searchPlaceholder": "Tokens suchen..."
   },
   "tokenItem": {
     "name": "Name:",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -383,7 +383,6 @@
     "transactionCount": "{count} Transaktionen",
     "options": "Optionen",
     "filter": {
-      "label": "Anzeigen:",
       "all": "Alle",
       "bchTxs": "BCH-Txs",
       "tokenTxs": "Token-Txs",
@@ -393,12 +392,13 @@
     "hideBalanceColumn": "Guthaben ausblenden",
     "exportCsv": "CSV exportieren",
     "exportFailed": "CSV-Export fehlgeschlagen",
-    "columns": {
-      "date": "Datum",
-      "amount": "Betrag",
-      "balance": "Guthaben",
-      "tokens": "Tokens"
-    },
+    "searchPlaceholder": "Token oder Tx-ID suchen...",
+    "noMatch": "Keine Transaktionen passen zum Filter",
+    "sent": "Gesendet",
+    "received": "Empfangen",
+    "today": "Heute",
+    "yesterday": "Gestern",
+    "balanceLabel": "Guthaben:",
     "csv": {
       "date": "Datum (UTC)",
       "transactionId": "Transaktions-ID",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -664,19 +664,15 @@
   },
   "hdAddresses": {
     "title": "HD Wallet Addresses",
-    "receivingAddresses": "Receiving Addresses",
-    "changeAddresses": "Change Addresses",
+    "receiving": "Receiving",
+    "change": "Change",
     "usedAddresses": "Used",
     "unusedAddresses": "Unused",
     "noAddresses": "No addresses scanned yet",
+    "options": "Options",
     "hideZeroBalances": "Hide zero balances",
     "showTokenAddresses": "Show addresses in token format",
-    "columns": {
-      "index": "Index",
-      "address": "Address",
-      "balance": "Balance",
-      "txs": "Txs"
-    }
+    "txCount": "{count} txs"
   },
   "sweepPrivateKey": {
     "title": "Sweep Private Key",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -387,10 +387,16 @@
     "transactionCount": "{count} Transactions",
     "options": "Options",
     "filter": {
+      "label": "Show:",
       "all": "All",
       "bchTxs": "BCH txs",
       "tokenTxs": "Token txs",
       "dateRange": "Filter range:"
+    },
+    "directionFilter": {
+      "all": "All",
+      "incoming": "Incoming",
+      "outgoing": "Outgoing"
     },
     "showFiatValue": "Show fiat value",
     "hideBalanceColumn": "Hide balance",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -383,7 +383,6 @@
     "transactionCount": "{count} Transactions",
     "options": "Options",
     "filter": {
-      "label": "Show:",
       "all": "All",
       "bchTxs": "BCH txs",
       "tokenTxs": "Token txs",
@@ -393,12 +392,13 @@
     "hideBalanceColumn": "Hide balance",
     "exportCsv": "Export CSV",
     "exportFailed": "CSV export failed",
-    "columns": {
-      "date": "Date",
-      "amount": "Amount",
-      "balance": "Balance",
-      "tokens": "Tokens"
-    },
+    "searchPlaceholder": "Search token or tx id...",
+    "noMatch": "No transactions match filter",
+    "sent": "Sent",
+    "received": "Received",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "balanceLabel": "Balance:",
     "csv": {
       "date": "Date (UTC)",
       "transactionId": "Transaction Id",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -664,6 +664,10 @@
   },
   "hdAddresses": {
     "title": "HD Wallet Addresses",
+    "intro": "An overview of all the wallet's addresses, grouped by used and unused.",
+    "infoReceivingChange": "Receiving addresses are the addresses you share to get paid. Change addresses are used internally: when sending a transaction, the wallet returns the leftover change to a fresh change address of its own.",
+    "infoPrivacyNote": "Using a new address for each payment helps protect your privacy.",
+    "currentTag": "current",
     "receiving": "Receiving",
     "change": "Change",
     "usedAddresses": "Used",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -175,9 +175,13 @@
       "all": "All tokens",
       "hiddenOnly": "Hidden only"
     },
+    "typeFilter": {
+      "all": "All",
+      "fungibles": "Fungible",
+      "nfts": "NFTs"
+    },
     "editVisibility": "Edit visibility",
-    "searchPlaceholder": "Search tokens...",
-    "searchMatches": "{count} search matches"
+    "searchPlaceholder": "Search tokens..."
   },
   "tokenItem": {
     "name": "Name:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -383,7 +383,6 @@
     "transactionCount": "{count} Transacciones",
     "options": "Opciones",
     "filter": {
-      "label": "Mostrar:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
@@ -393,12 +392,13 @@
     "hideBalanceColumn": "Ocultar saldo",
     "exportCsv": "Exportar CSV",
     "exportFailed": "Error al exportar CSV",
-    "columns": {
-      "date": "Fecha",
-      "amount": "Cantidad",
-      "balance": "Saldo",
-      "tokens": "Tokens"
-    },
+    "searchPlaceholder": "Buscar token o id de tx...",
+    "noMatch": "Ninguna transacción coincide con el filtro",
+    "sent": "Enviado",
+    "received": "Recibido",
+    "today": "Hoy",
+    "yesterday": "Ayer",
+    "balanceLabel": "Saldo:",
     "csv": {
       "date": "Fecha (UTC)",
       "transactionId": "ID de transacción",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -387,10 +387,16 @@
     "transactionCount": "{count} Transacciones",
     "options": "Opciones",
     "filter": {
+      "label": "Mostrar:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
       "dateRange": "Rango de fechas:"
+    },
+    "directionFilter": {
+      "all": "Todas",
+      "incoming": "Entrantes",
+      "outgoing": "Salientes"
     },
     "showFiatValue": "Mostrar valor en fiat",
     "hideBalanceColumn": "Ocultar saldo",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -175,9 +175,13 @@
       "all": "Todos los tokens",
       "hiddenOnly": "Solo ocultos"
     },
+    "typeFilter": {
+      "all": "Todos",
+      "fungibles": "Fungibles",
+      "nfts": "NFTs"
+    },
     "editVisibility": "Editar visibilidad",
-    "searchPlaceholder": "Buscar tokens...",
-    "searchMatches": "{count} resultados"
+    "searchPlaceholder": "Buscar tokens..."
   },
   "tokenItem": {
     "name": "Nombre:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -664,6 +664,10 @@
   },
   "hdAddresses": {
     "title": "Direcciones de billetera HD",
+    "intro": "Un resumen de todas las direcciones de la billetera, agrupadas por usadas y sin usar.",
+    "infoReceivingChange": "Las direcciones de recepción se comparten para recibir pagos. Las direcciones de cambio se usan internamente: al enviar una transacción, la billetera devuelve el cambio restante a una nueva dirección de cambio propia.",
+    "infoPrivacyNote": "Usar una nueva dirección para cada pago ayuda a proteger la privacidad.",
+    "currentTag": "actual",
     "receiving": "Recepción",
     "change": "Cambio",
     "usedAddresses": "Usadas",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -664,19 +664,15 @@
   },
   "hdAddresses": {
     "title": "Direcciones de billetera HD",
-    "receivingAddresses": "Direcciones de recepción",
-    "changeAddresses": "Direcciones de cambio",
+    "receiving": "Recepción",
+    "change": "Cambio",
     "usedAddresses": "Usadas",
     "unusedAddresses": "Sin usar",
     "noAddresses": "Aún no se han escaneado direcciones",
+    "options": "Opciones",
     "hideZeroBalances": "Ocultar saldos en cero",
     "showTokenAddresses": "Mostrar direcciones en formato de token",
-    "columns": {
-      "index": "Índice",
-      "address": "Dirección",
-      "balance": "Saldo",
-      "txs": "Txs"
-    }
+    "txCount": "{count} txs"
   },
   "sweepPrivateKey": {
     "title": "Barrer clave privada",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -664,6 +664,10 @@
   },
   "hdAddresses": {
     "title": "Adresses du portefeuille HD",
+    "intro": "Un aperçu de toutes les adresses du portefeuille, regroupées par utilisées et non utilisées.",
+    "infoReceivingChange": "Les adresses de réception sont celles que vous partagez pour recevoir des paiements. Les adresses de monnaie sont utilisées en interne : lors d'un envoi, le portefeuille renvoie la monnaie restante vers une nouvelle adresse de monnaie qui lui appartient.",
+    "infoPrivacyNote": "Utiliser une nouvelle adresse pour chaque paiement aide à protéger la vie privée.",
+    "currentTag": "actuelle",
     "receiving": "Réception",
     "change": "Monnaie",
     "usedAddresses": "Utilisées",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -383,7 +383,6 @@
     "transactionCount": "{count} Transactions",
     "options": "Options",
     "filter": {
-      "label": "Afficher :",
       "all": "Toutes",
       "bchTxs": "Txs BCH",
       "tokenTxs": "Txs tokens",
@@ -393,12 +392,13 @@
     "hideBalanceColumn": "Masquer le solde",
     "exportCsv": "Exporter en CSV",
     "exportFailed": "Échec de l'export CSV",
-    "columns": {
-      "date": "Date",
-      "amount": "Montant",
-      "balance": "Solde",
-      "tokens": "Tokens"
-    },
+    "searchPlaceholder": "Rechercher token ou id de tx...",
+    "noMatch": "Aucune transaction ne correspond au filtre",
+    "sent": "Envoyé",
+    "received": "Reçu",
+    "today": "Aujourd'hui",
+    "yesterday": "Hier",
+    "balanceLabel": "Solde :",
     "csv": {
       "date": "Date (UTC)",
       "transactionId": "ID de transaction",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -175,9 +175,13 @@
       "all": "Tous les tokens",
       "hiddenOnly": "Masqués uniquement"
     },
+    "typeFilter": {
+      "all": "Tous",
+      "fungibles": "Fongibles",
+      "nfts": "NFTs"
+    },
     "editVisibility": "Modifier la visibilité",
-    "searchPlaceholder": "Rechercher...",
-    "searchMatches": "{count} résultats"
+    "searchPlaceholder": "Rechercher..."
   },
   "tokenItem": {
     "name": "Nom :",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -664,19 +664,15 @@
   },
   "hdAddresses": {
     "title": "Adresses du portefeuille HD",
-    "receivingAddresses": "Adresses de réception",
-    "changeAddresses": "Adresses de monnaie",
+    "receiving": "Réception",
+    "change": "Monnaie",
     "usedAddresses": "Utilisées",
     "unusedAddresses": "Non utilisées",
     "noAddresses": "Aucune adresse analysée pour le moment",
+    "options": "Options",
     "hideZeroBalances": "Masquer les soldes nuls",
     "showTokenAddresses": "Afficher les adresses au format token",
-    "columns": {
-      "index": "Index",
-      "address": "Adresse",
-      "balance": "Solde",
-      "txs": "Txs"
-    }
+    "txCount": "{count} txs"
   },
   "sweepPrivateKey": {
     "title": "Balayer une clé privée",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -387,10 +387,16 @@
     "transactionCount": "{count} Transactions",
     "options": "Options",
     "filter": {
+      "label": "Afficher :",
       "all": "Toutes",
       "bchTxs": "Txs BCH",
       "tokenTxs": "Txs tokens",
       "dateRange": "Plage de dates :"
+    },
+    "directionFilter": {
+      "all": "Toutes",
+      "incoming": "Entrantes",
+      "outgoing": "Sortantes"
     },
     "showFiatValue": "Afficher la valeur en devise",
     "hideBalanceColumn": "Masquer le solde",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -664,19 +664,15 @@
   },
   "hdAddresses": {
     "title": "Endereços da Carteira HD",
-    "receivingAddresses": "Endereços de recebimento",
-    "changeAddresses": "Endereços de troco",
+    "receiving": "Recebimento",
+    "change": "Troco",
     "usedAddresses": "Usados",
     "unusedAddresses": "Não usados",
     "noAddresses": "Nenhum endereço escaneado ainda",
+    "options": "Opções",
     "hideZeroBalances": "Ocultar saldos zerados",
     "showTokenAddresses": "Mostrar endereços no formato de token",
-    "columns": {
-      "index": "Índice",
-      "address": "Endereço",
-      "balance": "Saldo",
-      "txs": "Txs"
-    }
+    "txCount": "{count} txs"
   },
   "sweepPrivateKey": {
     "title": "Sweep de Chave Privada",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -387,10 +387,16 @@
     "transactionCount": "{count} Transações",
     "options": "Opções",
     "filter": {
+      "label": "Exibir:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
       "dateRange": "Intervalo de datas:"
+    },
+    "directionFilter": {
+      "all": "Todas",
+      "incoming": "Recebidas",
+      "outgoing": "Enviadas"
     },
     "showFiatValue": "Mostrar valor em fiat",
     "hideBalanceColumn": "Ocultar saldo",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -175,9 +175,13 @@
       "all": "Todos os tokens",
       "hiddenOnly": "Apenas ocultos"
     },
+    "typeFilter": {
+      "all": "Todos",
+      "fungibles": "Fungíveis",
+      "nfts": "NFTs"
+    },
     "editVisibility": "Editar visibilidade",
-    "searchPlaceholder": "Buscar tokens...",
-    "searchMatches": "{count} resultados encontrados"
+    "searchPlaceholder": "Buscar tokens..."
   },
   "tokenItem": {
     "name": "Nome:",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -664,6 +664,10 @@
   },
   "hdAddresses": {
     "title": "Endereços da Carteira HD",
+    "intro": "Um resumo de todos os endereços da carteira, agrupados por usados e não usados.",
+    "infoReceivingChange": "Os endereços de recebimento são compartilhados para receber pagamentos. Os endereços de troco são usados internamente: ao enviar uma transação, a carteira devolve o troco restante para um novo endereço de troco próprio.",
+    "infoPrivacyNote": "Usar um novo endereço para cada pagamento ajuda a proteger a privacidade.",
+    "currentTag": "atual",
     "receiving": "Recebimento",
     "change": "Troco",
     "usedAddresses": "Usados",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -383,7 +383,6 @@
     "transactionCount": "{count} Transações",
     "options": "Opções",
     "filter": {
-      "label": "Exibir:",
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
@@ -393,12 +392,13 @@
     "hideBalanceColumn": "Ocultar saldo",
     "exportCsv": "Exportar CSV",
     "exportFailed": "Falha ao exportar CSV",
-    "columns": {
-      "date": "Data",
-      "amount": "Valor",
-      "balance": "Saldo",
-      "tokens": "Tokens"
-    },
+    "searchPlaceholder": "Buscar token ou id de tx...",
+    "noMatch": "Nenhuma transação corresponde ao filtro",
+    "sent": "Enviado",
+    "received": "Recebido",
+    "today": "Hoje",
+    "yesterday": "Ontem",
+    "balanceLabel": "Saldo:",
     "csv": {
       "date": "Data (UTC)",
       "transactionId": "ID da transação",


### PR DESCRIPTION
# Redesign history, tokens and addresses pages

Reworks the three list views around a shared design language: segmented pill filters, search and options controls behind icons, and card-based rows using theme-agnostic styling that needs no separate dark mode rules.

## History page

Replaces the fixed-column grid table with a responsive card list:

- Transactions grouped under day headers (Today / Yesterday / date), pending transactions in their own group
- Each card shows a direction badge, sent/received label and time, the signed BCH amount with optional fiat value and running balance, and token changes as wrapping chips on their own line, so transactions with multiple tokens lay out cleanly on desktop and mobile alike
- New direction filter (All / Incoming / Outgoing) as a segmented pill bar
- New search by token name, symbol, category or tx id (Ctrl+F focuses it)
- The Show filter (all / BCH / token txs), date range, fiat and balance toggles and CSV export remain in the options panel, now behind a tune icon; the transaction count moved to the bottom by the pagination

## Tokens page

Brought in line with the history page:

- Same control row: pill bar left, search and options icons right
- New token type filter: All / Fungible / NFTs
- Token count moved to the bottom of the list; shows a plain count while a search or type filter narrows the list
- Fix: categories holding both fungibles and NFTs shared one v-for key, leaving stale items in the list when filtering

## HD addresses page

Redesigned from a dense table into the same card style:

- Receiving/Change pill toggle instead of two stacked collapsible sections, filter toggles behind the options icon
- Address cards with derivation index badge, truncated address (with prefix on desktop) that copies on click, tx count and balance with fiat value for funded addresses
- Unused and used addresses under collapsible group headers
- New per-address QR dialog with the BCH or token icon embedded
- A "current" tag marks the receiving address the wallet page QR hands out
- One-line explainer with an info popup covering receiving vs change addresses and the privacy benefit of fresh addresses

## Micro-interactions

- Favorite star pops on toggle, copy icons pop while pressed (also when the copy target is the surrounding text or card)
- Wallet page address type toggle rotates a half turn on switch
- Settings notification dot pulses twice when it appears

## Search behavior

On mobile the search input hides behind a search icon that reveals it full-width and focused; closing clears the query so a hidden search can never silently filter the list. On desktop the input stays inline.

All five locale files updated in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
