### PR TITLE
add derivation path and wallet activity scan on seed phrase import

### DIFF
--- a/src/components/general/derivationPathSelect.vue
+++ b/src/components/general/derivationPathSelect.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+  import { ref, computed, watch } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { DERIVATION_PATHS, scanDerivationPaths } from 'src/utils/walletUtils'
+  import type { DerivationPathType, DerivationPathDetectionResult } from 'src/utils/walletUtils'
+  const { t } = useI18n()
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: DerivationPathType]
+  }>()
+
+  const props = defineProps<{
+    modelValue: DerivationPathType
+    seedPhrase: string
+    seedPhraseValid: boolean
+    walletType: 'single' | 'hd'
+  }>()
+
+  const selectedPath = computed({
+    get: () => props.modelValue,
+    set: (value: DerivationPathType) => emit('update:modelValue', value)
+  })
+
+  const detectionStatus = ref<'idle' | 'scanning' | DerivationPathDetectionResult>('idle')
+  const multipleAddressesUsed = ref(false)
+
+  const SCAN_TIMEOUT_MS = 15_000
+
+  // Incremented on every seed phrase change so a scan can tell its result is outdated
+  let scanId = 0
+
+  // A scan result no longer applies once the seed phrase changes
+  watch(() => [props.seedPhrase, props.seedPhraseValid], () => {
+    scanId++
+    detectionStatus.value = 'idle'
+    multipleAddressesUsed.value = false
+  })
+
+  async function scanForWalletActivity() {
+    if (!props.seedPhraseValid || detectionStatus.value === 'scanning') return
+    const currentScanId = ++scanId
+    detectionStatus.value = 'scanning'
+    try {
+      const timeout = new Promise<never>((_resolve, reject) =>
+        setTimeout(() => reject(new Error('derivation path scan timed out')), SCAN_TIMEOUT_MS)
+      )
+      const result = await Promise.race([scanDerivationPaths(props.seedPhrase), timeout])
+      if (currentScanId !== scanId) return
+      detectionStatus.value = result.path
+      multipleAddressesUsed.value = result.multipleAddressesUsed
+      if (result.path === 'standard' || result.path === 'bitcoindotcom') {
+        selectedPath.value = result.path
+      }
+    } catch {
+      // Scanning is best-effort: on electrum errors fall back to manual selection
+      if (currentScanId !== scanId) return
+      detectionStatus.value = 'idle'
+    }
+  }
+</script>
+
+<template>
+  <div>
+    <label>{{ t('derivationPathSelect.label') }} </label>
+    <select v-model="selectedPath">
+      <option value="standard">{{ DERIVATION_PATHS.standard.parent }} ({{ t('derivationPathSelect.standard') }})</option>
+      <option value="bitcoindotcom">{{ DERIVATION_PATHS.bitcoindotcom.parent }} ({{ t('derivationPathSelect.bitcoindotcom') }})</option>
+    </select>
+    <div v-if="seedPhraseValid && detectionStatus === 'idle'" style="margin-top: 5px; font-size: smaller; color: grey;">
+      <i18n-t keypath="derivationPathSelect.scanPrompt" tag="span">
+        <template #link>
+          <span class="scan-link" @click="scanForWalletActivity()">🔍 {{ t('derivationPathSelect.scanLinkText') }}</span>
+        </template>
+      </i18n-t>
+    </div>
+    <div v-else-if="detectionStatus !== 'idle'" style="margin-top: 5px; font-size: smaller; color: grey;">
+      <span v-if="detectionStatus === 'scanning'">{{ t('derivationPathSelect.scanning') }}</span>
+      <span v-else-if="detectionStatus === 'standard' || detectionStatus === 'bitcoindotcom'">
+        {{ t('derivationPathSelect.detected', { path: DERIVATION_PATHS[detectionStatus].parent }) }}
+      </span>
+      <span v-else-if="detectionStatus === 'both'">{{ t('derivationPathSelect.detectedBoth') }}</span>
+      <span v-else>{{ t('derivationPathSelect.noneFound') }}</span>
+    </div>
+    <div v-if="multipleAddressesUsed && walletType === 'single'" style="margin-top: 5px; font-size: smaller; color: orange;">
+      {{ t('derivationPathSelect.multiAddressWarning') }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.scan-link {
+  color: var(--color-primary);
+  cursor: pointer;
+}
+.scan-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/components/general/derivationPathSelect.vue
+++ b/src/components/general/derivationPathSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ref, computed, watch } from 'vue'
+  import { ref, watch } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { DERIVATION_PATHS, scanDerivationPaths } from 'src/utils/walletUtils'
   import type { DerivationPathType, DerivationPathDetectionResult } from 'src/utils/walletUtils'
@@ -16,36 +16,40 @@
     walletType: 'single' | 'hd'
   }>()
 
-  const selectedPath = computed({
-    get: () => props.modelValue,
-    set: (value: DerivationPathType) => emit('update:modelValue', value)
+  const selectedPath = ref<DerivationPathType>(props.modelValue)
+
+  // Emit changes to parent
+  watch(selectedPath, (value) => {
+    emit('update:modelValue', value)
   })
+
+  const SCAN_TIMEOUT_MS = 15_000
 
   const detectionStatus = ref<'idle' | 'scanning' | DerivationPathDetectionResult>('idle')
   const multipleAddressesUsed = ref(false)
 
-  const SCAN_TIMEOUT_MS = 15_000
-
-  // Incremented on every seed phrase change so a scan can tell its result is outdated
-  let scanId = 0
+  // Bumped on every seed phrase change so an in-flight scan can tell its result is
+  // for an outdated seed phrase. Deliberately a counter instead of comparing against
+  // the scanned seed phrase, to avoid keeping a copy of the seed in memory.
+  let scanGeneration = 0
 
   // A scan result no longer applies once the seed phrase changes
-  watch(() => [props.seedPhrase, props.seedPhraseValid], () => {
-    scanId++
+  watch(() => props.seedPhrase, () => {
+    scanGeneration++
     detectionStatus.value = 'idle'
     multipleAddressesUsed.value = false
   })
 
   async function scanForWalletActivity() {
     if (!props.seedPhraseValid || detectionStatus.value === 'scanning') return
-    const currentScanId = ++scanId
+    const startedForGeneration = scanGeneration
     detectionStatus.value = 'scanning'
     try {
       const timeout = new Promise<never>((_resolve, reject) =>
         setTimeout(() => reject(new Error('derivation path scan timed out')), SCAN_TIMEOUT_MS)
       )
       const result = await Promise.race([scanDerivationPaths(props.seedPhrase), timeout])
-      if (currentScanId !== scanId) return
+      if (scanGeneration !== startedForGeneration) return
       detectionStatus.value = result.path
       multipleAddressesUsed.value = result.multipleAddressesUsed
       if (result.path === 'standard' || result.path === 'bitcoindotcom') {
@@ -53,7 +57,7 @@
       }
     } catch {
       // Scanning is best-effort: on electrum errors fall back to manual selection
-      if (currentScanId !== scanId) return
+      if (scanGeneration !== startedForGeneration) return
       detectionStatus.value = 'idle'
     }
   }

--- a/src/components/settings/addWallet.vue
+++ b/src/components/settings/addWallet.vue
@@ -3,9 +3,10 @@
   import { useQuasar } from 'quasar'
   import { useStore } from 'src/stores/store'
   import { namedWalletExistsInDb } from 'src/utils/dbUtils'
-  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet, DERIVATION_PATHS } from 'src/utils/walletUtils'
+  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet } from 'src/utils/walletUtils'
   import type { DerivationPathType } from 'src/utils/walletUtils'
   import seedPhraseInput from '../general/seedPhraseInput.vue'
+  import derivationPathSelect from '../general/derivationPathSelect.vue'
   import { useI18n } from 'vue-i18n'
   const store = useStore()
   const $q = useQuasar()
@@ -179,11 +180,7 @@
       <div style="margin-bottom: 15px;">
         <seedPhraseInput v-model="seedPhrase" v-model:isValid="seedPhraseValid" />
         <div style="margin-top: 15px;">
-          <label>{{ t('addWallet.derivationPath.label') }} </label>
-          <select v-model="selectedDerivationPath">
-            <option value="standard">{{ DERIVATION_PATHS.standard.parent }} ({{ t('addWallet.derivationPath.standard') }})</option>
-            <option value="bitcoindotcom">{{ DERIVATION_PATHS.bitcoindotcom.parent }} ({{ t('addWallet.derivationPath.bitcoindotcom') }})</option>
-          </select>
+          <derivationPathSelect v-model="selectedDerivationPath" :seed-phrase="seedPhrase" :seed-phrase-valid="seedPhraseValid" :wallet-type="walletType" />
         </div>
         <input
           @click="importWallet()"

--- a/src/components/walletOnboarding.vue
+++ b/src/components/walletOnboarding.vue
@@ -7,8 +7,9 @@
   import { defaultWalletName } from 'src/stores/constants'
   import { useSettingsStore } from 'src/stores/settingsStore'
   import seedPhraseInput from './general/seedPhraseInput.vue'
+  import derivationPathSelect from './general/derivationPathSelect.vue'
   import LanguageSelector from './general/LanguageSelector.vue'
-  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet, DERIVATION_PATHS } from 'src/utils/walletUtils'
+  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet } from 'src/utils/walletUtils'
   import type { DerivationPathType } from 'src/utils/walletUtils'
   import type { Currency } from 'src/interfaces/interfaces'
   const store = useStore()
@@ -240,11 +241,7 @@
           </div>
         </div>
         <div style="margin-bottom: 20px;">
-          <span>{{ t('onboarding.derivationPath.label') }} </span>
-          <select v-model="selectedDerivationPath">
-            <option value="standard">{{ DERIVATION_PATHS.standard.parent }} ({{ t('onboarding.derivationPath.standard') }})</option>
-            <option value="bitcoindotcom">{{ DERIVATION_PATHS.bitcoindotcom.parent }} ({{ t('onboarding.derivationPath.bitcoindotcom') }})</option>
-          </select>
+          <derivationPathSelect v-model="selectedDerivationPath" :seed-phrase="seedPhrase" :seed-phrase-valid="seedPhraseValid" :wallet-type="walletType" />
         </div>
         <input @click="importWallet()" class="button primary" type="button" :value="t('onboarding.import.submitButton')" :disabled="isCreating" style="margin-bottom: 15px;">
       </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -112,11 +112,6 @@
       "singleDescription": "Verwendet eine feste Adresse für alle Transaktionen. Alle Vermögenswerte an einem Ort, aber weniger privat. Die WizardConnect-Verbindungsmethode wird nicht unterstützt.",
       "singleAddressNote": "Hinweis: Nur die erste Adresse deiner seed phrase wird verwendet. Wenn du diese seed phrase bereits mit anderen Wallets verwendet hast, werden Guthaben auf anderen Adressen nicht angezeigt."
     },
-    "derivationPath": {
-      "label": "Derivation Path:",
-      "standard": "Standard",
-      "bitcoindotcom": "Bitcoin.com Wallet"
-    },
     "preferences": {
       "title": "Einstellungen festlegen",
       "description": "Fast fertig! Konfiguriere deine Einstellungen unten.",
@@ -521,11 +516,6 @@
       "hint": "Oder stelle ein Wallet mit deiner bestehenden seed phrase wieder her.",
       "button": "Bestehendes Wallet importieren"
     },
-    "derivationPath": {
-      "label": "Ableitungspfad:",
-      "standard": "Standard",
-      "bitcoindotcom": "Bitcoin.com Wallet"
-    },
     "singleAddressNote": "Hinweis: Nur die erste Adresse deiner seed phrase wird verwendet. Wenn du diese seed phrase bereits mit anderen Wallets verwendet hast, werden Guthaben auf anderen Adressen nicht angezeigt.",
     "importButton": "Importieren"
   },
@@ -708,6 +698,18 @@
       "notMainnetWif": "Kein QR-Code, der einen Mainnet-Privatschlüssel im WIF-Format enthält",
       "notChipnetWif": "Kein QR-Code, der einen Chipnet-Privatschlüssel im WIF-Format enthält"
     }
+  },
+  "derivationPathSelect": {
+    "label": "Ableitungspfad:",
+    "standard": "Standard",
+    "bitcoindotcom": "Bitcoin.com Wallet",
+    "scanPrompt": "Unsicher? {link}",
+    "scanLinkText": "Beide Pfade prüfen",
+    "scanning": "Suche nach Wallet-Aktivität...",
+    "detected": "Wallet-Aktivität gefunden, {path} ausgewählt",
+    "detectedBoth": "Wallet-Aktivität auf beiden Ableitungspfaden gefunden",
+    "noneFound": "Keine Wallet-Aktivität auf einem der beiden Ableitungspfade gefunden",
+    "multiAddressWarning": "Diese seed phrase wurde mit mehreren Adressen verwendet. Ein Wallet mit einzelner Adresse zeigt diese Guthaben nicht an. Ein HD Wallet wird empfohlen."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -112,11 +112,6 @@
       "singleDescription": "Uses one fixed address for all transactions. All assets in one place, but less private. The WizardConnect connection method is not supported.",
       "singleAddressNote": "Note: Only the first address from your seed phrase will be used. If you've used this seed with other wallets, funds on other addresses won't appear."
     },
-    "derivationPath": {
-      "label": "Derivation path:",
-      "standard": "standard",
-      "bitcoindotcom": "Bitcoin.com wallet"
-    },
     "preferences": {
       "title": "Set up your preferences",
       "description": "Almost done! Configure your preferences below.",
@@ -521,11 +516,6 @@
       "hint": "Or restore a wallet using your existing seed phrase.",
       "button": "Import existing wallet"
     },
-    "derivationPath": {
-      "label": "Derivation path:",
-      "standard": "standard",
-      "bitcoindotcom": "Bitcoin.com wallet"
-    },
     "singleAddressNote": "Note: Only the first address from your seed phrase will be used. If you've used this seed with other wallets, funds on other addresses won't appear.",
     "importButton": "Import"
   },
@@ -708,6 +698,18 @@
       "notMainnetWif": "Not a QR code encoding a Mainnet Private Key in WIF format",
       "notChipnetWif": "Not a QR code encoding a Chipnet Private Key in WIF format"
     }
+  },
+  "derivationPathSelect": {
+    "label": "Derivation path:",
+    "standard": "standard",
+    "bitcoindotcom": "Bitcoin.com wallet",
+    "scanPrompt": "Unsure? {link}",
+    "scanLinkText": "Scan both for wallet activity",
+    "scanning": "Checking for wallet activity...",
+    "detected": "Wallet activity found, selected {path}",
+    "detectedBoth": "Wallet activity found on both derivation paths",
+    "noneFound": "No wallet activity found on either derivation path",
+    "multiAddressWarning": "This seed phrase was used with multiple addresses. A single address wallet will not show those funds. An HD wallet is recommended."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -112,11 +112,6 @@
       "singleDescription": "Usa una dirección fija para todas las transacciones. Todos los activos en un solo lugar, pero menos privado. El método de conexión WizardConnect no es compatible.",
       "singleAddressNote": "Nota: Solo se usará la primera dirección de tu frase semilla. Si has usado esta semilla con otras billeteras, los fondos en otras direcciones no aparecerán."
     },
-    "derivationPath": {
-      "label": "Ruta de derivación:",
-      "standard": "estándar",
-      "bitcoindotcom": "Billetera Bitcoin.com"
-    },
     "preferences": {
       "title": "Configura tus preferencias",
       "description": "¡Casi listo! Configura tus preferencias a continuación.",
@@ -521,11 +516,6 @@
       "hint": "O restaura una billetera usando tu frase semilla existente.",
       "button": "Importar billetera existente"
     },
-    "derivationPath": {
-      "label": "Ruta de derivación:",
-      "standard": "estándar",
-      "bitcoindotcom": "Billetera Bitcoin.com"
-    },
     "singleAddressNote": "Nota: Solo se usará la primera dirección de tu frase semilla. Si has usado esta semilla con otras billeteras, los fondos en otras direcciones no aparecerán.",
     "importButton": "Importar"
   },
@@ -708,6 +698,18 @@
       "notMainnetWif": "No es un código QR que codifica una clave privada de Mainnet en formato WIF",
       "notChipnetWif": "No es un código QR que codifica una clave privada de Chipnet en formato WIF"
     }
+  },
+  "derivationPathSelect": {
+    "label": "Ruta de derivación:",
+    "standard": "estándar",
+    "bitcoindotcom": "Billetera Bitcoin.com",
+    "scanPrompt": "¿No estás seguro? {link}",
+    "scanLinkText": "Escanear ambas rutas",
+    "scanning": "Buscando actividad de la billetera...",
+    "detected": "Actividad encontrada, se seleccionó {path}",
+    "detectedBoth": "Actividad encontrada en ambas rutas de derivación",
+    "noneFound": "No se encontró actividad en ninguna de las rutas de derivación",
+    "multiAddressWarning": "Esta frase semilla se usó con varias direcciones. Una billetera de dirección única no mostrará esos fondos. Se recomienda una billetera HD."
   },
   "seedPhraseInput": {
     "label": "Frase semilla:",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -112,11 +112,6 @@
       "singleDescription": "Utilise une seule adresse fixe pour toutes les transactions. Tous les actifs au même endroit, mais moins privé. La méthode de connexion WizardConnect n'est pas prise en charge.",
       "singleAddressNote": "Remarque : Seule la première adresse de votre phrase de récupération sera utilisée. Si vous avez utilisé cette phrase avec d'autres portefeuilles, les fonds sur d'autres adresses n'apparaîtront pas."
     },
-    "derivationPath": {
-      "label": "Chemin de dérivation :",
-      "standard": "standard",
-      "bitcoindotcom": "Portefeuille Bitcoin.com"
-    },
     "preferences": {
       "title": "Configurez vos préférences",
       "description": "Presque terminé ! Configurez vos préférences ci-dessous.",
@@ -521,11 +516,6 @@
       "hint": "Ou restaurez un portefeuille avec votre phrase de récupération existante.",
       "button": "Importer un portefeuille existant"
     },
-    "derivationPath": {
-      "label": "Chemin de dérivation :",
-      "standard": "standard",
-      "bitcoindotcom": "Portefeuille Bitcoin.com"
-    },
     "singleAddressNote": "Remarque : Seule la première adresse de votre phrase de récupération sera utilisée. Si vous avez utilisé cette phrase avec d'autres portefeuilles, les fonds sur d'autres adresses n'apparaîtront pas.",
     "importButton": "Importer"
   },
@@ -708,6 +698,18 @@
       "notMainnetWif": "Ce n'est pas un code QR encodant une clé privée Mainnet au format WIF",
       "notChipnetWif": "Ce n'est pas un code QR encodant une clé privée Chipnet au format WIF"
     }
+  },
+  "derivationPathSelect": {
+    "label": "Chemin de dérivation :",
+    "standard": "standard",
+    "bitcoindotcom": "Portefeuille Bitcoin.com",
+    "scanPrompt": "Pas sûr ? {link}",
+    "scanLinkText": "Analyser les deux chemins",
+    "scanning": "Recherche d'activité du portefeuille...",
+    "detected": "Activité trouvée, {path} sélectionné",
+    "detectedBoth": "Activité trouvée sur les deux chemins de dérivation",
+    "noneFound": "Aucune activité de portefeuille trouvée sur les deux chemins de dérivation",
+    "multiAddressWarning": "Cette phrase de récupération a été utilisée avec plusieurs adresses. Un portefeuille à adresse unique n'affichera pas ces fonds. Un portefeuille HD est recommandé."
   },
   "seedPhraseInput": {
     "label": "Phrase de récupération :",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -112,11 +112,6 @@
       "singleDescription": "Usa um endereço fixo para todas as transações. Todos os ativos em um só lugar, porém menos privado. O método de conexão WizardConnect não é suportado.",
       "singleAddressNote": "Nota: Apenas o primeiro endereço da sua seed phrase será usado. Se você usou essa seed com outras carteiras, fundos em outros endereços não aparecerão."
     },
-    "derivationPath": {
-      "label": "Derivation path:",
-      "standard": "padrão",
-      "bitcoindotcom": "Carteira Bitcoin.com"
-    },
     "preferences": {
       "title": "Configure suas preferências",
       "description": "Quase pronto! Configure suas preferências abaixo.",
@@ -521,11 +516,6 @@
       "hint": "Ou restaure uma carteira usando sua seed phrase existente.",
       "button": "Importar carteira existente"
     },
-    "derivationPath": {
-      "label": "Derivation path:",
-      "standard": "padrão",
-      "bitcoindotcom": "Carteira Bitcoin.com"
-    },
     "singleAddressNote": "Nota: Apenas o primeiro endereço da sua seed phrase será usado. Se você usou essa seed com outras carteiras, fundos em outros endereços não aparecerão.",
     "importButton": "Importar"
   },
@@ -708,6 +698,18 @@
       "notMainnetWif": "Não é um QR code com chave privada Mainnet no formato WIF",
       "notChipnetWif": "Não é um QR code com chave privada Chipnet no formato WIF"
     }
+  },
+  "derivationPathSelect": {
+    "label": "Derivation path:",
+    "standard": "padrão",
+    "bitcoindotcom": "Carteira Bitcoin.com",
+    "scanPrompt": "Não tem certeza? {link}",
+    "scanLinkText": "Verificar ambos os caminhos",
+    "scanning": "Verificando atividade da carteira...",
+    "detected": "Atividade encontrada, {path} selecionado",
+    "detectedBoth": "Atividade encontrada em ambos os caminhos de derivação",
+    "noneFound": "Nenhuma atividade encontrada em nenhum dos caminhos de derivação",
+    "multiAddressWarning": "Esta seed phrase foi usada com vários endereços. Uma carteira de endereço único não mostrará esses fundos. Uma carteira HD é recomendada."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -30,13 +30,19 @@ export interface DerivationPathScanResult {
   multipleAddressesUsed: boolean;
 }
 
+// BIP44 address discovery stops after this many consecutive unused addresses
+const GAP_LIMIT = 20;
+// Address history queries are pipelined over the same electrum connection in batches
+const SCAN_BATCH_SIZE = 10;
+
 /**
  * Scans which supported derivation path a seed phrase has on-chain activity on,
  * by checking the transaction history of the first address of each path.
  * BIP44 wallets fill addresses starting at index 0, so a used wallet is expected
- * to have history on its first address. For paths with activity, the next two
- * receive addresses are also checked: activity there means the seed phrase was
- * used as an HD wallet, so a single address import would miss funds.
+ * to have history on its first address. Paths with activity are then scanned up
+ * to the standard gap limit on both the receive and change chains: activity
+ * beyond the first receive address means the seed phrase was used as an HD
+ * wallet, so a single address import would miss funds.
  */
 export async function scanDerivationPaths(seedPhrase: string): Promise<DerivationPathScanResult> {
   const normalizedSeedPhrase = normalizeSeedPhrase(seedPhrase);
@@ -45,6 +51,23 @@ export async function scanDerivationPaths(seedPhrase: string): Promise<Derivatio
     const addressWallet = await Wallet.fromSeed(normalizedSeedPhrase, fullDerivationPath);
     const history = await addressWallet.getRawHistory();
     return history.length > 0;
+  }
+
+  // Receive and change chains are interleaved by index so the addresses most
+  // likely to be used are checked first, letting the scan end early on the
+  // first batch with activity
+  async function laterAddressesHaveActivity(parentDerivationPath: string): Promise<boolean> {
+    const addressPaths: string[] = [];
+    for (let addressIndex = 0; addressIndex < GAP_LIMIT; addressIndex++) {
+      addressPaths.push(`${parentDerivationPath}/0/${addressIndex + 1}`);
+      addressPaths.push(`${parentDerivationPath}/1/${addressIndex}`);
+    }
+    for (let i = 0; i < addressPaths.length; i += SCAN_BATCH_SIZE) {
+      const batch = addressPaths.slice(i, i + SCAN_BATCH_SIZE);
+      const batchResults = await Promise.all(batch.map(addressHasActivity));
+      if (batchResults.includes(true)) return true;
+    }
+    return false;
   }
 
   const [standardUsed, bitcoindotcomUsed] = await Promise.all([
@@ -56,11 +79,13 @@ export async function scanDerivationPaths(seedPhrase: string): Promise<Derivatio
   if (standardUsed) usedPaths.push("standard");
   if (bitcoindotcomUsed) usedPaths.push("bitcoindotcom");
 
-  const laterAddressPaths = usedPaths.flatMap((path) =>
-    [1, 2].map((addressIndex) => `${DERIVATION_PATHS[path].parent}/0/${addressIndex}`)
-  );
-  const laterAddressResults = await Promise.all(laterAddressPaths.map(addressHasActivity));
-  const multipleAddressesUsed = laterAddressResults.includes(true);
+  let multipleAddressesUsed = false;
+  for (const usedPath of usedPaths) {
+    if (await laterAddressesHaveActivity(DERIVATION_PATHS[usedPath].parent)) {
+      multipleAddressesUsed = true;
+      break;
+    }
+  }
 
   let path: DerivationPathDetectionResult = "none";
   if (standardUsed && bitcoindotcomUsed) path = "both";

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -23,6 +23,53 @@ export const DERIVATION_PATHS = {
   },
 } as const;
 
+export type DerivationPathDetectionResult = DerivationPathType | "both" | "none";
+
+export interface DerivationPathScanResult {
+  path: DerivationPathDetectionResult;
+  multipleAddressesUsed: boolean;
+}
+
+/**
+ * Scans which supported derivation path a seed phrase has on-chain activity on,
+ * by checking the transaction history of the first address of each path.
+ * BIP44 wallets fill addresses starting at index 0, so a used wallet is expected
+ * to have history on its first address. For paths with activity, the next two
+ * receive addresses are also checked: activity there means the seed phrase was
+ * used as an HD wallet, so a single address import would miss funds.
+ */
+export async function scanDerivationPaths(seedPhrase: string): Promise<DerivationPathScanResult> {
+  const normalizedSeedPhrase = normalizeSeedPhrase(seedPhrase);
+
+  async function addressHasActivity(fullDerivationPath: string): Promise<boolean> {
+    const addressWallet = await Wallet.fromSeed(normalizedSeedPhrase, fullDerivationPath);
+    const history = await addressWallet.getRawHistory();
+    return history.length > 0;
+  }
+
+  const [standardUsed, bitcoindotcomUsed] = await Promise.all([
+    addressHasActivity(DERIVATION_PATHS.standard.full),
+    addressHasActivity(DERIVATION_PATHS.bitcoindotcom.full),
+  ]);
+
+  const usedPaths: DerivationPathType[] = [];
+  if (standardUsed) usedPaths.push("standard");
+  if (bitcoindotcomUsed) usedPaths.push("bitcoindotcom");
+
+  const laterAddressPaths = usedPaths.flatMap((path) =>
+    [1, 2].map((addressIndex) => `${DERIVATION_PATHS[path].parent}/0/${addressIndex}`)
+  );
+  const laterAddressResults = await Promise.all(laterAddressPaths.map(addressHasActivity));
+  const multipleAddressesUsed = laterAddressResults.includes(true);
+
+  let path: DerivationPathDetectionResult = "none";
+  if (standardUsed && bitcoindotcomUsed) path = "both";
+  else if (standardUsed) path = "standard";
+  else if (bitcoindotcomUsed) path = "bitcoindotcom";
+
+  return { path, multipleAddressesUsed };
+}
+
 export interface CreateWalletResult {
   success: true;
   walletName: string;


### PR DESCRIPTION
Adds an explicit 'Unsure? Scan both' action to both import flows (onboarding and add extra wallet) that checks the first address of the two supported derivation paths for on-chain history and preselects the used path. Also checks the next receive addresses on used paths and warns when importing as single address wallet while the seed phrase has multi-address (HD) activity.

Closes #96