### PR TITLE
improve error message and add auto-recovery when device offline

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -74,6 +74,7 @@
       "errorFetchingUtxos": "Fehler beim Abrufen der Wallet-UTXOs",
       "errorFetchingHistory": "Fehler beim Abrufen der Wallet-Historie",
       "unableToConnectElectrum": "Verbindung zum Electrum-Server '{server}' nicht möglich",
+      "deviceOffline": "Dein Gerät scheint offline zu sein, bitte überprüfe deine Internetverbindung",
       "bcmrIndexerValidationError": "Validierungsfehler bei BCMR-Indexer-Antwort"
     }
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -74,6 +74,7 @@
       "errorFetchingUtxos": "Error in fetching wallet UTXOs",
       "errorFetchingHistory": "Error in fetching wallet history",
       "unableToConnectElectrum": "Unable to connect to Electrum server '{server}'",
+      "deviceOffline": "Your device appears to be offline, please check your internet connection",
       "bcmrIndexerValidationError": "BCMR indexer response validation error"
     }
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -74,6 +74,7 @@
       "errorFetchingUtxos": "Error al obtener los UTXOs de la billetera",
       "errorFetchingHistory": "Error al obtener el historial de la billetera",
       "unableToConnectElectrum": "No se puede conectar al servidor Electrum '{server}'",
+      "deviceOffline": "Tu dispositivo parece estar sin conexión, comprueba tu conexión a internet",
       "bcmrIndexerValidationError": "Error de validación de respuesta del indexador BCMR"
     }
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -74,6 +74,7 @@
       "errorFetchingUtxos": "Erreur lors de la récupération des UTXOs du portefeuille",
       "errorFetchingHistory": "Erreur lors de la récupération de l'historique du portefeuille",
       "unableToConnectElectrum": "Impossible de se connecter au serveur Electrum '{server}'",
+      "deviceOffline": "Votre appareil semble être hors ligne, veuillez vérifier votre connexion internet",
       "bcmrIndexerValidationError": "Erreur de validation de la réponse de l'indexeur BCMR"
     }
   },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -74,6 +74,7 @@
       "errorFetchingUtxos": "Erro ao buscar UTXOs da carteira",
       "errorFetchingHistory": "Erro ao buscar histórico da carteira",
       "unableToConnectElectrum": "Não foi possível conectar ao servidor Electrum '{server}'",
+      "deviceOffline": "Seu dispositivo parece estar offline, verifique sua conexão com a internet",
       "bcmrIndexerValidationError": "Erro de validação na resposta do indexador BCMR"
     }
   },

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -256,7 +256,7 @@ export const useStore = defineStore('store', () => {
     // instead of separate errors from each connection attempt
     // (only an explicit navigator.onLine === false is trustworthy)
     if (navigator.onLine === false) {
-      // Mark the skipped dapp inits as done so awaiters of dappConnectionStoresInitDone don't hang
+      // Mark the skipped dapp inits as done so code waiting on dappConnectionStoresInitDone doesn't hang
       isWcInitDone.value = true;
       isCcInitDone.value = true;
       isWizInitDone.value = true;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -252,9 +252,8 @@ export const useStore = defineStore('store', () => {
       throw new Error(`Wallet type mismatch: metadata says 'single' but wallet is HD. This may indicate corrupted settings.`);
     }
 
-    // Abort early when the device is certainly offline, so the user gets one clear error
-    // instead of separate errors from each connection attempt
-    // (only an explicit navigator.onLine === false is trustworthy)
+    // navigator.onLine is only trustworthy when false: abort early when certainly offline,
+    // so the user gets one clear error instead of separate errors per connection attempt
     if (navigator.onLine === false) {
       // Mark the skipped dapp inits as done so code waiting on dappConnectionStoresInitDone doesn't hang
       isWcInitDone.value = true;
@@ -371,8 +370,8 @@ export const useStore = defineStore('store', () => {
     }
   }
 
-  // Retry an aborted-offline initialization once connectivity returns. Other init failures
-  // are not retried: their dapp inits already ran and would register duplicate callbacks
+  // Only offline-aborted inits are retried: other init failures already ran their
+  // dapp inits, so retrying would register duplicate callbacks
   addEventListener('online', () => {
     if (!abortedInitOffline) return;
     abortedInitOffline = false;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -154,8 +154,7 @@ export const useStore = defineStore('store', () => {
   // Bumped at the start of initializeWallet(); checked after long awaits.
   let currentInitialization = 0;
 
-  // Set when initialization aborted because the device was offline,
-  // so the 'online' event can retry the aborted initialization
+  // Lets the 'online' event listener retry an initialization aborted while offline
   let abortedInitOffline = false;
 
   async function cancelWalletSubscriptions() {
@@ -253,12 +252,11 @@ export const useStore = defineStore('store', () => {
       throw new Error(`Wallet type mismatch: metadata says 'single' but wallet is HD. This may indicate corrupted settings.`);
     }
 
-    // Abort initialization early when the device is certainly offline, so the user gets
-    // one clear error message instead of separate errors from each connection attempt
-    // (navigator.onLine is only reliable when explicitly false; environments without the
-    // property should not be treated as offline)
+    // Abort early when the device is certainly offline, so the user gets one clear error
+    // instead of separate errors from each connection attempt
+    // (only an explicit navigator.onLine === false is trustworthy)
     if (navigator.onLine === false) {
-      // Mark the skipped dapp connection inits as done so callers waiting on dappConnectionStoresInitDone don't hang forever
+      // Mark the skipped dapp inits as done so awaiters of dappConnectionStoresInitDone don't hang
       isWcInitDone.value = true;
       isCcInitDone.value = true;
       isWizInitDone.value = true;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -7,6 +7,7 @@ import {
   Config,
   Connection,
   DefaultProvider,
+  disconnectProviders,
   convert,
   ExchangeRate,
   type Utxo,
@@ -153,6 +154,10 @@ export const useStore = defineStore('store', () => {
   // Bumped at the start of initializeWallet(); checked after long awaits.
   let currentInitialization = 0;
 
+  // Set when initialization aborted because the device was offline,
+  // so the 'online' event can retry the aborted initialization
+  let abortedInitOffline = false;
+
   async function cancelWalletSubscriptions() {
     const cancelSubscriptionCallbacks = [
       cancelWatchBchtxs,
@@ -235,6 +240,7 @@ export const useStore = defineStore('store', () => {
 
     walletInitialized.value = false;
     walletInitFailed.value = false;
+    abortedInitOffline = false;
     await cancelWalletSubscriptions();
 
     // Verify wallet type metadata matches the actual wallet class
@@ -245,6 +251,20 @@ export const useStore = defineStore('store', () => {
     }
     if (metadataType === 'single' && isActuallyHD) {
       throw new Error(`Wallet type mismatch: metadata says 'single' but wallet is HD. This may indicate corrupted settings.`);
+    }
+
+    // Abort initialization early when the device is certainly offline, so the user gets
+    // one clear error message instead of separate errors from each connection attempt
+    // (navigator.onLine is only reliable when false)
+    if (!navigator.onLine) {
+      // Mark the skipped dapp connection inits as done so callers waiting on dappConnectionStoresInitDone don't hang forever
+      isWcInitDone.value = true;
+      isCcInitDone.value = true;
+      isWizInitDone.value = true;
+      walletInitFailed.value = true;
+      abortedInitOffline = true;
+      displayAndLogError(new Error(t('store.errors.deviceOffline')));
+      return;
     }
 
     try {
@@ -338,6 +358,27 @@ export const useStore = defineStore('store', () => {
       displayAndLogError(error);
     }
   }
+
+  // A wallet constructed while offline cannot be reused: its HD address discovery never
+  // settles (getUtxos would hang forever), so reset the stuck providers and rebuild it
+  async function retryInitializationAfterOffline() {
+    try {
+      await disconnectProviders();
+      const reloadedWallet = await loadExistingWallet(activeWalletName.value, network.value);
+      setWallet(reloadedWallet);
+      await initializeWallet();
+    } catch (error) {
+      displayAndLogError(error);
+    }
+  }
+
+  // Retry an aborted-offline initialization once connectivity returns. Other init failures
+  // are not retried: their dapp inits already ran and would register duplicate callbacks
+  addEventListener('online', () => {
+    if (!abortedInitOffline) return;
+    abortedInitOffline = false;
+    void retryInitializationAfterOffline();
+  });
 
   // Show the received-BCH toast; failures (fiat-rate fetch) must never affect wallet state
   async function showReceivedBchNotification(balanceDifferenceSats: bigint){

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -255,8 +255,9 @@ export const useStore = defineStore('store', () => {
 
     // Abort initialization early when the device is certainly offline, so the user gets
     // one clear error message instead of separate errors from each connection attempt
-    // (navigator.onLine is only reliable when false)
-    if (!navigator.onLine) {
+    // (navigator.onLine is only reliable when explicitly false; environments without the
+    // property should not be treated as offline)
+    if (navigator.onLine === false) {
       // Mark the skipped dapp connection inits as done so callers waiting on dappConnectionStoresInitDone don't hang forever
       isWcInitDone.value = true;
       isCcInitDone.value = true;


### PR DESCRIPTION
When launching while offline, wallet initialization now aborts early with a single clear "device appears to be offline" message instead of a misleading Electrum server error preceded by an "Error initializing CashConnect" toast.

A window 'online' listener then recovers automatically: the wallet object built offline cannot be reused (its HD address discovery never settles its watchPromise, so getUtxos would hang forever) and the global electrum provider is stuck in a failed-connect state, so recovery force-disconnects the providers via disconnectProviders() and rebuilds the wallet from storage before re-running initialization.

Fixes #251