### PR TITLE
add private transaction notes

### DIFF
--- a/src/components/general/InfoPopup.vue
+++ b/src/components/general/InfoPopup.vue
@@ -16,13 +16,17 @@
 </script>
 
 <template>
-  <q-icon name="info_outline" class="info-popup-icon" @pointerenter="showPopup" @pointerleave="hidePopup">
+  <!-- The trigger slot lets any element act as the popup target, the info icon is the default -->
+  <span @pointerenter="showPopup" @pointerleave="hidePopup">
+    <slot name="trigger">
+      <q-icon name="info_outline" class="info-popup-icon" />
+    </slot>
     <!-- QMenu instead of QTooltip so opening works by click/tap on all platforms
       (hover-only tooltips are awkward on touch devices) -->
     <q-menu ref="menu" no-focus anchor="bottom middle" self="top middle" :offset="[0, 6]" class="info-popup">
       <slot />
     </q-menu>
-  </q-icon>
+  </span>
 </template>
 
 <style>

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -8,7 +8,7 @@
   import { type BcmrNftMetadata, type BcmrTokenMetadata, CurrencySymbols } from 'src/interfaces/interfaces';
   import DialogNftIcon from '../tokenItems/dialogNftIcon.vue';
   import TokenIcon from '../general/TokenIcon.vue';
-  import { formatTime, formatRelativeTime, satsToBch, formatBchAmount, formatFiatAmount, tokenChangeChips } from 'src/utils/utils';
+  import { formatReadableDate, formatRelativeTime, satsToBch, formatBchAmount, formatFiatAmount, tokenChangeChips } from 'src/utils/utils';
   import { maxTxNoteLength } from 'src/utils/txNotes';
   import { useI18n } from 'vue-i18n'
 
@@ -62,12 +62,6 @@
   const bchDisplayUnit = computed(() => {
     return store.network === "mainnet" ? "BCH" : "tBCH";
   });
-
-  // Easily readable date like "1 Aug 2026, 23:48"
-  function formatReadableDate(timestamp: number): string {
-    const day = new Date(timestamp * 1000).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
-    return `${day}, ${formatTime(timestamp)}`;
-  }
 
   function formatTokenAmount(amount: bigint, category: string) {
     const decimals = store.bcmrRegistries?.[category]?.token.decimals ?? 0;

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -8,6 +8,7 @@
   import { type BcmrNftMetadata, type BcmrTokenMetadata, CurrencySymbols } from 'src/interfaces/interfaces';
   import DialogNftIcon from '../tokenItems/dialogNftIcon.vue';
   import TokenIcon from '../general/TokenIcon.vue';
+  import InfoPopup from '../general/InfoPopup.vue';
   import { formatReadableDate, formatRelativeTime, satsToBch, formatBchAmount, formatFiatAmount, tokenChangeChips } from 'src/utils/utils';
   import { maxTxNoteLength } from 'src/utils/txNotes';
   import { useI18n } from 'vue-i18n'
@@ -62,6 +63,9 @@
   const bchDisplayUnit = computed(() => {
     return store.network === "mainnet" ? "BCH" : "tBCH";
   });
+
+  // A transaction in the current tip block has 1 confirmation
+  const confirmations = computed(() => (store.currentBlockHeight as number) - props.historyItem.blockHeight + 1);
 
   function formatTokenAmount(amount: bigint, category: string) {
     const decimals = store.bcmrRegistries?.[category]?.token.decimals ?? 0;
@@ -143,8 +147,20 @@
           </div>
           <div>
             {{ t('transactionDialog.status') }}
-              <span v-if="historyItem.timestamp === undefined">{{ t('transactionDialog.unconfirmed') }}</span>
-              <span v-else>{{ t('transactionDialog.confirmations', { count: store.currentBlockHeight as number - historyItem.blockHeight, block: historyItem.blockHeight.toLocaleString("en-US") }) }}
+              <span v-if="historyItem.timestamp === undefined">
+                {{ t('transactionDialog.unconfirmed') }}
+                <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
+                <InfoPopup v-if="historyItem.blockHeight < 0">
+                  <template #trigger>
+                    <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                  </template>
+                  {{ t('history.unconfirmedChainTooltip') }}
+                </InfoPopup>
+              </span>
+              <!-- under the customary 6 confirmations, show progress toward finality -->
+              <span v-else-if="confirmations < 6">{{ t('transactionDialog.confirmationsProgress', { count: confirmations, block: historyItem.blockHeight.toLocaleString("en-US") }) }}
+              </span>
+              <span v-else>{{ t('transactionDialog.confirmations', { count: confirmations, block: historyItem.blockHeight.toLocaleString("en-US") }) }}
               </span>
           </div>
           <div v-if="historyItem.timestamp">
@@ -364,6 +380,18 @@
   }
   .thisWalletTag{
     color: hsla(160, 100%, 37%, 1)
+  }
+  /* same amber pill as the history rows, the info popup carries the explanation */
+  .chain-badge {
+    display: inline-block;
+    margin-left: 2px;
+    padding: 0 7px;
+    border-radius: 9px;
+    font-size: 0.8em;
+    font-weight: 600;
+    vertical-align: middle;
+    background-color: rgba(230, 162, 60, 0.18);
+    color: #e6a23c;
   }
 
   @media only screen and (max-width: 450px) {

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref, nextTick } from 'vue';
+  import { computed, ref, watch, onUnmounted } from 'vue';
   import { useStore } from 'src/stores/store'
   import { useQuasar } from 'quasar'
   import { useSettingsStore } from 'src/stores/settingsStore';
@@ -8,7 +8,7 @@
   import { type BcmrNftMetadata, type BcmrTokenMetadata, CurrencySymbols } from 'src/interfaces/interfaces';
   import DialogNftIcon from '../tokenItems/dialogNftIcon.vue';
   import TokenIcon from '../general/TokenIcon.vue';
-  import { formatTimestamp, formatRelativeTime, satsToBch } from 'src/utils/utils';
+  import { formatTime, formatRelativeTime, satsToBch, formatBchAmount, formatFiatAmount, tokenChangeChips } from 'src/utils/utils';
   import { maxTxNoteLength } from 'src/utils/txNotes';
   import { useI18n } from 'vue-i18n'
 
@@ -40,23 +40,20 @@
     })
   }
 
-  const txNote = computed(() => store.txNotes[props.historyItem.hash]);
-  const isEditingNote = ref(false);
-  const noteDraft = ref("");
-  const noteInputRef = ref<HTMLInputElement | null>(null);
-
-  async function startNoteEdit() {
-    noteDraft.value = txNote.value ?? "";
-    isEditingNote.value = true;
-    // the input is behind a v-if, wait for the DOM update before focusing it
-    await nextTick();
-    noteInputRef.value?.focus();
-  }
+  // The note field autosaves: debounced while typing, immediately on blur and on dialog close
+  const noteDraft = ref(store.txNotes[props.historyItem.hash] ?? "");
+  let noteSaveTimeout: ReturnType<typeof setTimeout> | undefined;
 
   function saveNote() {
+    clearTimeout(noteSaveTimeout);
     store.setTxNote(props.historyItem.hash, noteDraft.value);
-    isEditingNote.value = false;
   }
+
+  watch(noteDraft, () => {
+    clearTimeout(noteSaveTimeout);
+    noteSaveTimeout = setTimeout(saveNote, 500);
+  });
+  onUnmounted(saveNote);
 
   const tokenMetadata = ref(undefined as undefined | BcmrTokenMetadata | BcmrNftMetadata);
   const selectedTokenId = ref("");
@@ -65,6 +62,12 @@
   const bchDisplayUnit = computed(() => {
     return store.network === "mainnet" ? "BCH" : "tBCH";
   });
+
+  // Easily readable date like "1 Aug 2026, 23:48"
+  function formatReadableDate(timestamp: number): string {
+    const day = new Date(timestamp * 1000).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+    return `${day}, ${formatTime(timestamp)}`;
+  }
 
   function formatTokenAmount(amount: bigint, category: string) {
     const decimals = store.bcmrRegistries?.[category]?.token.decimals ?? 0;
@@ -152,48 +155,60 @@
           </div>
           <div v-if="historyItem.timestamp">
             {{ t('transactionDialog.date') }}
-              <span>{{ formatTimestamp(historyItem.timestamp, settingsStore.dateFormat) }} ({{ formatRelativeTime(historyItem.timestamp) }})</span>
+              <span>{{ formatReadableDate(historyItem.timestamp) }} ({{ formatRelativeTime(historyItem.timestamp) }})</span>
           </div>
           <div>
             {{ t('transactionDialog.balanceChange') }}
-              <span>{{ satsToBch(historyItem.valueChange) }} {{ bchDisplayUnit }}</span>
-          </div>
-          <div>
-            {{ t('transactionDialog.size') }}
-              <span>{{ t('transactionDialog.sizeValue', { bytes: historyItem.size.toLocaleString("en-US") }) }}</span>
-          </div>
-          <div v-if="!isCoinbase">
-            {{ t('transactionDialog.fee') }}
-              <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat ({{ (historyItem.fee / historyItem.size).toFixed(1) }} sat/byte)</span>
-          </div>
-          <div v-else>
-            {{ t('transactionDialog.feesCollected') }}
-              <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat</span>
-          </div>
-          <div>
-            {{ t('transactionDialog.note') }}
-            <template v-if="!isEditingNote">
-              <span v-if="txNote" class="noteText">{{ txNote }}</span>
-              <span class="noteAction" @click="startNoteEdit">
-                {{ txNote ? t('transactionDialog.editNote') : t('transactionDialog.addNote') }}
+              <span class="balanceChange" :class="historyItem.valueChange < 0 ? 'negative' : 'positive'">
+                {{ formatBchAmount(historyItem.valueChange, true, 8) }} {{ bchDisplayUnit }}
               </span>
-            </template>
-            <template v-else>
-              <input
-                ref="noteInputRef"
-                v-model="noteDraft"
-                class="noteInput"
-                type="text"
-                :maxlength="maxTxNoteLength"
-                autocomplete="off"
-                spellcheck="false"
-                @keyup.enter="saveNote"
-                @keyup.esc="isEditingNote = false"
-              >
-              <span class="noteAction" @click="saveNote">{{ t('transactionDialog.saveNote') }}</span>
-            </template>
+              <span class="balanceChangeFiat" v-if="store.exchangeRate !== undefined">
+                ({{ `${historyItem.valueChange > 0 ? '+' : ''}` + formatFiatAmount(store.exchangeRate * historyItem.valueChange / 100_000_000, settingsStore.currency) }})
+              </span>
+            <div class="tokenChanges" v-if="historyItem.tokenAmountChanges.length">
+              <div class="token-chip" v-for="chip in tokenChangeChips(historyItem, store.bcmrRegistries)" :key="chip.key">
+                <TokenIcon
+                  :token-id="chip.category"
+                  :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(chip.category) : undefined"
+                  :size="20"
+                />
+                <span class="chip-value" :class="chip.negative ? 'negative' : 'positive'">{{ chip.amountText }}</span>
+                <span class="chip-symbol">{{ chip.symbol }}</span>
+              </div>
+            </div>
           </div>
+          <label class="noteField">
+            <input
+              v-model="noteDraft"
+              type="text"
+              :placeholder="t('transactionDialog.notePlaceholder')"
+              :maxlength="maxTxNoteLength"
+              autocomplete="off"
+              spellcheck="false"
+              @blur="saveNote"
+              @keyup.enter="saveNote"
+            >
+            <q-icon name="edit" size="16px" class="noteIcon" />
+          </label>
         </div>
+
+        <details class="txDetailsCollapse">
+          <summary>{{ t('transactionDialog.fullDetails') }}</summary>
+
+          <div style="display: flex; flex-direction: column; gap: 1rem; margin-top: 1rem;">
+            <div>
+              {{ t('transactionDialog.size') }}
+                <span>{{ t('transactionDialog.sizeValue', { bytes: historyItem.size.toLocaleString("en-US") }) }}</span>
+            </div>
+            <div v-if="!isCoinbase">
+              {{ t('transactionDialog.fee') }}
+                <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat ({{ (historyItem.fee / historyItem.size).toFixed(1) }} sat/byte)</span>
+            </div>
+            <div v-else>
+              {{ t('transactionDialog.feesCollected') }}
+                <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat</span>
+            </div>
+          </div>
 
         <fieldset style="max-height: 200px; overflow: scroll; margin-top: 1rem;">
           <legend style="font-size: medium;">{{ t('transactionDialog.inputs') }}</legend>
@@ -239,6 +254,8 @@
           </div>
         </fieldset>
 
+        </details>
+
       </fieldset>
     </q-card>
   </q-dialog>
@@ -274,18 +291,82 @@
   .break {
     word-break: break-all;
   }
-  .noteText {
-    word-break: break-word;
+  /* the balance change amount uses the same colors and token chips as the history list rows */
+  .balanceChange {
+    font-family: monospace;
   }
-  .noteAction {
-    cursor: pointer;
-    color: var(--color-primary);
+  .balanceChangeFiat {
+    opacity: 0.75;
+  }
+  .tokenChanges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .token-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    background-color: rgba(128, 128, 128, 0.08);
+    border-radius: 14px;
+    padding: 2px 10px 2px 4px;
+    font-size: 0.85em;
+  }
+  .chip-value {
+    font-family: monospace;
     white-space: nowrap;
   }
-  .noteInput {
-    width: 100%;
-    margin-top: 4px;
-    padding: 4px 10px;
+  .chip-symbol {
+    word-break: break-word;
+  }
+  .positive {
+    color: var(--color-primary);
+  }
+  .negative {
+    color: rgb(188, 30, 30);
+  }
+  body.dark .negative {
+    color: #ef9a9a;
+  }
+  .txDetailsCollapse {
+    margin-top: 1rem;
+  }
+  .txDetailsCollapse summary {
+    display: list-item;
+    cursor: pointer;
+  }
+  .noteField {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    border-radius: 8px;
+    background-color: rgba(128, 128, 128, 0.06);
+    transition: border-color 0.2s;
+    cursor: text;
+  }
+  .noteField:focus-within {
+    border-color: var(--color-primary);
+  }
+  .noteIcon {
+    flex: none;
+    opacity: 0.55;
+  }
+  .noteField input {
+    flex: 1;
+    min-width: 0;
+    width: auto;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    font-size: inherit;
+    color: inherit;
   }
   .thisWalletTag{
     color: hsla(160, 100%, 37%, 1)

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -198,6 +198,12 @@
               @blur="saveNote"
               @keyup.enter="saveNote"
             >
+            <!-- silent maxlength truncation is confusing, show the limit when writing gets close -->
+            <span
+              v-if="noteDraft.length >= maxTxNoteLength - 20"
+              class="noteCounter"
+              :class="{ atLimit: noteDraft.length >= maxTxNoteLength }"
+            >{{ noteDraft.length }}/{{ maxTxNoteLength }}</span>
             <q-icon name="edit" size="16px" class="noteIcon" />
           </label>
         </div>
@@ -364,6 +370,14 @@
   .noteIcon {
     flex: none;
     opacity: 0.55;
+  }
+  .noteCounter {
+    font-size: 0.75em;
+    opacity: 0.6;
+  }
+  .noteCounter.atLimit {
+    color: #e6a23c;
+    opacity: 1;
   }
   .noteField input {
     flex: 1;

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref } from 'vue';
+  import { computed, ref, nextTick } from 'vue';
   import { useStore } from 'src/stores/store'
   import { useQuasar } from 'quasar'
   import { useSettingsStore } from 'src/stores/settingsStore';
@@ -9,6 +9,7 @@
   import DialogNftIcon from '../tokenItems/dialogNftIcon.vue';
   import TokenIcon from '../general/TokenIcon.vue';
   import { formatTimestamp, formatRelativeTime, satsToBch } from 'src/utils/utils';
+  import { maxTxNoteLength } from 'src/utils/txNotes';
   import { useI18n } from 'vue-i18n'
 
   const store = useStore()
@@ -37,6 +38,24 @@
       timeout : 1000,
       color: "grey-6"
     })
+  }
+
+  const txNote = computed(() => store.txNotes[props.historyItem.hash]);
+  const isEditingNote = ref(false);
+  const noteDraft = ref("");
+  const noteInputRef = ref<HTMLInputElement | null>(null);
+
+  async function startNoteEdit() {
+    noteDraft.value = txNote.value ?? "";
+    isEditingNote.value = true;
+    // the input is behind a v-if, wait for the DOM update before focusing it
+    await nextTick();
+    noteInputRef.value?.focus();
+  }
+
+  function saveNote() {
+    store.setTxNote(props.historyItem.hash, noteDraft.value);
+    isEditingNote.value = false;
   }
 
   const tokenMetadata = ref(undefined as undefined | BcmrTokenMetadata | BcmrNftMetadata);
@@ -151,6 +170,29 @@
             {{ t('transactionDialog.feesCollected') }}
               <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat</span>
           </div>
+          <div>
+            {{ t('transactionDialog.note') }}
+            <template v-if="!isEditingNote">
+              <span v-if="txNote" class="noteText">{{ txNote }}</span>
+              <span class="noteAction" @click="startNoteEdit">
+                {{ txNote ? t('transactionDialog.editNote') : t('transactionDialog.addNote') }}
+              </span>
+            </template>
+            <template v-else>
+              <input
+                ref="noteInputRef"
+                v-model="noteDraft"
+                class="noteInput"
+                type="text"
+                :maxlength="maxTxNoteLength"
+                autocomplete="off"
+                spellcheck="false"
+                @keyup.enter="saveNote"
+                @keyup.esc="isEditingNote = false"
+              >
+              <span class="noteAction" @click="saveNote">{{ t('transactionDialog.saveNote') }}</span>
+            </template>
+          </div>
         </div>
 
         <fieldset style="max-height: 200px; overflow: scroll; margin-top: 1rem;">
@@ -231,6 +273,19 @@
   }
   .break {
     word-break: break-all;
+  }
+  .noteText {
+    word-break: break-word;
+  }
+  .noteAction {
+    cursor: pointer;
+    color: var(--color-primary);
+    white-space: nowrap;
+  }
+  .noteInput {
+    width: 100%;
+    margin-top: 4px;
+    padding: 4px 10px;
   }
   .thisWalletTag{
     color: hsla(160, 100%, 37%, 1)

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -10,6 +10,7 @@
   import { maxTxNoteLength } from 'src/utils/txNotes';
   import { txDirection, directionIcon, isCombined, isDappInteraction } from 'src/utils/txDirection';
   import TokenIcon from '../general/TokenIcon.vue';
+  import InfoPopup from '../general/InfoPopup.vue';
   import { useI18n } from 'vue-i18n'
   import { exportFile, useQuasar } from 'quasar'
 
@@ -124,6 +125,15 @@
 
   // Predicate for isDappInteraction, which is store-agnostic by design
   const walletHasAddress = (address: string) => store.wallet.hasAddress(address);
+
+  // Show confirmation progress toward the customary 6, after that a transaction
+  // is considered final and the count is no longer interesting
+  function confirmationsProgress(transaction: TransactionHistoryItem): number | undefined {
+    if (!transaction.timestamp || transaction.blockHeight <= 0) return undefined;
+    if (store.currentBlockHeight === undefined) return undefined;
+    const confirmations = Math.max(1, store.currentBlockHeight - transaction.blockHeight + 1);
+    return confirmations < 6 ? confirmations : undefined;
+  }
 
   const selectedHistory = computed(() => {
     let history = store.walletHistory;
@@ -293,6 +303,16 @@
               <div class="tx-type">
                 {{ t('history.' + txDirection(transaction)) }}
                 <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
+                <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
+                <InfoPopup v-if="transaction.blockHeight < 0" @click.stop>
+                  <template #trigger>
+                    <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                  </template>
+                  {{ t('history.unconfirmedChainTooltip') }}
+                </InfoPopup>
+                <span v-if="confirmationsProgress(transaction) !== undefined" class="tx-confirmations">
+                  {{ t('history.confirmationsProgress', { count: confirmationsProgress(transaction) }) }}
+                </span>
               </div>
               <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
             </div>
@@ -577,6 +597,29 @@
 .tx-time {
   font-size: 0.85em;
   opacity: 0.65;
+}
+
+/* confirmation progress reads as secondary info next to the bold type label */
+.tx-confirmations {
+  margin-left: 4px;
+  font-size: 0.8em;
+  font-weight: 400;
+  opacity: 0.65;
+  white-space: nowrap;
+}
+
+/* a transaction depending on unconfirmed inputs has a higher risk of not
+   confirming; the info popup next to the badge carries the explanation */
+.chain-badge {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 7px;
+  border-radius: 9px;
+  font-size: 0.7em;
+  font-weight: 600;
+  vertical-align: middle;
+  background-color: rgba(230, 162, 60, 0.18);
+  color: #e6a23c;
 }
 
 .tx-amounts {

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -2,7 +2,6 @@
   import { useSettingsStore } from 'src/stores/settingsStore';
   import { useStore } from 'src/stores/store'
   import { computed, ref, watch, nextTick, onActivated, onDeactivated } from 'vue';
-  import { useWindowSize } from 'src/utils/composables';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
   import { formatTime, formatFiatAmount, formatBchAmount, tokenChangeChips, dayLabel, localDayStart } from 'src/utils/utils';
@@ -31,11 +30,6 @@
   const dateTo = ref("");
   const searchQuery = ref("");
   const searchInputRef = ref<HTMLInputElement | null>(null);
-  const { width } = useWindowSize();
-  // The compact layout starts generously wide so notes get a full line of their own
-  const isMobile = computed(() => width.value <= 750);
-  // On small mobiles the badges move out of the label line to the bottom of the card
-  const isSmallMobile = computed(() => width.value <= 400);
   // On mobile the search input hides behind a search icon until toggled open
   const showSearch = ref(false);
 
@@ -250,8 +244,8 @@
             @click="directionFilter = option.value"
           >{{ t(option.label) }}</button>
         </div>
-        <input v-if="!isMobile || showSearch" ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input" autocomplete="off" autocapitalize="none" spellcheck="false">
-        <span v-if="isMobile" class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
+        <input ref="searchInputRef" v-model="searchQuery" type="text" :placeholder="t('history.searchPlaceholder')" class="search-input" :class="{ open: showSearch }" autocomplete="off" autocapitalize="none" spellcheck="false">
+        <span class="search-toggle" :class="{ active: showSearch || searchQuery.trim() }" @click="toggleSearch">
           <q-icon name="search" size="22px" />
         </span>
         <span class="options-toggle" :class="{ active: showOptions }" :title="t('history.options')" @click="toggleOptions">
@@ -307,9 +301,9 @@
               <div class="tx-info">
                 <div class="tx-type">
                   {{ t('history.' + txDirection(transaction)) }}
-                  <span v-if="!isSmallMobile && isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
+                  <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
                   <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
-                  <InfoPopup v-if="!isSmallMobile && transaction.blockHeight < 0" @click.stop>
+                  <InfoPopup v-if="transaction.blockHeight < 0" class="chain-popup" @click.stop>
                     <template #trigger>
                       <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
                     </template>
@@ -377,7 +371,7 @@
                 {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
               </div>
             </div>
-            <div class="tx-badges-line" v-if="isSmallMobile && (isDappInteraction(transaction, walletHasAddress) || transaction.blockHeight < 0)">
+            <div class="tx-badges-line" v-if="isDappInteraction(transaction, walletHasAddress) || transaction.blockHeight < 0">
               <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
               <InfoPopup v-if="transaction.blockHeight < 0" @click.stop>
                 <template #trigger>
@@ -459,6 +453,11 @@ fieldset.item {
   width: 180px;
   padding: 4px 10px;
   margin-left: auto;
+}
+
+/* the search icon only exists in the compact layout */
+.search-toggle {
+  display: none;
 }
 
 /* segmented pill bar for the transaction direction filter */
@@ -649,9 +648,9 @@ fieldset.item {
 
 /* on small mobiles the badges move out of the label line to their own bottom line */
 .tx-badges-line {
+  display: none;
   order: 6;
   flex-basis: 100%;
-  display: flex;
   gap: 4px;
 }
 
@@ -828,14 +827,19 @@ body.dark .negative {
 
 /* the compact layout starts generously wide so notes get a full line of their own */
 @media only screen and (max-width: 750px) {
-  /* the opened search moves to its own full-width line, the icons stay beside the pills */
+  /* the search hides behind its icon; opened, it moves to its own full-width line */
   .search-input {
+    display: none;
+  }
+  .search-input.open {
+    display: block;
     order: 5;
     flex-basis: 100%;
     width: 100%;
     margin-left: 0;
   }
   .search-toggle {
+    display: inline;
     margin-left: auto;
   }
   .type-filter button {
@@ -891,6 +895,17 @@ body.dark .negative {
      pill on small screens keeps the bar next to the icons */
   .type-filter button.combined-pill {
     display: none;
+  }
+}
+
+@media only screen and (max-width: 400px) {
+  /* the badges leave the crowded label line for their own line at the card bottom */
+  .tx-type .dapp-badge,
+  .tx-type .chain-popup {
+    display: none;
+  }
+  .tx-badges-line {
+    display: flex;
   }
 }
 </style>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -5,8 +5,9 @@
   import { useWindowSize } from 'src/utils/composables';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
-  import { formatTime, formatFiatAmount } from 'src/utils/utils';
+  import { formatTime, formatFiatAmount, formatBchAmount, tokenChangeChips } from 'src/utils/utils';
   import { historyToCsv } from 'src/utils/csvUtils';
+  import { maxTxNoteLength } from 'src/utils/txNotes';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
   import { exportFile, useQuasar } from 'quasar'
@@ -54,6 +55,42 @@
   const currentPage = ref(1)
   const selectedTransaction = ref(undefined as TransactionHistoryItem | undefined);
 
+  // Inline note editing in the transaction rows; only one row edits at a time
+  const editingNoteTx = ref(null as string | null);
+  const noteDraft = ref("");
+  const noteInputRef = ref<HTMLInputElement | null>(null);
+
+  async function startNoteEdit(txHash: string) {
+    editingNoteTx.value = txHash;
+    noteDraft.value = store.txNotes[txHash] ?? "";
+    // the input is behind a v-if, wait for the DOM update before focusing it
+    await nextTick();
+    noteInputRef.value?.focus();
+  }
+
+  function saveNoteEdit() {
+    if (editingNoteTx.value === null) return;
+    store.setTxNote(editingNoteTx.value, noteDraft.value);
+    editingNoteTx.value = null;
+  }
+
+  function cancelNoteEdit() {
+    editingNoteTx.value = null;
+  }
+
+  // Blur alone can't close the editor: pressing Quasar controls (pagination, toggles)
+  // prevents default on mousedown, so the input never blurs. Watch presses at the
+  // document level while editing and close on any press outside the edit field.
+  function handleGlobalMousedown(event: MouseEvent) {
+    const editingContainer = noteInputRef.value?.parentElement;
+    if (!editingContainer || !editingContainer.contains(event.target as Node)) saveNoteEdit();
+  }
+
+  watch(editingNoteTx, (editing) => {
+    if (editing !== null) document.addEventListener('mousedown', handleGlobalMousedown, true);
+    else document.removeEventListener('mousedown', handleGlobalMousedown, true);
+  });
+
   // Override Ctrl+F to focus the search input.
   function handleCtrlF(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
@@ -66,7 +103,11 @@
 
   // Listener added/removed on KeepAlive activate/deactivate so it only applies while this view is active.
   onActivated(() => document.addEventListener('keydown', handleCtrlF));
-  onDeactivated(() => document.removeEventListener('keydown', handleCtrlF));
+  onDeactivated(() => {
+    document.removeEventListener('keydown', handleCtrlF);
+    // close an open note editor when navigating away from the history view
+    saveNoteEdit();
+  });
 
   const bchDisplayUnit = computed(() => {
     return store.network === "mainnet" ? "BCH" : "tBCH";
@@ -158,52 +199,6 @@
   // value, while a wallet-authored transaction always pays the fee so its net is negative
   function isIncoming(transaction: TransactionHistoryItem): boolean {
     return transaction.valueChange >= 0;
-  }
-
-  interface TokenChangeChip {
-    key: string;
-    category: string;
-    amountText: string;
-    symbol: string;
-    negative: boolean;
-  }
-
-  // Tokens like BADGER have both fungibles and NFTs with the same category in user wallets,
-  // so one token change can yield both a fungible chip and an NFT chip
-  function tokenChangeChips(transaction: TransactionHistoryItem): TokenChangeChip[] {
-    const chips: TokenChangeChip[] = [];
-    for (const tokenChange of transaction.tokenAmountChanges) {
-      const tokenMetadata = store.bcmrRegistries?.[tokenChange.category]?.token;
-      const symbol = tokenMetadata?.symbol ?? tokenChange.category.slice(0, 8);
-      const decimals = tokenMetadata?.decimals ?? 0;
-      // Show the fungible change for any nonzero amount. When there is no NFT change either,
-      // still show it (as "0") so a token change never renders without a chip.
-      if (tokenChange.amount !== 0n || tokenChange.nftAmount === 0n) {
-        const amount = Number(tokenChange.amount) / 10 ** decimals;
-        chips.push({
-          key: tokenChange.category + "-ft",
-          category: tokenChange.category,
-          amountText: `${amount > 0 ? '+' : ''}${amount.toLocaleString("en-US", { maximumFractionDigits: decimals })}`,
-          symbol,
-          negative: amount < 0,
-        });
-      }
-      if (tokenChange.nftAmount !== 0n) {
-        chips.push({
-          key: tokenChange.category + "-nft",
-          category: tokenChange.category,
-          amountText: `${tokenChange.nftAmount > 0n ? '+' : ''}${tokenChange.nftAmount}`,
-          symbol: `${symbol} NFT`,
-          negative: tokenChange.nftAmount < 0n,
-        });
-      }
-    }
-    return chips;
-  }
-
-  function formatBchAmount(satoshis: number, signed = false): string {
-    const amount = (satoshis / 100_000_000).toLocaleString("en-US", { minimumFractionDigits: 5, maximumFractionDigits: 5 });
-    return signed && satoshis > 0 ? `+${amount}` : amount;
   }
 
   function toggleOptions() {
@@ -303,7 +298,7 @@
               <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
             </div>
             <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
-              <div class="token-chip" v-for="chip in tokenChangeChips(transaction)" :key="chip.key">
+              <div class="token-chip" v-for="chip in tokenChangeChips(transaction, store.bcmrRegistries)" :key="chip.key">
                 <TokenIcon
                   :token-id="chip.category"
                   :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(chip.category) : undefined"
@@ -313,7 +308,29 @@
                 <span class="chip-symbol">{{ chip.symbol }}</span>
               </div>
             </div>
-            <div class="tx-note" v-if="store.txNotes[transaction.hash]">{{ store.txNotes[transaction.hash] }}</div>
+            <div class="tx-note" v-if="editingNoteTx === transaction.hash" @click.stop>
+              <input
+                ref="noteInputRef"
+                v-model="noteDraft"
+                class="note-input"
+                type="text"
+                :maxlength="maxTxNoteLength"
+                autocomplete="off"
+                spellcheck="false"
+                @blur="saveNoteEdit"
+                @keyup.enter="saveNoteEdit"
+                @keyup.esc="cancelNoteEdit"
+              >
+            </div>
+            <div
+              class="tx-note"
+              v-else-if="store.txNotes[transaction.hash]"
+              :title="store.txNotes[transaction.hash]"
+              @click.stop="startNoteEdit(transaction.hash)"
+            >{{ store.txNotes[transaction.hash] }}</div>
+            <div class="tx-note tx-note-add" v-else @click.stop="startNoteEdit(transaction.hash)">
+              <span class="add-note-hint">{{ t('history.addNote') }} <q-icon name="edit" size="14px" /></span>
+            </div>
             <div class="tx-amounts">
               <div class="tx-amount-line">
                 <div class="tx-bch" :class="transaction.valueChange < 0 ? 'negative' : 'positive'">
@@ -590,16 +607,51 @@ body.dark .negative {
   color: #ef9a9a;
 }
 
-/* the note renders as a single truncated line below the main row, like the token chips */
+/* the note sits front and center between the direction info and the amounts,
+   filling the free space and truncating with an ellipsis when it runs out;
+   clicking it edits the note inline instead of opening the transaction dialog */
 .tx-note {
-  order: 6;
-  flex-basis: 100%;
-  font-size: 0.85em;
-  font-style: italic;
-  opacity: 0.65;
+  flex: 1 1 0;
+  min-width: 0;
+  text-align: center;
+  opacity: 0.8;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: text;
+  /* enlarge the click target without growing the row; the horizontal padding
+     keeps the note and its edit input clear of the neighboring text */
+  padding: 10px 12px;
+  margin: -10px 0;
+}
+
+/* rows without a note reveal the hint on hover */
+.add-note-hint {
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.tx-item:hover .add-note-hint {
+  opacity: 0.55;
+}
+
+.add-note-hint .q-icon {
+  vertical-align: -0.15em;
+}
+
+.note-input {
+  width: 100%;
+  text-align: center;
+  font-size: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  border-bottom: 1px solid var(--color-primary);
+  border-radius: 0;
+  padding: 0 4px 1px;
+  margin: 0;
 }
 
 /* token changes render as wrapping chips on their own line below the main row, so any
@@ -659,6 +711,18 @@ body.dark .negative {
   }
   .tx-item {
     padding: 8px 10px;
+  }
+  /* not enough room in the main row on mobile, the note gets its own
+     full-width line below it (before the token chips at order 5) */
+  .tx-note {
+    flex: none;
+    order: 4;
+    flex-basis: 100%;
+    font-size: 0.9em;
+  }
+  /* no hover on touch screens, adding notes happens in the transaction dialog */
+  .tx-note-add {
+    display: none;
   }
 }
 

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -92,9 +92,10 @@
     if (!editingContainer || !editingContainer.contains(event.target as Node)) saveNoteEdit();
   }
 
-  watch(editingNoteTx, (editing) => {
-    if (editing !== null) document.addEventListener('mousedown', handleGlobalMousedown, true);
-    else document.removeEventListener('mousedown', handleGlobalMousedown, true);
+  watch(editingNoteTx, (editing, _prev, onCleanup) => {
+    if (editing === null) return;
+    document.addEventListener('mousedown', handleGlobalMousedown, true);
+    onCleanup(() => document.removeEventListener('mousedown', handleGlobalMousedown, true));
   });
 
   // Override Ctrl+F to focus the search input.

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -32,7 +32,10 @@
   const searchQuery = ref("");
   const searchInputRef = ref<HTMLInputElement | null>(null);
   const { width } = useWindowSize();
-  const isMobile = computed(() => width.value <= 600);
+  // The compact layout starts generously wide so notes get a full line of their own
+  const isMobile = computed(() => width.value <= 750);
+  // On small mobiles the badges move out of the label line to the bottom of the card
+  const isSmallMobile = computed(() => width.value <= 400);
   // On mobile the search input hides behind a search icon until toggled open
   const showSearch = ref(false);
 
@@ -243,7 +246,7 @@
           <button
             v-for="option in directionOptions"
             :key="option.value"
-            :class="{ active: directionFilter === option.value }"
+            :class="{ active: directionFilter === option.value, 'combined-pill': option.value === 'combined' }"
             @click="directionFilter = option.value"
           >{{ t(option.label) }}</button>
         </div>
@@ -296,38 +299,43 @@
             :key="transaction.hash"
             @click="() => selectedTransaction = transaction"
           >
-            <div class="tx-direction" :class="[txDirection(transaction), { pending: !transaction.timestamp }]">
-              <q-icon :name="directionIcon(transaction)" size="20px" />
-            </div>
-            <div class="tx-info">
-              <div class="tx-type">
-                {{ t('history.' + txDirection(transaction)) }}
-                <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
-                <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
-                <InfoPopup v-if="transaction.blockHeight < 0" @click.stop>
-                  <template #trigger>
-                    <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
-                  </template>
-                  {{ t('history.unconfirmedChainTooltip') }}
-                </InfoPopup>
-                <span v-if="confirmationsProgress(transaction) !== undefined" class="tx-confirmations">
-                  {{ t('history.confirmationsProgress', { count: confirmationsProgress(transaction) }) }}
-                </span>
+            <!-- the left section and the amounts section flex equally, keeping the note centered on the card -->
+            <div class="tx-left">
+              <div class="tx-direction" :class="[txDirection(transaction), { pending: !transaction.timestamp }]">
+                <q-icon :name="directionIcon(transaction)" size="20px" />
               </div>
-              <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
-            </div>
-            <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
-              <div class="token-chip" v-for="chip in tokenChangeChips(transaction, store.bcmrRegistries)" :key="chip.key">
-                <TokenIcon
-                  :token-id="chip.category"
-                  :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(chip.category) : undefined"
-                  :size="22"
-                />
-                <span class="value" :class="{ negative: chip.negative, positive: !chip.negative }">{{ chip.amountText }}</span>
-                <span class="chip-symbol">{{ chip.symbol }}</span>
+              <div class="tx-info">
+                <div class="tx-type">
+                  {{ t('history.' + txDirection(transaction)) }}
+                  <span v-if="!isSmallMobile && isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
+                  <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
+                  <InfoPopup v-if="!isSmallMobile && transaction.blockHeight < 0" @click.stop>
+                    <template #trigger>
+                      <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                    </template>
+                    {{ t('history.unconfirmedChainTooltip') }}
+                  </InfoPopup>
+                </div>
+                <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
               </div>
             </div>
-            <div class="tx-note" v-if="editingNoteTx === transaction.hash" @click.stop>
+            <div class="tx-bottom-row" v-if="confirmationsProgress(transaction) !== undefined || transaction.tokenAmountChanges.length">
+              <div class="tx-confirmations-line" v-if="confirmationsProgress(transaction) !== undefined">
+                {{ t('history.confirmationsProgress', { count: confirmationsProgress(transaction) }) }}
+              </div>
+              <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
+                <div class="token-chip" v-for="chip in tokenChangeChips(transaction, store.bcmrRegistries)" :key="chip.key">
+                  <TokenIcon
+                    :token-id="chip.category"
+                    :icon-url="!settingsStore.disableTokenIcons ? store.tokenIconUrl(chip.category) : undefined"
+                    :size="22"
+                  />
+                  <span class="value" :class="{ negative: chip.negative, positive: !chip.negative }">{{ chip.amountText }}</span>
+                  <span class="chip-symbol">{{ chip.symbol }}</span>
+                </div>
+              </div>
+            </div>
+            <div class="tx-note tx-note-editing" v-if="editingNoteTx === transaction.hash" @click.stop>
               <input
                 :ref="setNoteInputRef"
                 v-model="noteDraft"
@@ -340,6 +348,12 @@
                 @keyup.enter="saveNoteEdit"
                 @keyup.esc="cancelNoteEdit"
               >
+              <!-- silent maxlength truncation is confusing, show the limit when writing gets close -->
+              <span
+                v-if="noteDraft.length >= maxTxNoteLength - 20"
+                class="note-counter"
+                :class="{ 'at-limit': noteDraft.length >= maxTxNoteLength }"
+              >{{ noteDraft.length }}/{{ maxTxNoteLength }}</span>
             </div>
             <div
               class="tx-note"
@@ -362,6 +376,15 @@
               <div class="tx-balance" v-if="showBalance">
                 {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
               </div>
+            </div>
+            <div class="tx-badges-line" v-if="isSmallMobile && (isDappInteraction(transaction, walletHasAddress) || transaction.blockHeight < 0)">
+              <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
+              <InfoPopup v-if="transaction.blockHeight < 0" @click.stop>
+                <template #trigger>
+                  <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                </template>
+                {{ t('history.unconfirmedChainTooltip') }}
+              </InfoPopup>
             </div>
           </div>
         </template>
@@ -396,6 +419,12 @@
 .loading-full-history {
   text-align: center;
   padding: 15px 0;
+}
+
+/* fieldsets default to min-inline-size: min-content, so a long nowrap note
+   would stretch the whole section (and page) beyond the viewport width */
+fieldset.item {
+  min-inline-size: 0;
 }
 
 .control-row {
@@ -573,12 +602,22 @@
   color: #e6a23c;
 }
 
+/* equal flexible side sections keep the note centered on the card */
+.tx-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1 1 0;
+}
+
 .tx-info {
   min-width: 0;
 }
 
 .tx-type {
   font-weight: 600;
+  /* keep the label and its badges on one line, the note shrinks instead */
+  white-space: nowrap;
 }
 
 /* transactions spending from a contract carry a small dapp tag next to the type */
@@ -599,17 +638,35 @@
   opacity: 0.65;
 }
 
-/* confirmation progress reads as secondary info next to the bold type label */
-.tx-confirmations {
-  margin-left: 4px;
-  font-size: 0.8em;
-  font-weight: 400;
+/* shared bottom row: the confirmation progress sits left, the token chips right */
+.tx-bottom-row {
+  order: 5;
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* on small mobiles the badges move out of the label line to their own bottom line */
+.tx-badges-line {
+  order: 6;
+  flex-basis: 100%;
+  display: flex;
+  gap: 4px;
+}
+
+.tx-badges-line .dapp-badge {
+  margin-left: 0;
+}
+
+.tx-confirmations-line {
+  font-size: 0.85em;
   opacity: 0.65;
   white-space: nowrap;
 }
 
 /* a transaction depending on unconfirmed inputs has a higher risk of not
-   confirming; the info popup next to the badge carries the explanation */
+   confirming; the badge opens an info popup with the explanation */
 .chain-badge {
   display: inline-block;
   margin-left: 4px;
@@ -623,7 +680,9 @@
 }
 
 .tx-amounts {
-  margin-left: auto;
+  flex: 1 1 0;
+  /* fixed minimum so varying amount widths don't shift the note center per row */
+  min-width: 200px;
   text-align: right;
 }
 
@@ -667,22 +726,38 @@ body.dark .negative {
   color: #ef9a9a;
 }
 
-/* the note sits front and center between the direction info and the amounts,
-   filling the free space and truncating with an ellipsis when it runs out;
-   clicking it edits the note inline instead of opening the transaction dialog */
+/* the note lives between the direction info and the amounts, truncating with an
+   ellipsis; clicking it edits the note inline instead of opening the dialog */
 .tx-note {
-  flex: 1 1 0;
+  flex: 1.8 1 0;
   min-width: 0;
+  max-width: 360px;
   text-align: center;
   opacity: 0.8;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: text;
-  /* enlarge the click target without growing the row; the horizontal padding
-     keeps the note and its edit input clear of the neighboring text */
+  /* enlarge the click target without growing the row */
   padding: 10px 12px;
   margin: -10px 0;
+}
+
+/* while editing, the slot holds the input plus the limit counter side by side */
+.tx-note-editing {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.note-counter {
+  font-size: 0.75em;
+  opacity: 0.6;
+}
+
+.note-counter.at-limit {
+  color: #e6a23c;
+  opacity: 1;
 }
 
 /* rows without a note reveal the hint on hover */
@@ -699,11 +774,12 @@ body.dark .negative {
   vertical-align: -0.15em;
 }
 
-/* the focused state needs the same overrides: the global chota input rules
-   outweigh a single class and would bring back the border and focus ring */
-.tx-note .note-input,
-.tx-note .note-input:focus {
-  width: 100%;
+/* plain underlined input; the focused state needs the same overrides or the
+   global chota input rules bring back the border and focus ring */
+.tx-note-editing .note-input,
+.tx-note-editing .note-input:focus {
+  flex: 1 1 0;
+  min-width: 0;
   text-align: center;
   font-size: inherit;
   color: inherit;
@@ -717,12 +793,10 @@ body.dark .negative {
   margin: 0;
 }
 
-/* token changes render as wrapping chips on their own line below the main row, so any
-   number of tokens per transaction lays out cleanly; order moves them after the amounts,
-   which sit in the main row despite coming later in the DOM */
+/* token changes render as wrapping chips filling the rest of the bottom row,
+   so any number of tokens per transaction lays out cleanly */
 .tx-tokens {
-  order: 5;
-  flex-basis: 100%;
+  flex: 1 1 auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -752,8 +826,9 @@ body.dark .negative {
   margin: 10px 0 4px;
 }
 
-@media only screen and (max-width: 600px) {
-  /* search moves to its own full-width line, the options toggle stays beside the pills */
+/* the compact layout starts generously wide so notes get a full line of their own */
+@media only screen and (max-width: 750px) {
+  /* the opened search moves to its own full-width line, the icons stay beside the pills */
   .search-input {
     order: 5;
     flex-basis: 100%;
@@ -772,20 +847,33 @@ body.dark .negative {
     align-items: flex-end;
     gap: 0;
   }
+  /* dissolve the centering wrapper, the compact layout keeps the amounts in the main row */
+  .tx-left {
+    display: contents;
+  }
+  .tx-amounts {
+    flex: 0 1 auto;
+    margin-left: auto;
+    min-width: 0;
+  }
   .tx-item {
     padding: 8px 10px;
   }
-  /* not enough room in the main row on mobile, the note gets its own
-     full-width line below it (before the token chips at order 5) */
+  /* the note gets its own full-width line; it must stay shrinkable or its
+     min-content width would stretch the fieldset past the viewport */
   .tx-note {
-    flex: none;
+    flex: 0 1 100%;
     order: 4;
-    flex-basis: 100%;
+    max-width: none;
     font-size: 0.9em;
   }
   /* no hover on touch screens, adding notes happens in the transaction dialog */
   .tx-note-add {
     display: none;
+  }
+  /* narrow screens need the label line to wrap rather than overflow the card */
+  .tx-type {
+    white-space: normal;
   }
 }
 
@@ -795,6 +883,14 @@ body.dark .negative {
   }
   legend {
     margin-left: 0.5rem;
+  }
+}
+
+@media only screen and (max-width: 450px) {
+  /* combined transactions are rare and still listed under All, dropping the
+     pill on small screens keeps the bar next to the icons */
+  .type-filter button.combined-pill {
+    display: none;
   }
 }
 </style>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -5,9 +5,10 @@
   import { useWindowSize } from 'src/utils/composables';
   import type { TransactionHistoryItem } from 'mainnet-js';
   import TransactionDialog from './transactionDialog.vue';
-  import { formatTime, formatFiatAmount, formatBchAmount, tokenChangeChips } from 'src/utils/utils';
+  import { formatTime, formatFiatAmount, formatBchAmount, tokenChangeChips, dayLabel, localDayStart } from 'src/utils/utils';
   import { historyToCsv } from 'src/utils/csvUtils';
   import { maxTxNoteLength } from 'src/utils/txNotes';
+  import { txDirection, directionIcon, isCombined, isDappInteraction } from 'src/utils/txDirection';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
   import { exportFile, useQuasar } from 'quasar'
@@ -63,8 +64,8 @@
 
   // Template refs inside v-for are collected into arrays, so a function ref is
   // needed to capture the single active edit input as a plain element
-  function setNoteInputRef(el: unknown) {
-    noteInputRef.value = el as HTMLInputElement | null;
+  function setNoteInputRef(element: unknown) {
+    noteInputRef.value = element as HTMLInputElement | null;
   }
 
   async function startNoteEdit(txHash: string) {
@@ -121,17 +122,14 @@
     return store.network === "mainnet" ? "BCH" : "tBCH";
   });
 
-  // Date inputs hold local calendar dates (YYYY-MM-DD); compare in local time to match the displayed dates
-  function localDayStart(isoDate: string, dayOffset = 0): number {
-    const [year = 0, month = 1, day = 1] = isoDate.split('-').map(Number);
-    return new Date(year, month - 1, day + dayOffset).getTime() / 1000;
-  }
+  // Predicate for isDappInteraction, which is store-agnostic by design
+  const walletHasAddress = (address: string) => store.wallet.hasAddress(address);
 
   const selectedHistory = computed(() => {
     let history = store.walletHistory;
     if (selectedFilter.value === "bchTransactions") history = history?.filter(tx => !tx.tokenAmountChanges.length);
     if (selectedFilter.value === "tokenTransactions") history = history?.filter(tx => tx.tokenAmountChanges.length);
-    if (selectedFilter.value === "dappTransactions") history = history?.filter(tx => isDappInteraction(tx));
+    if (selectedFilter.value === "dappTransactions") history = history?.filter(tx => isDappInteraction(tx, walletHasAddress));
     // The direction pills partition the history: each one shows exactly the rows
     // carrying that label, so combined transactions only appear under Combined
     if (directionFilter.value === "incoming") history = history?.filter(tx => txDirection(tx) === 'received');
@@ -180,19 +178,7 @@
   })
   const totalPages = computed(() => Math.ceil((searchedHistory.value?.length ?? 0) / itemsPerPage))
 
-  // Group consecutive transactions by calendar day (history is sorted newest first).
-  // Pending transactions have no timestamp and group under their own header.
-  function dayLabel(timestamp: number | undefined): string {
-    if (!timestamp) return t('history.pending');
-    const date = new Date(timestamp * 1000);
-    const today = new Date();
-    const yesterday = new Date();
-    yesterday.setDate(today.getDate() - 1);
-    if (date.toDateString() === today.toDateString()) return t('history.today');
-    if (date.toDateString() === yesterday.toDateString()) return t('history.yesterday');
-    return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
-  }
-
+  // Group consecutive transactions by calendar day (history is sorted newest first)
   const groupedHistory = computed(() => {
     const groups: { label: string; transactions: TransactionHistoryItem[] }[] = [];
     for (const transaction of paginatedHistory.value ?? []) {
@@ -206,46 +192,6 @@
     }
     return groups;
   });
-
-  // Direction is judged per asset flow: the BCH change and every token change count
-  // separately. A transaction with flows both ways (a swap, loan or mint) is combined
-  function txHasIncoming(transaction: TransactionHistoryItem): boolean {
-    if (transaction.valueChange > 0) return true;
-    return transaction.tokenAmountChanges.some(change => change.amount > 0n || change.nftAmount > 0n);
-  }
-
-  function txHasOutgoing(transaction: TransactionHistoryItem): boolean {
-    if (transaction.valueChange < 0) return true;
-    return transaction.tokenAmountChanges.some(change => change.amount < 0n || change.nftAmount < 0n);
-  }
-
-  // A transaction the wallet coauthored that also spends a contract (P2SH) input is
-  // a dapp interaction. Requiring one of the wallet's own inputs filters out third
-  // parties that merely pay us from a P2SH wallet, like exchange withdrawals
-  function isDappInteraction(transaction: TransactionHistoryItem): boolean {
-    const hasP2shInput = transaction.inputs.some(input => {
-      // P2SH cashaddr payloads start with p, or r for the token-aware variant
-      const payload = input.address.split(":")[1] ?? "";
-      return payload.startsWith("p") || payload.startsWith("r");
-    });
-    if (!hasP2shInput) return false;
-    return transaction.inputs.some(input => store.wallet.hasAddress(input.address));
-  }
-
-  function isCombined(transaction: TransactionHistoryItem): boolean {
-    return txHasIncoming(transaction) && txHasOutgoing(transaction);
-  }
-
-  function txDirection(transaction: TransactionHistoryItem): 'received' | 'sent' | 'combined' {
-    if (isCombined(transaction)) return 'combined';
-    return txHasOutgoing(transaction) ? 'sent' : 'received';
-  }
-
-  function directionIcon(transaction: TransactionHistoryItem): string {
-    const direction = txDirection(transaction);
-    if (direction === 'combined') return 'swap_vert';
-    return direction === 'received' ? 'arrow_downward' : 'arrow_upward';
-  }
 
   function toggleOptions() {
     showOptions.value = !showOptions.value
@@ -264,7 +210,7 @@
   function exportCsv() {
     const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value, store.txNotes, tx => ({
       direction: t('history.' + txDirection(tx)),
-      dapp: isDappInteraction(tx),
+      dapp: isDappInteraction(tx, walletHasAddress),
     }));
     const status = exportFile("cashonize-tx-history.csv", csvContent, { mimeType: "text/csv" });
     if (status !== true) $q.notify({ message: t('history.exportFailed'), icon: 'warning', color: "red" });
@@ -346,7 +292,7 @@
             <div class="tx-info">
               <div class="tx-type">
                 {{ t('history.' + txDirection(transaction)) }}
-                <span v-if="isDappInteraction(transaction)" class="dapp-badge">{{ t('history.dapp') }}</span>
+                <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
               </div>
               <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
             </div>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -24,7 +24,7 @@
   // state options menu
   const showOptions = ref(false)
   const showFiatValue = ref(settingsStore.showFiatValueHistory)
-  const hideBalance = ref(settingsStore.hideBalanceColumn)
+  const showBalance = ref(settingsStore.showBalanceInHistory)
   const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions" | "dappTransactions");
   const directionFilter = ref("all" as "all" | "incoming" | "outgoing" | "combined");
   const dateFrom = ref("");
@@ -212,9 +212,9 @@
     settingsStore.showFiatValueHistory = showFiatValue.value;
   }
 
-  function toggleHideBalance() {
-    localStorage.setItem("hideBalanceColumn", hideBalance.value ? "true" : "false");
-    settingsStore.hideBalanceColumn = hideBalance.value;
+  function toggleShowBalance() {
+    localStorage.setItem("showBalanceInHistory", showBalance.value ? "true" : "false");
+    settingsStore.showBalanceInHistory = showBalance.value;
   }
 
   function exportCsv() {
@@ -278,7 +278,7 @@
           {{ t('history.showFiatValue') }} <q-toggle v-model="showFiatValue" @update:model-value="toggleShowFiatValue" dense />
         </div>
         <div class="option-item">
-          {{ t('history.hideBalanceColumn') }} <q-toggle v-model="hideBalance" @update:model-value="toggleHideBalance" dense />
+          {{ t('history.showBalance') }} <q-toggle v-model="showBalance" @update:model-value="toggleShowBalance" dense />
         </div>
         <div class="option-item" v-if="!isCapacitor">
           <button @click="exportCsv">{{ t('history.exportCsv') }}</button>
@@ -359,7 +359,7 @@
                   ({{ `${transaction.valueChange > 0 ? '+' : ''}` + formatFiatAmount(store.exchangeRate * transaction.valueChange / 100_000_000, settingsStore.currency) }})
                 </div>
               </div>
-              <div class="tx-balance" v-if="!hideBalance">
+              <div class="tx-balance" v-if="showBalance">
                 {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
               </div>
             </div>

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -23,8 +23,8 @@
   const showOptions = ref(false)
   const showFiatValue = ref(settingsStore.showFiatValueHistory)
   const hideBalance = ref(settingsStore.hideBalanceColumn)
-  const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions");
-  const directionFilter = ref("all" as "all" | "incoming" | "outgoing");
+  const selectedFilter = ref("allTransactions" as "allTransactions" | "bchTransactions" | "tokenTransactions" | "dappTransactions");
+  const directionFilter = ref("all" as "all" | "incoming" | "outgoing" | "combined");
   const dateFrom = ref("");
   const dateTo = ref("");
   const searchQuery = ref("");
@@ -50,6 +50,7 @@
     { value: "all", label: "history.directionFilter.all" },
     { value: "incoming", label: "history.directionFilter.incoming" },
     { value: "outgoing", label: "history.directionFilter.outgoing" },
+    { value: "combined", label: "history.directionFilter.combined" },
   ] as const;
 
   const currentPage = ref(1)
@@ -130,8 +131,12 @@
     let history = store.walletHistory;
     if (selectedFilter.value === "bchTransactions") history = history?.filter(tx => !tx.tokenAmountChanges.length);
     if (selectedFilter.value === "tokenTransactions") history = history?.filter(tx => tx.tokenAmountChanges.length);
-    if (directionFilter.value === "incoming") history = history?.filter(tx => isIncoming(tx));
-    if (directionFilter.value === "outgoing") history = history?.filter(tx => !isIncoming(tx));
+    if (selectedFilter.value === "dappTransactions") history = history?.filter(tx => isDappInteraction(tx));
+    // The direction pills partition the history: each one shows exactly the rows
+    // carrying that label, so combined transactions only appear under Combined
+    if (directionFilter.value === "incoming") history = history?.filter(tx => txDirection(tx) === 'received');
+    if (directionFilter.value === "outgoing") history = history?.filter(tx => txDirection(tx) === 'sent');
+    if (directionFilter.value === "combined") history = history?.filter(tx => isCombined(tx));
     const fromTimestamp = dateFrom.value ? localDayStart(dateFrom.value) : undefined;
     const untilTimestamp = dateTo.value ? localDayStart(dateTo.value, 1) : undefined;
     if (fromTimestamp !== undefined || untilTimestamp !== undefined) {
@@ -202,10 +207,44 @@
     return groups;
   });
 
-  // Direction is derived from the net BCH change: receiving (BCH or tokens) always adds
-  // value, while a wallet-authored transaction always pays the fee so its net is negative
-  function isIncoming(transaction: TransactionHistoryItem): boolean {
-    return transaction.valueChange >= 0;
+  // Direction is judged per asset flow: the BCH change and every token change count
+  // separately. A transaction with flows both ways (a swap, loan or mint) is combined
+  function txHasIncoming(transaction: TransactionHistoryItem): boolean {
+    if (transaction.valueChange > 0) return true;
+    return transaction.tokenAmountChanges.some(change => change.amount > 0n || change.nftAmount > 0n);
+  }
+
+  function txHasOutgoing(transaction: TransactionHistoryItem): boolean {
+    if (transaction.valueChange < 0) return true;
+    return transaction.tokenAmountChanges.some(change => change.amount < 0n || change.nftAmount < 0n);
+  }
+
+  // A transaction the wallet coauthored that also spends a contract (P2SH) input is
+  // a dapp interaction. Requiring one of the wallet's own inputs filters out third
+  // parties that merely pay us from a P2SH wallet, like exchange withdrawals
+  function isDappInteraction(transaction: TransactionHistoryItem): boolean {
+    const hasP2shInput = transaction.inputs.some(input => {
+      // P2SH cashaddr payloads start with p, or r for the token-aware variant
+      const payload = input.address.split(":")[1] ?? "";
+      return payload.startsWith("p") || payload.startsWith("r");
+    });
+    if (!hasP2shInput) return false;
+    return transaction.inputs.some(input => store.wallet.hasAddress(input.address));
+  }
+
+  function isCombined(transaction: TransactionHistoryItem): boolean {
+    return txHasIncoming(transaction) && txHasOutgoing(transaction);
+  }
+
+  function txDirection(transaction: TransactionHistoryItem): 'received' | 'sent' | 'combined' {
+    if (isCombined(transaction)) return 'combined';
+    return txHasOutgoing(transaction) ? 'sent' : 'received';
+  }
+
+  function directionIcon(transaction: TransactionHistoryItem): string {
+    const direction = txDirection(transaction);
+    if (direction === 'combined') return 'swap_vert';
+    return direction === 'received' ? 'arrow_downward' : 'arrow_upward';
   }
 
   function toggleOptions() {
@@ -223,7 +262,10 @@
   }
 
   function exportCsv() {
-    const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value, store.txNotes);
+    const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value, store.txNotes, tx => ({
+      direction: t('history.' + txDirection(tx)),
+      dapp: isDappInteraction(tx),
+    }));
     const status = exportFile("cashonize-tx-history.csv", csvContent, { mimeType: "text/csv" });
     if (status !== true) $q.notify({ message: t('history.exportFailed'), icon: 'warning', color: "red" });
   }
@@ -265,6 +307,7 @@
             <option value="allTransactions">{{ t('history.filter.all') }}</option>
             <option value="bchTransactions">{{ t('history.filter.bchTxs') }}</option>
             <option value="tokenTransactions">{{ t('history.filter.tokenTxs') }}</option>
+            <option value="dappTransactions">{{ t('history.filter.dappTxs') }}</option>
           </select>
         </div>
         <div class="option-item date-range">
@@ -297,11 +340,14 @@
             :key="transaction.hash"
             @click="() => selectedTransaction = transaction"
           >
-            <div class="tx-direction" :class="[isIncoming(transaction) ? 'received' : 'sent', { pending: !transaction.timestamp }]">
-              <q-icon :name="isIncoming(transaction) ? 'arrow_downward' : 'arrow_upward'" size="20px" />
+            <div class="tx-direction" :class="[txDirection(transaction), { pending: !transaction.timestamp }]">
+              <q-icon :name="directionIcon(transaction)" size="20px" />
             </div>
             <div class="tx-info">
-              <div class="tx-type">{{ isIncoming(transaction) ? t('history.received') : t('history.sent') }}</div>
+              <div class="tx-type">
+                {{ t('history.' + txDirection(transaction)) }}
+                <span v-if="isDappInteraction(transaction)" class="dapp-badge">{{ t('history.dapp') }}</span>
+              </div>
               <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
             </div>
             <div class="tx-tokens" v-if="transaction.tokenAmountChanges.length">
@@ -551,6 +597,11 @@
   color: var(--color-grey);
 }
 
+.tx-direction.combined {
+  background-color: rgba(74, 144, 217, 0.15);
+  color: #4a90d9;
+}
+
 .tx-direction.pending {
   background-color: rgba(230, 162, 60, 0.18);
   color: #e6a23c;
@@ -562,6 +613,19 @@
 
 .tx-type {
   font-weight: 600;
+}
+
+/* transactions spending from a contract carry a small dapp tag next to the type */
+.dapp-badge {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 7px;
+  border-radius: 9px;
+  font-size: 0.7em;
+  font-weight: 600;
+  vertical-align: middle;
+  background-color: rgba(142, 111, 216, 0.18);
+  color: #8e6fd8;
 }
 
 .tx-time {

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -100,6 +100,7 @@
 
   function txMatchesSearch(tx: TransactionHistoryItem, query: string): boolean {
     if (tx.hash.toLowerCase().includes(query)) return true;
+    if (store.txNotes[tx.hash]?.toLowerCase().includes(query)) return true;
     return tx.tokenAmountChanges.some(tokenChange => {
       if (tokenChange.category.toLowerCase().includes(query)) return true;
       const metadata = store.bcmrRegistries?.[tokenChange.category];
@@ -220,7 +221,7 @@
   }
 
   function exportCsv() {
-    const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value);
+    const csvContent = historyToCsv(searchedHistory.value ?? [], store.bcmrRegistries, bchDisplayUnit.value, store.txNotes);
     const status = exportFile("cashonize-tx-history.csv", csvContent, { mimeType: "text/csv" });
     if (status !== true) $q.notify({ message: t('history.exportFailed'), icon: 'warning', color: "red" });
   }
@@ -312,6 +313,7 @@
                 <span class="chip-symbol">{{ chip.symbol }}</span>
               </div>
             </div>
+            <div class="tx-note" v-if="store.txNotes[transaction.hash]">{{ store.txNotes[transaction.hash] }}</div>
             <div class="tx-amounts">
               <div class="tx-amount-line">
                 <div class="tx-bch" :class="transaction.valueChange < 0 ? 'negative' : 'positive'">
@@ -586,6 +588,18 @@
 }
 body.dark .negative {
   color: #ef9a9a;
+}
+
+/* the note renders as a single truncated line below the main row, like the token chips */
+.tx-note {
+  order: 6;
+  flex-basis: 100%;
+  font-size: 0.85em;
+  font-style: italic;
+  opacity: 0.65;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* token changes render as wrapping chips on their own line below the main row, so any

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -60,6 +60,12 @@
   const noteDraft = ref("");
   const noteInputRef = ref<HTMLInputElement | null>(null);
 
+  // Template refs inside v-for are collected into arrays, so a function ref is
+  // needed to capture the single active edit input as a plain element
+  function setNoteInputRef(el: unknown) {
+    noteInputRef.value = el as HTMLInputElement | null;
+  }
+
   async function startNoteEdit(txHash: string) {
     editingNoteTx.value = txHash;
     noteDraft.value = store.txNotes[txHash] ?? "";
@@ -310,7 +316,7 @@
             </div>
             <div class="tx-note" v-if="editingNoteTx === transaction.hash" @click.stop>
               <input
-                ref="noteInputRef"
+                :ref="setNoteInputRef"
                 v-model="noteDraft"
                 class="note-input"
                 type="text"
@@ -639,7 +645,10 @@ body.dark .negative {
   vertical-align: -0.15em;
 }
 
-.note-input {
+/* the focused state needs the same overrides: the global chota input rules
+   outweigh a single class and would bring back the border and focus ring */
+.tx-note .note-input,
+.tx-note .note-input:focus {
   width: 100%;
   text-align: center;
   font-size: inherit;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -424,6 +424,9 @@
       "note": "Notiz"
     },
     "pending": "ausstehend",
+    "confirmationsProgress": "{count}/6 Bestätigungen",
+    "unconfirmedChain": "unbestätigte Kette",
+    "unconfirmedChainTooltip": "Diese Transaktion hängt von einer anderen unbestätigten Transaktion ab, was das Risiko erhöht, dass sie nicht bestätigt wird.",
     "transactionCountPartial": "{count}+ Transaktionen",
     "loadingFullHistory": "Lade vollständige Historie"
   },
@@ -437,6 +440,7 @@
     "status": "Status:",
     "unconfirmed": "unbestätigt",
     "confirmations": "{count} Bestätigungen (gemindet in Block #{block})",
+    "confirmationsProgress": "{count}/6 Bestätigungen (gemindet in Block #{block})",
     "date": "Datum:",
     "balanceChange": "Guthabenänderung:",
     "size": "Größe:",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -390,12 +390,14 @@
       "all": "Alle",
       "bchTxs": "BCH-Txs",
       "tokenTxs": "Token-Txs",
+      "dappTxs": "Dapp-Txs",
       "dateRange": "Zeitraum:"
     },
     "directionFilter": {
       "all": "Alle",
       "incoming": "Eingehend",
-      "outgoing": "Ausgehend"
+      "outgoing": "Ausgehend",
+      "combined": "Kombiniert"
     },
     "showFiatValue": "Fiat-Wert anzeigen",
     "hideBalanceColumn": "Guthaben ausblenden",
@@ -405,6 +407,8 @@
     "noMatch": "Keine Transaktionen passen zum Filter",
     "sent": "Gesendet",
     "received": "Empfangen",
+    "combined": "Kombiniert",
+    "dapp": "Dapp",
     "today": "Heute",
     "yesterday": "Gestern",
     "balanceLabel": "Guthaben:",
@@ -415,6 +419,8 @@
       "amount": "Betrag ({unit})",
       "balance": "Guthaben ({unit})",
       "tokenChanges": "Token-Änderungen",
+      "direction": "Richtung",
+      "dapp": "Dapp",
       "note": "Notiz"
     },
     "pending": "ausstehend",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -400,7 +400,7 @@
       "combined": "Kombiniert"
     },
     "showFiatValue": "Fiat-Wert anzeigen",
-    "hideBalanceColumn": "Guthaben ausblenden",
+    "showBalance": "Guthaben nach der Transaktion anzeigen",
     "exportCsv": "CSV exportieren",
     "exportFailed": "CSV-Export fehlgeschlagen",
     "searchPlaceholder": "Token oder Tx-ID suchen...",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -408,6 +408,7 @@
     "today": "Heute",
     "yesterday": "Gestern",
     "balanceLabel": "Guthaben:",
+    "addNote": "Notiz hinzufügen",
     "csv": {
       "date": "Datum (UTC)",
       "transactionId": "Transaktions-ID",
@@ -439,10 +440,8 @@
     "inputs": "Inputs",
     "outputs": "Outputs",
     "coinbase": "Coinbase",
-    "note": "Notiz:",
-    "addNote": "Notiz hinzufügen",
-    "editNote": "bearbeiten",
-    "saveNote": "speichern"
+    "notePlaceholder": "Persönliche Notiz hinzufügen",
+    "fullDetails": "Vollständige Transaktionsdetails"
   },
   "alertDialog": {
     "transactionSent": "Transaktion gesendet!",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -413,7 +413,8 @@
       "transactionId": "Transaktions-ID",
       "amount": "Betrag ({unit})",
       "balance": "Guthaben ({unit})",
-      "tokenChanges": "Token-Änderungen"
+      "tokenChanges": "Token-Änderungen",
+      "note": "Notiz"
     },
     "pending": "ausstehend",
     "transactionCountPartial": "{count}+ Transaktionen",
@@ -437,7 +438,11 @@
     "feesCollected": "Eingesammelte Gebühren:",
     "inputs": "Inputs",
     "outputs": "Outputs",
-    "coinbase": "Coinbase"
+    "coinbase": "Coinbase",
+    "note": "Notiz:",
+    "addNote": "Notiz hinzufügen",
+    "editNote": "bearbeiten",
+    "saveNote": "speichern"
   },
   "alertDialog": {
     "transactionSent": "Transaktion gesendet!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -390,12 +390,14 @@
       "all": "All",
       "bchTxs": "BCH txs",
       "tokenTxs": "Token txs",
+      "dappTxs": "Dapp txs",
       "dateRange": "Filter range:"
     },
     "directionFilter": {
       "all": "All",
       "incoming": "Incoming",
-      "outgoing": "Outgoing"
+      "outgoing": "Outgoing",
+      "combined": "Combined"
     },
     "showFiatValue": "Show fiat value",
     "hideBalanceColumn": "Hide balance",
@@ -405,6 +407,8 @@
     "noMatch": "No transactions match filter",
     "sent": "Sent",
     "received": "Received",
+    "combined": "Combined",
+    "dapp": "dapp",
     "today": "Today",
     "yesterday": "Yesterday",
     "balanceLabel": "Balance:",
@@ -415,6 +419,8 @@
       "amount": "Amount ({unit})",
       "balance": "Balance ({unit})",
       "tokenChanges": "Token Changes",
+      "direction": "Direction",
+      "dapp": "Dapp",
       "note": "Note"
     },
     "pending": "pending",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -408,6 +408,7 @@
     "today": "Today",
     "yesterday": "Yesterday",
     "balanceLabel": "Balance:",
+    "addNote": "add note",
     "csv": {
       "date": "Date (UTC)",
       "transactionId": "Transaction Id",
@@ -439,10 +440,8 @@
     "inputs": "Inputs",
     "outputs": "Outputs",
     "coinbase": "coinbase",
-    "note": "Note:",
-    "addNote": "add note",
-    "editNote": "edit",
-    "saveNote": "save"
+    "notePlaceholder": "Add a personal note",
+    "fullDetails": "Full Transaction Details"
   },
   "alertDialog": {
     "transactionSent": "Transaction Sent!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -400,7 +400,7 @@
       "combined": "Combined"
     },
     "showFiatValue": "Show fiat value",
-    "hideBalanceColumn": "Hide balance",
+    "showBalance": "Show balance after transaction",
     "exportCsv": "Export CSV",
     "exportFailed": "CSV export failed",
     "searchPlaceholder": "Search token or tx id...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -413,7 +413,8 @@
       "transactionId": "Transaction Id",
       "amount": "Amount ({unit})",
       "balance": "Balance ({unit})",
-      "tokenChanges": "Token Changes"
+      "tokenChanges": "Token Changes",
+      "note": "Note"
     },
     "pending": "pending",
     "transactionCountPartial": "{count}+ Transactions",
@@ -437,7 +438,11 @@
     "feesCollected": "Fees collected:",
     "inputs": "Inputs",
     "outputs": "Outputs",
-    "coinbase": "coinbase"
+    "coinbase": "coinbase",
+    "note": "Note:",
+    "addNote": "add note",
+    "editNote": "edit",
+    "saveNote": "save"
   },
   "alertDialog": {
     "transactionSent": "Transaction Sent!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -424,6 +424,9 @@
       "note": "Note"
     },
     "pending": "pending",
+    "confirmationsProgress": "{count}/6 confirmations",
+    "unconfirmedChain": "unconfirmed chain",
+    "unconfirmedChainTooltip": "This transaction depends on another unconfirmed transaction, which increases the risk that it does not confirm.",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Loading full history"
   },
@@ -437,6 +440,7 @@
     "status": "Status:",
     "unconfirmed": "unconfirmed",
     "confirmations": "{count} confirmations (mined in block #{block})",
+    "confirmationsProgress": "{count}/6 confirmations (mined in block #{block})",
     "date": "Date:",
     "balanceChange": "Balance change:",
     "size": "Size:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -390,12 +390,14 @@
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
+      "dappTxs": "Txs de dapps",
       "dateRange": "Rango de fechas:"
     },
     "directionFilter": {
       "all": "Todas",
       "incoming": "Entrantes",
-      "outgoing": "Salientes"
+      "outgoing": "Salientes",
+      "combined": "Combinadas"
     },
     "showFiatValue": "Mostrar valor en fiat",
     "hideBalanceColumn": "Ocultar saldo",
@@ -405,6 +407,8 @@
     "noMatch": "Ninguna transacción coincide con el filtro",
     "sent": "Enviado",
     "received": "Recibido",
+    "combined": "Combinado",
+    "dapp": "dapp",
     "today": "Hoy",
     "yesterday": "Ayer",
     "balanceLabel": "Saldo:",
@@ -415,6 +419,8 @@
       "amount": "Cantidad ({unit})",
       "balance": "Saldo ({unit})",
       "tokenChanges": "Cambios de tokens",
+      "direction": "Dirección",
+      "dapp": "Dapp",
       "note": "Nota"
     },
     "pending": "pendiente",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -424,6 +424,9 @@
       "note": "Nota"
     },
     "pending": "pendiente",
+    "confirmationsProgress": "{count}/6 confirmaciones",
+    "unconfirmedChain": "cadena sin confirmar",
+    "unconfirmedChainTooltip": "Esta transacción depende de otra transacción sin confirmar, lo que aumenta el riesgo de que no se confirme.",
     "transactionCountPartial": "{count}+ Transacciones",
     "loadingFullHistory": "Cargando historial completo"
   },
@@ -437,6 +440,7 @@
     "status": "Estado:",
     "unconfirmed": "sin confirmar",
     "confirmations": "{count} confirmaciones (minado en bloque #{block})",
+    "confirmationsProgress": "{count}/6 confirmaciones (minado en bloque #{block})",
     "date": "Fecha:",
     "balanceChange": "Cambio de saldo:",
     "size": "Tamaño:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -400,7 +400,7 @@
       "combined": "Combinadas"
     },
     "showFiatValue": "Mostrar valor en fiat",
-    "hideBalanceColumn": "Ocultar saldo",
+    "showBalance": "Mostrar saldo después de la transacción",
     "exportCsv": "Exportar CSV",
     "exportFailed": "Error al exportar CSV",
     "searchPlaceholder": "Buscar token o id de tx...",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -408,6 +408,7 @@
     "today": "Hoy",
     "yesterday": "Ayer",
     "balanceLabel": "Saldo:",
+    "addNote": "añadir nota",
     "csv": {
       "date": "Fecha (UTC)",
       "transactionId": "ID de transacción",
@@ -439,10 +440,8 @@
     "inputs": "Entradas",
     "outputs": "Salidas",
     "coinbase": "coinbase",
-    "note": "Nota:",
-    "addNote": "añadir nota",
-    "editNote": "editar",
-    "saveNote": "guardar"
+    "notePlaceholder": "Añadir una nota personal",
+    "fullDetails": "Detalles completos de la transacción"
   },
   "alertDialog": {
     "transactionSent": "¡Transacción enviada!",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -413,7 +413,8 @@
       "transactionId": "ID de transacción",
       "amount": "Cantidad ({unit})",
       "balance": "Saldo ({unit})",
-      "tokenChanges": "Cambios de tokens"
+      "tokenChanges": "Cambios de tokens",
+      "note": "Nota"
     },
     "pending": "pendiente",
     "transactionCountPartial": "{count}+ Transacciones",
@@ -437,7 +438,11 @@
     "feesCollected": "Comisiones recolectadas:",
     "inputs": "Entradas",
     "outputs": "Salidas",
-    "coinbase": "coinbase"
+    "coinbase": "coinbase",
+    "note": "Nota:",
+    "addNote": "añadir nota",
+    "editNote": "editar",
+    "saveNote": "guardar"
   },
   "alertDialog": {
     "transactionSent": "¡Transacción enviada!",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -408,6 +408,7 @@
     "today": "Aujourd'hui",
     "yesterday": "Hier",
     "balanceLabel": "Solde :",
+    "addNote": "ajouter une note",
     "csv": {
       "date": "Date (UTC)",
       "transactionId": "ID de transaction",
@@ -439,10 +440,8 @@
     "inputs": "Entrées",
     "outputs": "Sorties",
     "coinbase": "coinbase",
-    "note": "Note :",
-    "addNote": "ajouter une note",
-    "editNote": "modifier",
-    "saveNote": "enregistrer"
+    "notePlaceholder": "Ajouter une note personnelle",
+    "fullDetails": "Détails complets de la transaction"
   },
   "alertDialog": {
     "transactionSent": "Transaction envoyée !",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -390,12 +390,14 @@
       "all": "Toutes",
       "bchTxs": "Txs BCH",
       "tokenTxs": "Txs tokens",
+      "dappTxs": "Txs dapps",
       "dateRange": "Plage de dates :"
     },
     "directionFilter": {
       "all": "Toutes",
       "incoming": "Entrantes",
-      "outgoing": "Sortantes"
+      "outgoing": "Sortantes",
+      "combined": "Combinées"
     },
     "showFiatValue": "Afficher la valeur en devise",
     "hideBalanceColumn": "Masquer le solde",
@@ -405,6 +407,8 @@
     "noMatch": "Aucune transaction ne correspond au filtre",
     "sent": "Envoyé",
     "received": "Reçu",
+    "combined": "Combiné",
+    "dapp": "dapp",
     "today": "Aujourd'hui",
     "yesterday": "Hier",
     "balanceLabel": "Solde :",
@@ -415,6 +419,8 @@
       "amount": "Montant ({unit})",
       "balance": "Solde ({unit})",
       "tokenChanges": "Variations de tokens",
+      "direction": "Direction",
+      "dapp": "Dapp",
       "note": "Note"
     },
     "pending": "en attente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -424,6 +424,9 @@
       "note": "Note"
     },
     "pending": "en attente",
+    "confirmationsProgress": "{count}/6 confirmations",
+    "unconfirmedChain": "chaîne non confirmée",
+    "unconfirmedChainTooltip": "Cette transaction dépend d'une autre transaction non confirmée, ce qui augmente le risque qu'elle ne soit pas confirmée.",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Chargement de l'historique complet"
   },
@@ -437,6 +440,7 @@
     "status": "Statut :",
     "unconfirmed": "non confirmée",
     "confirmations": "{count} confirmations (miné au bloc #{block})",
+    "confirmationsProgress": "{count}/6 confirmations (miné au bloc #{block})",
     "date": "Date :",
     "balanceChange": "Variation du solde :",
     "size": "Taille :",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -413,7 +413,8 @@
       "transactionId": "ID de transaction",
       "amount": "Montant ({unit})",
       "balance": "Solde ({unit})",
-      "tokenChanges": "Variations de tokens"
+      "tokenChanges": "Variations de tokens",
+      "note": "Note"
     },
     "pending": "en attente",
     "transactionCountPartial": "{count}+ Transactions",
@@ -437,7 +438,11 @@
     "feesCollected": "Frais collectés :",
     "inputs": "Entrées",
     "outputs": "Sorties",
-    "coinbase": "coinbase"
+    "coinbase": "coinbase",
+    "note": "Note :",
+    "addNote": "ajouter une note",
+    "editNote": "modifier",
+    "saveNote": "enregistrer"
   },
   "alertDialog": {
     "transactionSent": "Transaction envoyée !",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -400,7 +400,7 @@
       "combined": "Combinées"
     },
     "showFiatValue": "Afficher la valeur en devise",
-    "hideBalanceColumn": "Masquer le solde",
+    "showBalance": "Afficher le solde après la transaction",
     "exportCsv": "Exporter en CSV",
     "exportFailed": "Échec de l'export CSV",
     "searchPlaceholder": "Rechercher token ou id de tx...",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -413,7 +413,8 @@
       "transactionId": "ID da transação",
       "amount": "Valor ({unit})",
       "balance": "Saldo ({unit})",
-      "tokenChanges": "Alterações de tokens"
+      "tokenChanges": "Alterações de tokens",
+      "note": "Nota"
     },
     "pending": "pendente",
     "transactionCountPartial": "{count}+ Transações",
@@ -437,7 +438,11 @@
     "feesCollected": "Taxas coletadas:",
     "inputs": "Entradas",
     "outputs": "Saídas",
-    "coinbase": "coinbase"
+    "coinbase": "coinbase",
+    "note": "Nota:",
+    "addNote": "adicionar nota",
+    "editNote": "editar",
+    "saveNote": "salvar"
   },
   "alertDialog": {
     "transactionSent": "Transação enviada!",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -408,6 +408,7 @@
     "today": "Hoje",
     "yesterday": "Ontem",
     "balanceLabel": "Saldo:",
+    "addNote": "adicionar nota",
     "csv": {
       "date": "Data (UTC)",
       "transactionId": "ID da transação",
@@ -439,10 +440,8 @@
     "inputs": "Entradas",
     "outputs": "Saídas",
     "coinbase": "coinbase",
-    "note": "Nota:",
-    "addNote": "adicionar nota",
-    "editNote": "editar",
-    "saveNote": "salvar"
+    "notePlaceholder": "Adicionar uma nota pessoal",
+    "fullDetails": "Detalhes completos da transação"
   },
   "alertDialog": {
     "transactionSent": "Transação enviada!",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -400,7 +400,7 @@
       "combined": "Combinadas"
     },
     "showFiatValue": "Mostrar valor em fiat",
-    "hideBalanceColumn": "Ocultar saldo",
+    "showBalance": "Mostrar saldo após a transação",
     "exportCsv": "Exportar CSV",
     "exportFailed": "Falha ao exportar CSV",
     "searchPlaceholder": "Buscar token ou id de tx...",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -390,12 +390,14 @@
       "all": "Todas",
       "bchTxs": "Txs de BCH",
       "tokenTxs": "Txs de tokens",
+      "dappTxs": "Txs de dapps",
       "dateRange": "Intervalo de datas:"
     },
     "directionFilter": {
       "all": "Todas",
       "incoming": "Recebidas",
-      "outgoing": "Enviadas"
+      "outgoing": "Enviadas",
+      "combined": "Combinadas"
     },
     "showFiatValue": "Mostrar valor em fiat",
     "hideBalanceColumn": "Ocultar saldo",
@@ -405,6 +407,8 @@
     "noMatch": "Nenhuma transação corresponde ao filtro",
     "sent": "Enviado",
     "received": "Recebido",
+    "combined": "Combinado",
+    "dapp": "dapp",
     "today": "Hoje",
     "yesterday": "Ontem",
     "balanceLabel": "Saldo:",
@@ -415,6 +419,8 @@
       "amount": "Valor ({unit})",
       "balance": "Saldo ({unit})",
       "tokenChanges": "Alterações de tokens",
+      "direction": "Direção",
+      "dapp": "Dapp",
       "note": "Nota"
     },
     "pending": "pendente",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -424,6 +424,9 @@
       "note": "Nota"
     },
     "pending": "pendente",
+    "confirmationsProgress": "{count}/6 confirmações",
+    "unconfirmedChain": "cadeia não confirmada",
+    "unconfirmedChainTooltip": "Esta transação depende de outra transação não confirmada, o que aumenta o risco de que não seja confirmada.",
     "transactionCountPartial": "{count}+ Transações",
     "loadingFullHistory": "Carregando histórico completo"
   },
@@ -437,6 +440,7 @@
     "status": "Status:",
     "unconfirmed": "não confirmada",
     "confirmations": "{count} confirmações (minerada no bloco #{block})",
+    "confirmationsProgress": "{count}/6 confirmações (minerada no bloco #{block})",
     "date": "Data:",
     "balanceChange": "Variação de saldo:",
     "size": "Tamanho:",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -49,7 +49,8 @@ export const useSettingsStore = defineStore('settingsStore', () => {
   const showPrivateKeyWif = ref(false);
   // history settings
   const showFiatValueHistory = ref(true);
-  const hideBalanceColumn = ref(false);
+  // Balance after each transaction in the history, hidden by default like in payment apps
+  const showBalanceInHistory = ref(false);
   // token list settings
   type TokenDisplayFilter = 'all' | 'default' | 'favoritesOnly' | 'hiddenOnly';
   const tokenDisplayFilter = ref<TokenDisplayFilter>('default');
@@ -114,8 +115,17 @@ export const useSettingsStore = defineStore('settingsStore', () => {
   const readFiatValueHistory = localStorage.getItem("fiatValueHistory");
   if(readFiatValueHistory) showFiatValueHistory.value = readFiatValueHistory == "true";
 
-  const readHideBalanceColumn = localStorage.getItem("hideBalanceColumn");
-  if(readHideBalanceColumn) hideBalanceColumn.value = readHideBalanceColumn == "true";
+  const readShowBalanceInHistory = localStorage.getItem("showBalanceInHistory");
+  if(readShowBalanceInHistory) showBalanceInHistory.value = readShowBalanceInHistory == "true";
+  // Migration: the setting was previously stored inverted as 'hideBalanceColumn'
+  const oldHideBalanceColumn = localStorage.getItem("hideBalanceColumn");
+  if (oldHideBalanceColumn !== null) {
+    if (readShowBalanceInHistory === null) {
+      showBalanceInHistory.value = oldHideBalanceColumn !== "true";
+      localStorage.setItem("showBalanceInHistory", showBalanceInHistory.value ? "true" : "false");
+    }
+    localStorage.removeItem("hideBalanceColumn");
+  }
 
   const readQrScan = localStorage.getItem("qrScan");
   if(!readQrScan && (isDesktop || !isMobileDevice)) qrScan.value = false;
@@ -425,7 +435,7 @@ export const useSettingsStore = defineStore('settingsStore', () => {
     ipfsGateway,
     darkMode,
     showFiatValueHistory,
-    hideBalanceColumn,
+    showBalanceInHistory,
     tokenBurn,
     showCauldronSwap,
     showCauldronFTValue,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -47,6 +47,7 @@ import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
 import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/dbUtils"
 import { fetchCauldronPrices, type CauldronPriceData } from "src/utils/cauldronApi"
+import { loadTxNotes, saveTxNote, removeTxNotes } from "src/utils/txNotes"
 import { defaultWalletName } from './constants';
 import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
@@ -90,6 +91,8 @@ export const useStore = defineStore('store', () => {
   const walletUtxos = ref(undefined as (Utxo[] | undefined));
   const walletHistory = ref(undefined as (WalletHistoryReturnType | undefined));
   const isHistoryPartial = ref(false);
+  // Private notes on the active wallet's transactions, keyed by txid (see utils/txNotes.ts)
+  const txNotes = ref({} as Record<string, string>);
   const tokenList = ref(null as (TokenList | null))
   const plannedTokenId = ref(undefined as (undefined | string));
   const currentBlockHeight = ref(undefined as (number | undefined));
@@ -223,6 +226,12 @@ export const useStore = defineStore('store', () => {
     }
     _wallet.value?.stop().catch(() => {});
     _wallet.value = newWallet;
+    const newNetwork = newWallet.network == NetworkType.Mainnet ? "mainnet" : "chipnet";
+    txNotes.value = loadTxNotes(newNetwork, newWallet.name);
+  }
+
+  function setTxNote(txid: string, note: string) {
+    txNotes.value = saveTxNote(network.value, wallet.value.name, txid, note);
   }
 
   async function initializeWallet() {
@@ -614,6 +623,7 @@ export const useStore = defineStore('store', () => {
     // Delete from both mainnet and testnet databases
     await deleteWalletFromDb(walletName, 'bitcoincash');
     await deleteWalletFromDb(walletName, 'bchtest');
+    removeTxNotes(walletName);
     // Refresh the available wallets list
     await refreshAvailableWallets();
   }
@@ -969,6 +979,8 @@ export const useStore = defineStore('store', () => {
     filteredTokenList,
     walletHistory,
     isHistoryPartial,
+    txNotes,
+    setTxNote,
     walletInitFailed,
     plannedTokenId,
     dappConnectionStoresInitDone,

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -48,11 +48,19 @@ function formatTokenChange(
   return parts.join("; ");
 }
 
+// Direction and dapp classification are computed by the caller: they need the
+// wallet's own addresses and translated labels, which don't belong in this utility
+export interface TxDirectionInfo {
+  direction: string;
+  dapp: boolean;
+}
+
 export function historyToCsv(
   history: TransactionHistoryItem[],
   bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined,
   bchUnit: string,
-  txNotes: Record<string, string>
+  txNotes: Record<string, string>,
+  getDirectionInfo: (tx: TransactionHistoryItem) => TxDirectionInfo
 ): string {
   const header = [
     t("history.csv.date"),
@@ -60,16 +68,23 @@ export function historyToCsv(
     t("history.csv.amount", { unit: bchUnit }),
     t("history.csv.balance", { unit: bchUnit }),
     t("history.csv.tokenChanges"),
+    t("history.csv.direction"),
+    t("history.csv.dapp"),
     t("history.csv.note"),
   ];
-  const rows = history.map(tx => [
-    tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : t("history.pending"),
-    tx.hash,
-    (tx.valueChange / SATS_PER_BCH).toFixed(8),
-    (tx.balance / SATS_PER_BCH).toFixed(8),
-    tx.tokenAmountChanges.map(change => formatTokenChange(change, bcmrRegistries)).join("; "),
-    txNotes[tx.hash] ?? "",
-  ]);
+  const rows = history.map(tx => {
+    const directionInfo = getDirectionInfo(tx);
+    return [
+      tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : t("history.pending"),
+      tx.hash,
+      (tx.valueChange / SATS_PER_BCH).toFixed(8),
+      (tx.balance / SATS_PER_BCH).toFixed(8),
+      tx.tokenAmountChanges.map(change => formatTokenChange(change, bcmrRegistries)).join("; "),
+      directionInfo.direction,
+      directionInfo.dapp ? t("history.dapp") : "",
+      txNotes[tx.hash] ?? "",
+    ];
+  });
   return [header, ...rows]
     .map(row => row.map(csvEscape).join(","))
     .join("\r\n");

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -51,7 +51,8 @@ function formatTokenChange(
 export function historyToCsv(
   history: TransactionHistoryItem[],
   bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined,
-  bchUnit: string
+  bchUnit: string,
+  txNotes: Record<string, string>
 ): string {
   const header = [
     t("history.csv.date"),
@@ -59,6 +60,7 @@ export function historyToCsv(
     t("history.csv.amount", { unit: bchUnit }),
     t("history.csv.balance", { unit: bchUnit }),
     t("history.csv.tokenChanges"),
+    t("history.csv.note"),
   ];
   const rows = history.map(tx => [
     tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : t("history.pending"),
@@ -66,6 +68,7 @@ export function historyToCsv(
     (tx.valueChange / SATS_PER_BCH).toFixed(8),
     (tx.balance / SATS_PER_BCH).toFixed(8),
     tx.tokenAmountChanges.map(change => formatTokenChange(change, bcmrRegistries)).join("; "),
+    txNotes[tx.hash] ?? "",
   ]);
   return [header, ...rows]
     .map(row => row.map(csvEscape).join(","))

--- a/src/utils/txDirection.ts
+++ b/src/utils/txDirection.ts
@@ -1,0 +1,46 @@
+import type { TransactionHistoryItem } from "mainnet-js";
+
+export type TxDirection = 'received' | 'sent' | 'combined';
+
+// Direction is judged per asset flow: the BCH change and every token change count
+// separately. A transaction with flows both ways (a swap, loan or mint) is combined
+export function txHasIncoming(transaction: TransactionHistoryItem): boolean {
+  if (transaction.valueChange > 0) return true;
+  return transaction.tokenAmountChanges.some(change => change.amount > 0n || change.nftAmount > 0n);
+}
+
+export function txHasOutgoing(transaction: TransactionHistoryItem): boolean {
+  if (transaction.valueChange < 0) return true;
+  return transaction.tokenAmountChanges.some(change => change.amount < 0n || change.nftAmount < 0n);
+}
+
+export function isCombined(transaction: TransactionHistoryItem): boolean {
+  return txHasIncoming(transaction) && txHasOutgoing(transaction);
+}
+
+export function txDirection(transaction: TransactionHistoryItem): TxDirection {
+  if (isCombined(transaction)) return 'combined';
+  return txHasOutgoing(transaction) ? 'sent' : 'received';
+}
+
+export function directionIcon(transaction: TransactionHistoryItem): string {
+  const direction = txDirection(transaction);
+  if (direction === 'combined') return 'swap_vert';
+  return direction === 'received' ? 'arrow_downward' : 'arrow_upward';
+}
+
+// A transaction the wallet coauthored that also spends a contract (P2SH) input is
+// a dapp interaction. Requiring one of the wallet's own inputs filters out third
+// parties that merely pay us from a P2SH wallet, like exchange withdrawals
+export function isDappInteraction(
+  transaction: TransactionHistoryItem,
+  hasWalletAddress: (address: string) => boolean
+): boolean {
+  const hasP2shInput = transaction.inputs.some(input => {
+    // P2SH cashaddr payloads start with p, or r for the token-aware variant
+    const payload = input.address.split(":")[1] ?? "";
+    return payload.startsWith("p") || payload.startsWith("r");
+  });
+  if (!hasP2shInput) return false;
+  return transaction.inputs.some(input => hasWalletAddress(input.address));
+}

--- a/src/utils/txDirection.ts
+++ b/src/utils/txDirection.ts
@@ -24,6 +24,8 @@ export function txDirection(transaction: TransactionHistoryItem): TxDirection {
 }
 
 export function directionIcon(transaction: TransactionHistoryItem): string {
+  // pending transactions show a waiting icon, the label next to it carries the direction
+  if (!transaction.timestamp) return 'hourglass_empty';
   const direction = txDirection(transaction);
   if (direction === 'combined') return 'swap_vert';
   return direction === 'received' ? 'arrow_downward' : 'arrow_upward';

--- a/src/utils/txNotes.ts
+++ b/src/utils/txNotes.ts
@@ -1,0 +1,46 @@
+// Private transaction notes, stored in localStorage per wallet per network as a txid → note map.
+// Keyed by txid so notes survive rescans and re-imports; notes never leave the device.
+
+export const maxTxNoteLength = 200;
+
+type Network = 'mainnet' | 'chipnet';
+
+function txNotesKey(network: Network, walletName: string): string {
+  return `txNotes-${network}-${walletName}`;
+}
+
+export function loadTxNotes(network: Network, walletName: string): Record<string, string> {
+  const readTxNotes = localStorage.getItem(txNotesKey(network, walletName));
+  if (!readTxNotes) return {};
+  try {
+    return JSON.parse(readTxNotes) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+// Fresh read-modify-write: another tab may have written notes since this tab loaded them,
+// so re-read before writing to only ever overwrite the single txid being edited.
+// An empty note deletes the entry. Returns the updated map for the caller's reactive state.
+export function saveTxNote(
+  network: Network,
+  walletName: string,
+  txid: string,
+  note: string
+): Record<string, string> {
+  const txNotes = loadTxNotes(network, walletName);
+  const trimmedNote = note.trim().slice(0, maxTxNoteLength);
+  if (trimmedNote) {
+    txNotes[txid] = trimmedNote;
+  } else {
+    delete txNotes[txid];
+  }
+  localStorage.setItem(txNotesKey(network, walletName), JSON.stringify(txNotes));
+  return txNotes;
+}
+
+// A future wallet created under the same name must not inherit the old wallet's notes
+export function removeTxNotes(walletName: string) {
+  localStorage.removeItem(txNotesKey('mainnet', walletName));
+  localStorage.removeItem(txNotesKey('chipnet', walletName));
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -65,6 +65,31 @@ export function formatTime(timestamp: number): string {
   return new Date(timestamp * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
 }
 
+// Easily readable date like "1 Aug 2026, 23:48"
+export function formatReadableDate(timestamp: number): string {
+  const day = new Date(timestamp * 1000).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+  return `${day}, ${formatTime(timestamp)}`;
+}
+
+// Calendar-day label for grouping history rows: Today, Yesterday, or "1 Aug 2026".
+// Pending transactions have no timestamp and group under their own header
+export function dayLabel(timestamp: number | undefined): string {
+  if (!timestamp) return t('history.pending');
+  const date = new Date(timestamp * 1000);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  if (date.toDateString() === today.toDateString()) return t('history.today');
+  if (date.toDateString() === yesterday.toDateString()) return t('history.yesterday');
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+// Date inputs hold local calendar dates (YYYY-MM-DD); compare in local time to match the displayed dates
+export function localDayStart(isoDate: string, dayOffset = 0): number {
+  const [year = 0, month = 1, day = 1] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day + dayOffset).getTime() / 1000;
+}
+
 export function formatRelativeTime(timestamp: number): string {
   const now = Math.floor(Date.now() / 1000);
   const diff = now - timestamp;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { decodeBip39Mnemonic, hexToBin } from "@bitauth/libauth"
 import { Notify } from "quasar";
-import { Wallet, TestNetWallet, HDWallet, TestNetHDWallet, type Utxo } from "mainnet-js"
-import type { ElectrumTokenData, TokenDataFT, TokenDataNFT, CurrencyShortNames, DateFormat, WalletType } from "../interfaces/interfaces"
+import { Wallet, TestNetWallet, HDWallet, TestNetHDWallet, type Utxo, type TransactionHistoryItem } from "mainnet-js"
+import type { BcmrTokenMetadata, ElectrumTokenData, TokenDataFT, TokenDataNFT, CurrencyShortNames, DateFormat, WalletType } from "../interfaces/interfaces"
 import { type Ref, watch, type WatchStopHandle } from "vue";
 import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
@@ -158,6 +158,55 @@ export function formatNumber(value: number, maxDecimals: number): string {
 export function satsToBch(satoshis: bigint | number) {
   return Number(satoshis) / 100_000_000;
 };
+
+export function formatBchAmount(satoshis: number, signed = false, maxDecimals = 5): string {
+  const amount = (satoshis / 100_000_000).toLocaleString("en-US", { minimumFractionDigits: 5, maximumFractionDigits: maxDecimals });
+  return signed && satoshis > 0 ? `+${amount}` : amount;
+}
+
+export interface TokenChangeChip {
+  key: string;
+  category: string;
+  amountText: string;
+  symbol: string;
+  negative: boolean;
+}
+
+// Tokens like BADGER have both fungibles and NFTs with the same category in user wallets,
+// so one token change can yield both a fungible chip and an NFT chip
+export function tokenChangeChips(
+  transaction: TransactionHistoryItem,
+  bcmrRegistries: Record<string, BcmrTokenMetadata> | undefined
+): TokenChangeChip[] {
+  const chips: TokenChangeChip[] = [];
+  for (const tokenChange of transaction.tokenAmountChanges) {
+    const tokenMetadata = bcmrRegistries?.[tokenChange.category]?.token;
+    const symbol = tokenMetadata?.symbol ?? tokenChange.category.slice(0, 8);
+    const decimals = tokenMetadata?.decimals ?? 0;
+    // Show the fungible change for any nonzero amount. When there is no NFT change either,
+    // still show it (as "0") so a token change never renders without a chip.
+    if (tokenChange.amount !== 0n || tokenChange.nftAmount === 0n) {
+      const amount = Number(tokenChange.amount) / 10 ** decimals;
+      chips.push({
+        key: tokenChange.category + "-ft",
+        category: tokenChange.category,
+        amountText: `${amount > 0 ? '+' : ''}${amount.toLocaleString("en-US", { maximumFractionDigits: decimals })}`,
+        symbol,
+        negative: amount < 0,
+      });
+    }
+    if (tokenChange.nftAmount !== 0n) {
+      chips.push({
+        key: tokenChange.category + "-nft",
+        category: tokenChange.category,
+        amountText: `${tokenChange.nftAmount > 0n ? '+' : ''}${tokenChange.nftAmount}`,
+        symbol: `${symbol} NFT`,
+        negative: tokenChange.nftAmount < 0n,
+      });
+    }
+  }
+  return chips;
+}
 
 export function getTokenUtxos(utxos:  Utxo[]){
   return utxos.filter((val) =>val.token);

--- a/test/csvUtils.test.ts
+++ b/test/csvUtils.test.ts
@@ -36,34 +36,38 @@ describe('csvEscape', () => {
 
 describe('historyToCsv', () => {
   it('should write the header with the given BCH unit', () => {
-    expect(historyToCsv([], undefined, "tBCH"))
-      .toBe("Date (UTC),Transaction Id,Amount (tBCH),Balance (tBCH),Token Changes");
+    expect(historyToCsv([], undefined, "tBCH", {}))
+      .toBe("Date (UTC),Transaction Id,Amount (tBCH),Balance (tBCH),Token Changes,Note");
   })
   it('should format the date as ISO UTC and amounts with 8 decimals', () => {
-    const csv = historyToCsv([makeTx({})], undefined, "BCH");
-    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,");
+    const csv = historyToCsv([makeTx({})], undefined, "BCH", {});
+    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,");
   })
   it('should mark unconfirmed transactions as pending', () => {
     const pendingTx = makeTx({});
     delete pendingTx.timestamp;
-    const csv = historyToCsv([pendingTx], undefined, "BCH");
+    const csv = historyToCsv([pendingTx], undefined, "BCH", {});
     expect(csv).toContain("pending,txhash123");
   })
   it('should apply token symbol and decimals from the registry', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: 12345n, nftAmount: -1n }] });
-    const csv = historyToCsv([tx], registries, "BCH");
+    const csv = historyToCsv([tx], registries, "BCH", {});
     expect(csv).toContain("+123.45 FURU; -1 FURU NFT");
   })
   it('should fall back to the category prefix for unknown tokens', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: -5n, nftAmount: 0n }] });
-    const csv = historyToCsv([tx], undefined, "BCH");
+    const csv = historyToCsv([tx], undefined, "BCH", {});
     expect(csv).toContain("-5 aabbccdd");
   })
   it('should strip formula-injection characters from token symbols', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryB, amount: 1n, nftAmount: 0n }] });
-    const csv = historyToCsv([tx], registries, "BCH");
+    const csv = historyToCsv([tx], registries, "BCH", {});
     expect(csv).not.toContain("=cmd");
     expect(csv).not.toContain("|");
     expect(csv).toContain("+1 cmdCcalcA0");
+  })
+  it('should include the note for a transaction and escape it', () => {
+    const csv = historyToCsv([makeTx({})], undefined, "BCH", { txhash123: 'rent, "march"' });
+    expect(csv.split("\r\n")[1]).toBe('2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,"rent, ""march"""');
   })
 })

--- a/test/csvUtils.test.ts
+++ b/test/csvUtils.test.ts
@@ -34,40 +34,47 @@ describe('csvEscape', () => {
   })
 })
 
+// Direction info is precomputed by the history view in the real app
+const sentTx = () => ({ direction: "Sent", dapp: false });
+
 describe('historyToCsv', () => {
   it('should write the header with the given BCH unit', () => {
-    expect(historyToCsv([], undefined, "tBCH", {}))
-      .toBe("Date (UTC),Transaction Id,Amount (tBCH),Balance (tBCH),Token Changes,Note");
+    expect(historyToCsv([], undefined, "tBCH", {}, sentTx))
+      .toBe("Date (UTC),Transaction Id,Amount (tBCH),Balance (tBCH),Token Changes,Direction,Dapp,Note");
   })
   it('should format the date as ISO UTC and amounts with 8 decimals', () => {
-    const csv = historyToCsv([makeTx({})], undefined, "BCH", {});
-    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,");
+    const csv = historyToCsv([makeTx({})], undefined, "BCH", {}, sentTx);
+    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,Sent,,");
   })
   it('should mark unconfirmed transactions as pending', () => {
     const pendingTx = makeTx({});
     delete pendingTx.timestamp;
-    const csv = historyToCsv([pendingTx], undefined, "BCH", {});
+    const csv = historyToCsv([pendingTx], undefined, "BCH", {}, sentTx);
     expect(csv).toContain("pending,txhash123");
   })
   it('should apply token symbol and decimals from the registry', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: 12345n, nftAmount: -1n }] });
-    const csv = historyToCsv([tx], registries, "BCH", {});
+    const csv = historyToCsv([tx], registries, "BCH", {}, sentTx);
     expect(csv).toContain("+123.45 FURU; -1 FURU NFT");
   })
   it('should fall back to the category prefix for unknown tokens', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryA, amount: -5n, nftAmount: 0n }] });
-    const csv = historyToCsv([tx], undefined, "BCH", {});
+    const csv = historyToCsv([tx], undefined, "BCH", {}, sentTx);
     expect(csv).toContain("-5 aabbccdd");
   })
   it('should strip formula-injection characters from token symbols', () => {
     const tx = makeTx({ tokenAmountChanges: [{ category: categoryB, amount: 1n, nftAmount: 0n }] });
-    const csv = historyToCsv([tx], registries, "BCH", {});
+    const csv = historyToCsv([tx], registries, "BCH", {}, sentTx);
     expect(csv).not.toContain("=cmd");
     expect(csv).not.toContain("|");
     expect(csv).toContain("+1 cmdCcalcA0");
   })
+  it('should write the direction label and dapp marker columns', () => {
+    const csv = historyToCsv([makeTx({})], undefined, "BCH", {}, () => ({ direction: "Combined", dapp: true }));
+    expect(csv.split("\r\n")[1]).toBe("2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,Combined,dapp,");
+  })
   it('should include the note for a transaction and escape it', () => {
-    const csv = historyToCsv([makeTx({})], undefined, "BCH", { txhash123: 'rent, "march"' });
-    expect(csv.split("\r\n")[1]).toBe('2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,"rent, ""march"""');
+    const csv = historyToCsv([makeTx({})], undefined, "BCH", { txhash123: 'rent, "march"' }, sentTx);
+    expect(csv.split("\r\n")[1]).toBe('2023-11-14T22:13:20.000Z,txhash123,-0.50000000,1.50000000,,Sent,,"rent, ""march"""');
   })
 })

--- a/test/txDirection.test.ts
+++ b/test/txDirection.test.ts
@@ -1,0 +1,89 @@
+import { txDirection, isCombined, isDappInteraction } from "../src/utils/txDirection";
+import type { TransactionHistoryItem } from "mainnet-js";
+
+const category = "aabbccdd".repeat(8);
+
+const makeTx = (overrides: Partial<TransactionHistoryItem>): TransactionHistoryItem => ({
+  hash: "txhash123",
+  blockHeight: 800000,
+  timestamp: 1700000000,
+  size: 250,
+  fee: 300,
+  balance: 150_000_000,
+  valueChange: -50_000_000,
+  inputs: [],
+  outputs: [],
+  tokenAmountChanges: [],
+  ...overrides,
+});
+
+const input = (address: string) => ({ address, value: 10_000 } as TransactionHistoryItem["inputs"][number]);
+
+describe('txDirection', () => {
+  it('should classify a plain BCH receive as received', () => {
+    expect(txDirection(makeTx({ valueChange: 100_000 }))).toBe('received');
+  });
+
+  it('should classify a plain BCH send as sent', () => {
+    expect(txDirection(makeTx({ valueChange: -100_000 }))).toBe('sent');
+  });
+
+  it('should classify a token receive with dust as received', () => {
+    const tx = makeTx({ valueChange: 1000, tokenAmountChanges: [{ category, amount: 5n, nftAmount: 0n }] });
+    expect(txDirection(tx)).toBe('received');
+  });
+
+  it('should classify a token send paying the fee as sent', () => {
+    const tx = makeTx({ valueChange: -500, tokenAmountChanges: [{ category, amount: -5n, nftAmount: 0n }] });
+    expect(txDirection(tx)).toBe('sent');
+  });
+
+  it('should classify BCH in with tokens out as combined', () => {
+    const tx = makeTx({ valueChange: 349_321_793, tokenAmountChanges: [{ category, amount: -540n, nftAmount: -1n }] });
+    expect(txDirection(tx)).toBe('combined');
+    expect(isCombined(tx)).toBe(true);
+  });
+
+  it('should classify BCH out with tokens in as combined', () => {
+    const tx = makeTx({ valueChange: -1000, tokenAmountChanges: [{ category, amount: 0n, nftAmount: 1n }] });
+    expect(txDirection(tx)).toBe('combined');
+  });
+
+  it('should classify a token for token trade as combined', () => {
+    const tx = makeTx({ valueChange: -500, tokenAmountChanges: [
+      { category, amount: 10n, nftAmount: 0n },
+      { category: "11223344".repeat(8), amount: -3n, nftAmount: 0n },
+    ]});
+    expect(txDirection(tx)).toBe('combined');
+  });
+});
+
+describe('isDappInteraction', () => {
+  const ownAddress = "bitcoincash:qq1234ownaddress";
+  const hasWalletAddress = (address: string) => address === ownAddress;
+
+  it('should detect a cosigned transaction spending a P2SH input', () => {
+    const tx = makeTx({ inputs: [input("bitcoincash:pp1234contract"), input(ownAddress)] });
+    expect(isDappInteraction(tx, hasWalletAddress)).toBe(true);
+  });
+
+  it('should detect the token-aware P2SH address variant', () => {
+    const tx = makeTx({ inputs: [input("bitcoincash:rr1234contract"), input(ownAddress)] });
+    expect(isDappInteraction(tx, hasWalletAddress)).toBe(true);
+  });
+
+  it('should not flag a third party paying from a P2SH wallet', () => {
+    const tx = makeTx({ inputs: [input("bitcoincash:pp1234exchange")] });
+    expect(isDappInteraction(tx, hasWalletAddress)).toBe(false);
+  });
+
+  it('should not flag plain P2PKH transactions', () => {
+    const tx = makeTx({ inputs: [input("bitcoincash:qq1234other"), input(ownAddress)] });
+    expect(isDappInteraction(tx, hasWalletAddress)).toBe(false);
+  });
+
+  it('should handle the coinbase pseudo address', () => {
+    const tx = makeTx({ inputs: [input("coinbase")] });
+    expect(isDappInteraction(tx, hasWalletAddress)).toBe(false);
+  });
+});

--- a/test/txNotes.test.ts
+++ b/test/txNotes.test.ts
@@ -1,0 +1,67 @@
+import { loadTxNotes, saveTxNote, removeTxNotes, maxTxNoteLength } from "../src/utils/txNotes";
+
+// The global setup stubs localStorage as a no-op; these tests need a working store
+function makeLocalStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+  };
+}
+
+describe('txNotes', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', makeLocalStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should save and load a note per wallet per network', () => {
+    saveTxNote('mainnet', 'mywallet', 'txid1', 'rent payment');
+    expect(loadTxNotes('mainnet', 'mywallet')).toEqual({ txid1: 'rent payment' });
+    expect(loadTxNotes('chipnet', 'mywallet')).toEqual({});
+    expect(loadTxNotes('mainnet', 'otherwallet')).toEqual({});
+  });
+
+  it('should trim notes and cap them at the maximum length', () => {
+    const notes = saveTxNote('mainnet', 'mywallet', 'txid1', '  ' + 'a'.repeat(maxTxNoteLength + 50) + '  ');
+    expect(notes['txid1']).toBe('a'.repeat(maxTxNoteLength));
+  });
+
+  it('should delete the entry when saving an empty or whitespace note', () => {
+    saveTxNote('mainnet', 'mywallet', 'txid1', 'note');
+    const notes = saveTxNote('mainnet', 'mywallet', 'txid1', '   ');
+    expect(notes).toEqual({});
+    expect(loadTxNotes('mainnet', 'mywallet')).toEqual({});
+  });
+
+  it('should preserve notes written after load (concurrent tab)', () => {
+    saveTxNote('mainnet', 'mywallet', 'txid1', 'from this tab');
+    // simulate another tab writing a note for a different txid
+    const key = 'txNotes-mainnet-mywallet';
+    const otherTabNotes = { ...JSON.parse(localStorage.getItem(key)!), txid2: 'from other tab' };
+    localStorage.setItem(key, JSON.stringify(otherTabNotes));
+    // this tab saves a new note; the other tab's note must survive
+    const notes = saveTxNote('mainnet', 'mywallet', 'txid3', 'also this tab');
+    expect(notes).toEqual({ txid1: 'from this tab', txid2: 'from other tab', txid3: 'also this tab' });
+  });
+
+  it('should return an empty map for corrupted stored data', () => {
+    localStorage.setItem('txNotes-mainnet-mywallet', 'not json');
+    expect(loadTxNotes('mainnet', 'mywallet')).toEqual({});
+  });
+
+  it('should remove notes for both networks on wallet deletion', () => {
+    saveTxNote('mainnet', 'mywallet', 'txid1', 'note');
+    saveTxNote('chipnet', 'mywallet', 'txid2', 'note');
+    saveTxNote('mainnet', 'otherwallet', 'txid3', 'kept');
+    removeTxNotes('mywallet');
+    expect(loadTxNotes('mainnet', 'mywallet')).toEqual({});
+    expect(loadTxNotes('chipnet', 'mywallet')).toEqual({});
+    expect(loadTxNotes('mainnet', 'otherwallet')).toEqual({ txid3: 'kept' });
+  });
+});


### PR DESCRIPTION
Notes are stored on-device only, in localStorage per wallet per network, keyed by txid so they survive rescans and re-imports. Editable from the transaction dialog, shown and searchable in the history list, and included in the CSV export. Addresses #160 / #256.