### PR TITLE
add close button and image upload to QR scan overlay

### DIFF
--- a/src/components/qr/qrCodeScanDialog.vue
+++ b/src/components/qr/qrCodeScanDialog.vue
@@ -209,8 +209,12 @@
 .scanner-upload-btn {
   position: absolute;
   bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  /* centered with auto margins instead of translateX, because the global
+     button:active scale transform would replace a transform while pressed */
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: fit-content;
   z-index: 2001;
   font-size: 13px;
   padding: 4px 14px;

--- a/src/components/qr/qrCodeScanDialog.vue
+++ b/src/components/qr/qrCodeScanDialog.vue
@@ -114,12 +114,17 @@
     // reset so selecting the same file again re-triggers the change event
     input.value = '';
     if (!file) return;
+    let result: QrScanner.ScanResult;
     try {
-      const result = await QrScanner.scanImage(file, { returnDetailedScanResult: true });
-      handleDecode(result);
-    } catch {
-      filterHint.value = t('qrScanner.noQrCodeInImage');
+      result = await QrScanner.scanImage(file, { returnDetailedScanResult: true });
+    } catch (err) {
+      // the library rejects with "No QR code found" when the image has no readable QR;
+      // anything else (worker load failure, unreadable file) should surface as-is
+      const message = caughtErrorToString(err);
+      filterHint.value = message.includes('No QR code found') ? t('qrScanner.noQrCodeInImage') : message;
+      return;
     }
+    handleDecode(result);
   }
 
   // Use watch to handle cases where the video ref isn't available at onMounted

--- a/src/components/qr/qrCodeScanDialog.vue
+++ b/src/components/qr/qrCodeScanDialog.vue
@@ -221,8 +221,9 @@
 </style>
 
 <style>
-/* Disable backdrop blur for scanner dialog — interferes with video compositing on mobile */
-.scanner-dialog .q-dialog__backdrop {
+/* Backdrop blur interferes with the camera video compositing on mobile, so disable
+   it there; desktop keeps the blurred backdrop like other dialogs */
+body.mobile .scanner-dialog .q-dialog__backdrop {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }

--- a/src/components/qr/qrCodeScanDialog.vue
+++ b/src/components/qr/qrCodeScanDialog.vue
@@ -19,6 +19,7 @@
   const showDialog = ref(true);
   const videoElement = ref<HTMLVideoElement | null>(null);
   const videoPlaying = ref(false);
+  const fileInput = ref<HTMLInputElement | null>(null);
 
   let scanner: QrScanner | null = null;
   let didDecode = false;
@@ -103,6 +104,24 @@
     }
   }
 
+  function openImagePicker() {
+    fileInput.value?.click();
+  }
+
+  async function handleImageSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    // reset so selecting the same file again re-triggers the change event
+    input.value = '';
+    if (!file) return;
+    try {
+      const result = await QrScanner.scanImage(file, { returnDetailedScanResult: true });
+      handleDecode(result);
+    } catch {
+      filterHint.value = t('qrScanner.noQrCodeInImage');
+    }
+  }
+
   // Use watch to handle cases where the video ref isn't available at onMounted
   // (QDialog portal/transition timing can delay ref binding)
   watch(videoElement, (el) => {
@@ -128,8 +147,13 @@
 <template>
   <q-dialog v-model="showDialog" class="scanner-dialog" transition-show="fade" transition-hide="fade" @before-hide="handleBeforeHide">
     <div v-if="error" class="scanner-error-dialog text-center bg-red-1 text-red q-pa-md">
-      <q-icon name="error" left/>
-      {{ error }}
+      <div>
+        <q-icon name="error" left/>
+        {{ error }}
+      </div>
+      <q-btn class="q-mt-md" color="primary" icon="image" :label="t('qrScanner.chooseImage')" no-caps @click="openImagePicker" />
+      <div v-if="filterHint" class="q-mt-sm">{{ filterHint }}</div>
+      <input ref="fileInput" type="file" accept="image/*" style="display: none;" @change="handleImageSelected">
     </div>
     <q-card v-else class="scanner-card" :style="isMobile ? 'width: 100%; height: 100%;' : 'width: 75%; height: 75%;'">
       <video
@@ -144,6 +168,9 @@
       <div style="display: flex; height: 100%;">
         <ScannerUI :filter-hint="filterHint" />
       </div>
+      <q-btn class="scanner-close-btn" icon="close" color="white" flat round dense v-close-popup />
+      <q-btn class="scanner-upload-btn" icon="image" :label="t('qrScanner.chooseImage')" no-caps flat rounded dense @click="openImagePicker" />
+      <input ref="fileInput" type="file" accept="image/*" style="display: none;" @change="handleImageSelected">
     </q-card>
   </q-dialog>
 </template>
@@ -164,6 +191,27 @@
 }
 .scanner-video.video-ready {
   opacity: 1;
+}
+/* z-index 2001 puts the buttons above the scanner-box overlay shadow (z-index 2000) */
+.scanner-close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2001;
+  font-size: 14px;
+  background: rgba(0, 0, 0, 0.45);
+}
+.scanner-upload-btn {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2001;
+  font-size: 13px;
+  padding: 4px 14px;
+  color: white;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.25);
 }
 </style>
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -723,6 +723,8 @@
   },
   "qrScanner": {
     "scanQrCode": "QR-Code scannen",
+    "chooseImage": "Bild auswählen",
+    "noQrCodeInImage": "Kein QR-Code im Bild gefunden",
     "errors": {
       "permissionRequired": "Berechtigung für den Kamerazugriff erforderlich",
       "noCamera": "Keine Kamera auf diesem Gerät gefunden",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -723,6 +723,8 @@
   },
   "qrScanner": {
     "scanQrCode": "Scan QR Code",
+    "chooseImage": "Choose image",
+    "noQrCodeInImage": "No QR code found in image",
     "errors": {
       "permissionRequired": "Permission required to access the camera",
       "noCamera": "No camera found on this device",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -723,6 +723,8 @@
   },
   "qrScanner": {
     "scanQrCode": "Escanear código QR",
+    "chooseImage": "Elegir imagen",
+    "noQrCodeInImage": "No se encontró código QR en la imagen",
     "errors": {
       "permissionRequired": "Se requiere permiso para acceder a la cámara",
       "noCamera": "No se encontró cámara en este dispositivo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -723,6 +723,8 @@
   },
   "qrScanner": {
     "scanQrCode": "Scanner le code QR",
+    "chooseImage": "Choisir une image",
+    "noQrCodeInImage": "Aucun code QR trouvé dans l'image",
     "errors": {
       "permissionRequired": "Permission requise pour accéder à la caméra",
       "noCamera": "Aucune caméra trouvée sur cet appareil",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -723,6 +723,8 @@
   },
   "qrScanner": {
     "scanQrCode": "Escanear QR Code",
+    "chooseImage": "Escolher imagem",
+    "noQrCodeInImage": "Nenhum QR Code encontrado na imagem",
     "errors": {
       "permissionRequired": "Permissão necessária para acessar a câmera",
       "noCamera": "Nenhuma câmera encontrada neste dispositivo",


### PR DESCRIPTION
- clear X button to close the scanner without tapping the backdrop
- "Choose image" button decodes a QR from a gallery/file image via QrScanner.scanImage, going through the same filter validation
- image upload is also offered on the camera-error state as a fallback

closes #245, closes #218