### PR TITLE
add chipnet support to the portfolio view

### DIFF
--- a/src/components/portfolio/portfolioView.vue
+++ b/src/components/portfolio/portfolioView.vue
@@ -54,6 +54,12 @@
   const displayUnit = ref<'currency' | 'bch'>('currency')
   const showSmallBalances = ref(false)
   const showUnpriced = ref(false)
+  // chipnet balances are shown in the mainnet BCH price here just like on the wallet
+  // page, marked with the same 't' prefix on the unit and currency names
+  const bchUnitName = computed(() => store.network === 'mainnet' ? 'BCH' : 'tBCH')
+  const currencyName = computed(() => {
+    return (store.network === 'mainnet' ? '' : 't') + CurrencyShortNames[settingsStore.currency]
+  })
   // fall back to BCH display while no exchange rate is available
   const effectiveUnit = computed(() => store.exchangeRate === undefined ? 'bch' : displayUnit.value)
 
@@ -89,7 +95,7 @@
     const bchBalance = Number(store.balance) / 100_000_000
     const bchEntry: PricedAsset = {
       name: 'Bitcoin Cash',
-      symbol: 'BCH',
+      symbol: bchUnitName.value,
       amountDisplay: amountFormatter.format(bchBalance),
       bchValue: bchBalance
     }
@@ -426,7 +432,7 @@
     if (effectiveUnit.value === 'currency' && store.exchangeRate !== undefined) {
       return formatFiatAmount(bchValue * store.exchangeRate, settingsStore.currency)
     }
-    return bchValueFormatter.format(bchValue) + ' BCH'
+    return bchValueFormatter.format(bchValue) + ' ' + bchUnitName.value
   }
 
   // Custom hover tooltip for the chart, positioned relative to the donut wrapper
@@ -502,13 +508,13 @@
       <div style="cursor: pointer;" @click="() => store.changeView(1)">
         ← {{ t('portfolio.backToWallet') }}
       </div>
-      <div v-if="store.network === 'mainnet'" class="unit-toggle">
+      <div class="unit-toggle">
         <button
           :class="{ active: effectiveUnit === 'currency' }"
           :disabled="store.exchangeRate === undefined"
           @click="displayUnit = 'currency'"
-        >{{ CurrencyShortNames[settingsStore.currency] }}</button>
-        <button :class="{ active: effectiveUnit === 'bch' }" @click="displayUnit = 'bch'">BCH</button>
+        >{{ currencyName }}</button>
+        <button :class="{ active: effectiveUnit === 'bch' }" @click="displayUnit = 'bch'">{{ bchUnitName }}</button>
       </div>
     </div>
 
@@ -520,11 +526,7 @@
       </InfoPopup>
     </div>
 
-    <div v-if="store.network !== 'mainnet'" class="page-note">
-      {{ t('portfolio.mainnetOnly') }}
-    </div>
-
-    <div v-else-if="!assets || !portfolioReady" style="text-align: center;">
+    <div v-if="!assets || !portfolioReady" style="text-align: center;">
       <template v-if="store.walletInitFailed">{{ t('portfolio.loadingFailed') }}</template>
       <template v-else>{{ t('portfolio.loading') }} <q-spinner-dots size="1.2em" /></template>
     </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -173,7 +173,6 @@
     "stakedValue": "Gestakter Wert",
     "includeStaked": "ParyonUSD-Stakes im Gesamtwert einbeziehen",
     "stakingInfo": "Ein Staking-Beleg hält den zu einer bestimmten Epoche gestakten Betrag fest. Der aktuelle Einsatz kann bei der Auszahlung niedriger sein, dieser Wert ist daher eine Schätzung.",
-    "mainnetOnly": "Die Portfolio-Ansicht ist nur im Mainnet verfügbar",
     "noAssets": "Noch kein BCH und keine Tokens in diesem Wallet",
     "loading": "Lade Wallet-Daten",
     "loadingFailed": "Wallet-Daten konnten nicht geladen werden"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -173,7 +173,6 @@
     "stakedValue": "Staked value",
     "includeStaked": "Include ParyonUSD stakes in total",
     "stakingInfo": "A staking receipt records the amount staked at a specific epoch. The current stake can be lower by the time it is withdrawn, so this value is an estimate.",
-    "mainnetOnly": "The portfolio view is only available on mainnet",
     "noAssets": "No BCH or tokens in this wallet yet",
     "loading": "Loading wallet data",
     "loadingFailed": "Failed to load wallet data"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -173,7 +173,6 @@
     "stakedValue": "Valor en staking",
     "includeStaked": "Incluir los stakes de ParyonUSD en el total",
     "stakingInfo": "Un recibo de staking registra la cantidad depositada en una época específica. La cantidad actual puede ser menor al momento de retirarla, por lo que este valor es una estimación.",
-    "mainnetOnly": "La vista de portafolio solo está disponible en mainnet",
     "noAssets": "Aún no hay BCH ni tokens en esta billetera",
     "loading": "Cargando datos de la billetera",
     "loadingFailed": "Error al cargar los datos de la billetera"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -173,7 +173,6 @@
     "stakedValue": "Valeur stakée",
     "includeStaked": "Inclure les stakes ParyonUSD dans le total",
     "stakingInfo": "Un reçu de staking enregistre le montant staké à une époque donnée. Le montant actuel peut être plus bas au moment du retrait, cette valeur est donc une estimation.",
-    "mainnetOnly": "La vue portfolio est uniquement disponible sur le mainnet",
     "noAssets": "Pas encore de BCH ni de tokens dans ce portefeuille",
     "loading": "Chargement des données du portefeuille",
     "loadingFailed": "Échec du chargement des données du portefeuille"

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -173,7 +173,6 @@
     "stakedValue": "Valor em staking",
     "includeStaked": "Incluir os stakes ParyonUSD no total",
     "stakingInfo": "Um recibo de staking registra a quantia depositada em uma época específica. A quantia atual pode ser menor no momento do saque, portanto este valor é uma estimativa.",
-    "mainnetOnly": "A visão de portfólio só está disponível na mainnet",
     "noAssets": "Ainda não há BCH nem tokens nesta carteira",
     "loading": "Carregando dados da carteira",
     "loadingFailed": "Falha ao carregar os dados da carteira"

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -959,13 +959,19 @@ export const useStore = defineStore('store', () => {
   // prices, like the portfolio view the user explicitly opened
   async function fetchCauldronPricesForTokens(force = false) {
     if (!force && !settingsStore.showCauldronFTValue) return;
-    if (network.value !== 'mainnet') return;
+    // the token list only shows token values on mainnet, so outside the portfolio
+    // there is nothing to fetch chipnet prices for
+    if (!force && network.value !== 'mainnet') return;
 
     const fungibleTokens = tokenList.value?.filter(token => 'amount' in token)
     if (fungibleTokens?.length === 0) return;
 
+    const initialization = currentInitialization;
     const ftTokenIds = fungibleTokens?.map(token => token.category) ?? [];
-    cauldronPrices.value = await fetchCauldronPrices(ftTokenIds);
+    const prices = await fetchCauldronPrices(ftTokenIds, network.value);
+    // prices are network specific, discard them when the wallet or network changed meanwhile
+    if (initialization !== currentInitialization) return;
+    cauldronPrices.value = prices;
   }
 
   // Periodically refetch exchange rate and Cauldron prices on separate intervals

--- a/src/utils/cauldronApi.ts
+++ b/src/utils/cauldronApi.ts
@@ -2,7 +2,12 @@ import { CauldronValueLockedSchema } from "./zodValidation";
 import { cachedFetch } from "./cacheUtils";
 import { useSettingsStore } from "src/stores/settingsStore";
 
-const MIN_LIQUIDITY_SATS = 100_000_000; // 1 BCH minimum
+// The chipnet indexer is not user-configurable, it is the only one serving chipnet
+const CAULDRON_INDEXER_CHIPNET = "https://indexer-chipnet.riften.net";
+// Minimum pool liquidity for a price to be used. Chipnet pools are orders of
+// magnitude smaller than mainnet ones, so mainnet's 1 BCH would reject them all
+const MIN_LIQUIDITY_SATS_MAINNET = 100_000_000; // 1 BCH
+const MIN_LIQUIDITY_SATS_CHIPNET = 1_000_000; // 0.01 tBCH
 const CAULDRON_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface CauldronPriceData {
@@ -13,10 +18,13 @@ export interface CauldronPriceData {
 
 // Fetch prices for multiple tokens
 export async function fetchCauldronPrices(
-  tokenIds: string[]
+  tokenIds: string[],
+  network: 'mainnet' | 'chipnet'
 ): Promise<Record<string, CauldronPriceData>> {
   const results: Record<string, CauldronPriceData> = {};
-  const indexerUrl = useSettingsStore().cauldronIndexer;
+  const isMainnet = network === 'mainnet';
+  const indexerUrl = isMainnet ? useSettingsStore().cauldronIndexer : CAULDRON_INDEXER_CHIPNET;
+  const minLiquiditySats = isMainnet ? MIN_LIQUIDITY_SATS_MAINNET : MIN_LIQUIDITY_SATS_CHIPNET;
 
   const fetchPromises = tokenIds.map(async (tokenId) => {
     try {
@@ -47,7 +55,7 @@ export async function fetchCauldronPrices(
       results[tokenId] = {
         satoshis: data.satoshis,
         tokenAmount: data.token_amount,
-        hasSufficientLiquidity: data.satoshis >= MIN_LIQUIDITY_SATS
+        hasSufficientLiquidity: data.satoshis >= minLiquiditySats
       };
     }
   }


### PR DESCRIPTION
The portfolio was mainnet only because Cauldron prices were never fetched on chipnet. Select the indexer per network and lower the pool liquidity gate on chipnet, where pools are orders of magnitude smaller than the 1 BCH mainnet minimum.

Values stay in the mainnet BCH price like on the wallet page, with the same t-prefix on the unit and currency names.