### PR TITLE
Wallet reactivity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Single-route SPA — views are switched via `store.displayView` in `WalletPage.v
 - **store.ts**: Main wallet state - `_wallet` (mutable ref), `wallet` (computed, throws if null), balance, UTXOs, token list, BCMR registries. Handles wallet initialization, network switching, transaction watching.
 - **settingsStore.ts**: User preferences persisted to localStorage - currency, dark mode, electrum servers, per-wallet backup status, auto-approve settings for WalletConnect.
 - **walletconnectStore.ts** / **cashconnectStore.ts**: dApp connection protocol handlers. Access the wallet via Pinia cross-store ref (`useStore()` inside `defineStore` setup).
+- `_wallet` is a `shallowRef`, so only swapping wallets is reactive, not changes inside the wallet object. Reactive code reading wallet internals depends on `walletUtxos` instead, which is why `store.walletHasAddress()` exists next to `store.wallet.hasAddress()`.
 
 ### Multi-Wallet Support
 - Wallets stored in IndexedDB via `@mainnet-cash/indexeddb-storage` (databases: "bitcoincash" for mainnet, "bchtest" for chipnet)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Single-route SPA — views are switched via `store.displayView` in `WalletPage.v
 - **store.ts**: Main wallet state - `_wallet` (mutable ref), `wallet` (computed, throws if null), balance, UTXOs, token list, BCMR registries. Handles wallet initialization, network switching, transaction watching.
 - **settingsStore.ts**: User preferences persisted to localStorage - currency, dark mode, electrum servers, per-wallet backup status, auto-approve settings for WalletConnect.
 - **walletconnectStore.ts** / **cashconnectStore.ts**: dApp connection protocol handlers. Access the wallet via Pinia cross-store ref (`useStore()` inside `defineStore` setup).
-- `_wallet` is a `shallowRef`, so only swapping wallets is reactive, not changes inside the wallet object. Reactive code reading wallet internals depends on `walletUtxos` instead, which is why `store.walletHasAddress()` exists next to `store.wallet.hasAddress()`.
+- `_wallet` is a `shallowRef`: mainnet-js owns the wallet's internal state, so only swapping wallets is reactive, not changes inside the wallet object. Reactive code reading wallet internals depends on `walletUtxos` instead, which is why `store.walletHasAddress()` exists next to `store.wallet.hasAddress()`.
 
 ### Multi-Wallet Support
 - Wallets stored in IndexedDB via `@mainnet-cash/indexeddb-storage` (databases: "bitcoincash" for mainnet, "bchtest" for chipnet)

--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -226,7 +226,7 @@
           <legend style="font-size: medium;">{{ t('transactionDialog.inputs') }}</legend>
           <div v-for="(input, index) in historyItem.inputs" :key="index" class="input" :class="settingsStore.darkMode ? 'dark' : ''">
             <span>{{ index }}: </span>
-            <span class="break" :class="store.wallet.hasAddress(input.address) ? 'thisWalletTag' : ''">{{ isCoinbase ? t('transactionDialog.coinbase') : input.address.split(":")[1] }}</span>
+            <span class="break" :class="store.walletHasAddress(input.address) ? 'thisWalletTag' : ''">{{ isCoinbase ? t('transactionDialog.coinbase') : input.address.split(":")[1] }}</span>
             <div style="margin-left: 25px;">
               <div v-if="input.value > 10_000">{{ satsToBch(input.value) }} {{ bchDisplayUnit }}</div>
               <span v-if="input.token" @click="loadTokenMetadata(input.token!.category, input.token?.nft?.commitment)" style="cursor: pointer;">
@@ -248,7 +248,7 @@
           <legend style="font-size: medium;">{{ t('transactionDialog.outputs') }}</legend>
           <div v-for="(output, index) in historyItem.outputs" :key="index" class="output" :class="settingsStore.darkMode ? 'dark' : ''">
             <span v-if="output.value === 0" class="break">{{ index }}: {{ output.address }}</span>
-            <span v-else>{{ index }}: <span class="break" :class="store.wallet.hasAddress(output.address) ? 'thisWalletTag' : ''">{{ output.address.split(":")[1] }}</span></span>
+            <span v-else>{{ index }}: <span class="break" :class="store.walletHasAddress(output.address) ? 'thisWalletTag' : ''">{{ output.address.split(":")[1] }}</span></span>
             <div style="margin-left: 25px;">
               <div v-if="output.value > 10_000">{{ satsToBch(output.value) }} {{ bchDisplayUnit }}</div>
               <span v-if="output.token" @click="loadTokenMetadata(output.token!.category, output.token?.nft?.commitment)" style="cursor: pointer;">

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -75,7 +75,7 @@
   });
 
   // Predicate for isDappInteraction, which is store-agnostic by design
-  const walletHasAddress = (address: string) => store.wallet.hasAddress(address);
+  const walletHasAddress = (address: string) => store.walletHasAddress(address);
 
   // Show confirmation progress toward the customary 6, after that a transaction
   // is considered final and the count is no longer interesting

--- a/src/components/walletconnect/WC2TransactionRequest.vue
+++ b/src/components/walletconnect/WC2TransactionRequest.vue
@@ -62,10 +62,10 @@
   }
 
   const bchSpentInputs:bigint = sourceOutputs.reduce((total:bigint, sourceOutput) =>
-    store.wallet.hasAddress(toCashaddr(sourceOutput.lockingBytecode)) ? total + sourceOutput.valueSatoshis : total, 0n
+    store.walletHasAddress(toCashaddr(sourceOutput.lockingBytecode)) ? total + sourceOutput.valueSatoshis : total, 0n
   );
   const bchReceivedOutputs:bigint = txDetails.outputs.reduce((total:bigint, outputs) =>
-    store.wallet.hasAddress(toCashaddr(outputs.lockingBytecode)) ? total + outputs.valueSatoshis : total, 0n
+    store.walletHasAddress(toCashaddr(outputs.lockingBytecode)) ? total + outputs.valueSatoshis : total, 0n
   );
   const bchBalanceChange = bchReceivedOutputs - bchSpentInputs;
   const currencyBalanceChange = convertToCurrency(bchBalanceChange, exchangeRate.value);
@@ -76,7 +76,7 @@
   const nftsReceived: NonNullable<Output['token']>[] = [];
 
   for (const input of sourceOutputs) {
-    const walletOrigin = store.wallet.hasAddress(toCashaddr(input.lockingBytecode));
+    const walletOrigin = store.walletHasAddress(toCashaddr(input.lockingBytecode));
     if(input.token && walletOrigin){
       const tokenCategory = binToHex(input.token.category);
       if(input.token.nft){
@@ -88,7 +88,7 @@
     }
   }
   for (const output of txDetails.outputs) {
-    const walletDestination = store.wallet.hasAddress(toCashaddr(output.lockingBytecode));
+    const walletDestination = store.walletHasAddress(toCashaddr(output.lockingBytecode));
     if(output.token && walletDestination) {
       const tokenCategory = binToHex(output.token.category);
       if(output.token.nft) {
@@ -256,7 +256,7 @@
                   <td>{{ inputIndex }}</td>
                   <td>
                     {{ toCashaddr(input.lockingBytecode).slice(0,25)  + '...' }}
-                    <span v-if="store.wallet.hasAddress(toCashaddr(input.lockingBytecode))" class="thisWalletTag">
+                    <span v-if="store.walletHasAddress(toCashaddr(input.lockingBytecode))" class="thisWalletTag">
                       {{ t('walletConnect.transactionRequest.thisWallet') }}
                     </span>
                   </td>
@@ -302,7 +302,7 @@
                   <td>{{ outputIndex }}</td>
                   <td>
                     {{ toCashaddr(output.lockingBytecode).slice(0,25)  + '...' }}
-                    <span v-if="store.wallet.hasAddress(toCashaddr(output.lockingBytecode))" class="thisWalletTag">
+                    <span v-if="store.walletHasAddress(toCashaddr(output.lockingBytecode))" class="thisWalletTag">
                       {{ t('walletConnect.transactionRequest.thisWallet') }}
                     </span>
                   </td>

--- a/src/stores/cashconnectStore.ts
+++ b/src/stores/cashconnectStore.ts
@@ -59,7 +59,7 @@ export const useCashconnectStore = defineStore("cashconnectStore", () => {
       return;
     }
     // Get the Private Key to use for CashConnect.
-    const cashConnectPrivateKey = getCashConnectPrivateKeyForWallet(mainStore.wallet as WalletType);
+    const cashConnectPrivateKey = getCashConnectPrivateKeyForWallet(mainStore.wallet);
     // Instantiate CashConnect.
     cashConnectWallet.value = new Wallet({
       cashConnectPrivateKey: cashConnectPrivateKey,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -150,6 +150,16 @@ export const useStore = defineStore('store', () => {
     return _wallet.value
   })
 
+  // Whether an address belongs to the wallet, for use in computed properties and templates.
+  // hasAddress reads the HD address cache, which sits outside Vue reactivity because _wallet is
+  // a shallowRef, so reading it alone would subscribe to nothing. walletUtxos is assigned right
+  // after every getUtxos() call, which is what advances that cache, so depending on it here
+  // re-runs callers once address discovery has moved on.
+  function walletHasAddress(address: string) {
+    void walletUtxos.value;
+    return wallet.value.hasAddress(address);
+  }
+
   const dappConnectionStoresInitDone = computed(() => isWcInitDone.value && isCcInitDone.value && isWizInitDone.value)
   const bcmrIndexer = computed(() => network.value == 'mainnet' ? defaultBcmrIndexer : defaultBcmrIndexerChipnet)
 
@@ -158,7 +168,8 @@ export const useStore = defineStore('store', () => {
   // discovery window is marked, which markAddressUsed refuses to bring about but another open
   // tab marking at the same time still can (see deriveFreshAddressIndex)
   const currentAddressIndex = computed(() => {
-    // walletUtxos updates when transactions arrive, re-deriving the index on address usage changes
+    // depositRawHistory and walletCache below sit outside Vue reactivity, walletUtxos is the
+    // signal that they advanced (see walletHasAddress)
     void walletUtxos.value;
     // marks are kept but ignored while the setting is off, so the wallet hands out the same
     // address it would have without the feature
@@ -1183,8 +1194,9 @@ export const useStore = defineStore('store', () => {
     activeWalletName,
     availableWallets,
     displayView,
-    _wallet, // the _wallet is the actual reactive wallet object but this can be null
+    _wallet, // the _wallet is the actual wallet object but this can be null
     wallet, // computed property to access the wallet, always non-null
+    walletHasAddress,
     balance,
     maxAmountToSend,
     walletUtxos,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -100,13 +100,11 @@ export const useStore = defineStore('store', () => {
   const activeWalletName = ref(localStorage.getItem('activeWalletName') ?? defaultWalletName);
   const availableWallets = ref([] as WalletInfo[]);
   // Wallet State
-  // _wallet holds the wallet object and is null until one is set, so it is the ref to write
-  // through, both to swap in another wallet and to change a property like the provider.
+  // _wallet holds the wallet object and is null until one is set.
   // The wallet's internals belong to mainnet-js: the library owns the key cache and the address
   // histories and mutates them behind its own references, including from callbacks holding the
-  // wallet from before it reached this store. Vue cannot track state it does not own, so a deep
-  // ref would only appear to work; a shallowRef states what is true, that swapping in another
-  // wallet is the reactive event and nothing inside it is.
+  // wallet from before it reached this store. Vue cannot track that, so only swapping in
+  // another wallet is reactive, nothing inside it is.
   const _wallet = shallowRef(null as (WalletType | null));
   const balance = ref(undefined as (bigint | undefined));
   const maxAmountToSend = ref(undefined as (bigint | undefined));
@@ -145,18 +143,18 @@ export const useStore = defineStore('store', () => {
   const explorerUrl = computed(() => network.value == "mainnet" ? settingsStore.explorerMainnet : settingsStore.explorerChipnet);
 
   // Access to the wallet without a null check at every call site: throws rather than hand out
-  // null. Read-only, and it hands out the same object _wallet holds, so writes go through
-  // _wallet whether they replace the wallet or set a property on it.
+  // null. Read-only, so replacing the wallet goes through _wallet.
   const wallet = computed(() => {
     if (!_wallet.value) throw new Error('No wallet set in global store');
     return _wallet.value
   })
 
   // Preferred over wallet.hasAddress in computed properties and templates: hasAddress reads the
-  // HD address cache, which mainnet-js owns and Vue therefore does not track. walletUtxos is
-  // the store's own signal that the cache advanced, since it is assigned right after every
-  // getUtxos() call, which is what grows it.
+  // HD address cache, which mainnet-js owns and Vue therefore does not track. Unlike a direct
+  // call, this one is tracked, so callers re-run when the cache advances.
   function walletHasAddress(address: string) {
+    // The read is the subscription, without it reactive callers never re-run. walletUtxos stands
+    // in for the cache because the store assigns it right after the getUtxos() calls that grow it.
     void walletUtxos.value;
     return wallet.value.hasAddress(address);
   }

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -100,12 +100,13 @@ export const useStore = defineStore('store', () => {
   const activeWalletName = ref(localStorage.getItem('activeWalletName') ?? defaultWalletName);
   const availableWallets = ref([] as WalletInfo[]);
   // Wallet State
-  // _wallet is the actual wallet object and is null until the wallet is set
-  // so _wallet is used for mutating properties of the wallet, like changing the provider.
-  // A shallowRef because only swapping in another wallet drives the UI. Deep reactivity would
-  // proxy the key cache and the address histories, yet mainnet-js mutates those from callbacks
-  // holding the unproxied wallet, so it would fire only part of the time. Code that reacts to
-  // wallet-internal changes depends on walletUtxos instead.
+  // _wallet holds the wallet object and is null until one is set, so it is the ref to write
+  // through, both to swap in another wallet and to change a property like the provider.
+  // The wallet's internals belong to mainnet-js: the library owns the key cache and the address
+  // histories and mutates them behind its own references, including from callbacks holding the
+  // wallet from before it reached this store. Vue cannot track state it does not own, so a deep
+  // ref would only appear to work; a shallowRef states what is true, that swapping in another
+  // wallet is the reactive event and nothing inside it is.
   const _wallet = shallowRef(null as (WalletType | null));
   const balance = ref(undefined as (bigint | undefined));
   const maxAmountToSend = ref(undefined as (bigint | undefined));
@@ -143,18 +144,18 @@ export const useStore = defineStore('store', () => {
   const network = computed(() => wallet.value.network == NetworkType.Mainnet ? "mainnet" : "chipnet")
   const explorerUrl = computed(() => network.value == "mainnet" ? settingsStore.explorerMainnet : settingsStore.explorerChipnet);
 
-  // The wallet computed property, throws if it were to be accessed when _wallet is null
-  // The computed property should not be mutated, use _wallet instead
+  // Access to the wallet without a null check at every call site: throws rather than hand out
+  // null. Read-only, and it hands out the same object _wallet holds, so writes go through
+  // _wallet whether they replace the wallet or set a property on it.
   const wallet = computed(() => {
     if (!_wallet.value) throw new Error('No wallet set in global store');
     return _wallet.value
   })
 
-  // Whether an address belongs to the wallet, for use in computed properties and templates.
-  // hasAddress reads the HD address cache, which sits outside Vue reactivity because _wallet is
-  // a shallowRef, so reading it alone would subscribe to nothing. walletUtxos is assigned right
-  // after every getUtxos() call, which is what advances that cache, so depending on it here
-  // re-runs callers once address discovery has moved on.
+  // Preferred over wallet.hasAddress in computed properties and templates: hasAddress reads the
+  // HD address cache, which mainnet-js owns and Vue therefore does not track. walletUtxos is
+  // the store's own signal that the cache advanced, since it is assigned right after every
+  // getUtxos() call, which is what grows it.
   function walletHasAddress(address: string) {
     void walletUtxos.value;
     return wallet.value.hasAddress(address);

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -230,7 +230,8 @@ export const useStore = defineStore('store', () => {
   let cancelWatchBchBalanceCashConnect: undefined | CancelFn;
 
   // Counter to detect stale async operations after network/wallet switches.
-  // Bumped at the start of initializeWallet(); checked after long awaits.
+  // Bumped whenever the state those operations write into is discarded, so at the start of
+  // initializeWallet() and in resetWalletState(); checked after long awaits.
   let currentInitialization = 0;
 
   // Lets the 'online' event listener retry an initialization aborted while offline
@@ -649,9 +650,28 @@ export const useStore = defineStore('store', () => {
   }
 
   async function resetWalletState({ resetDappConnections = true } = {}){
+    // Bump the initialization counter before anything else, so the fetches already in flight
+    // become no-ops. Without it, a reply arriving late from the old wallet or server would
+    // repopulate the state cleared below.
+    currentInitialization++;
     viewStack.length = 0;
     walletInitialized.value = false;
     walletInitFailed.value = false;
+
+    // Stop the intervals and clear the state before the awaits below, so the views do not go on
+    // showing the old wallet's balance and history for as long as cancelling takes.
+    stopRefetchIntervals();
+    balance.value = undefined;
+    maxAmountToSend.value = undefined;
+    plannedTokenId.value = undefined;
+    tokenList.value = null;
+    bcmrRegistries.value = undefined;
+    queriedHistoryCategories = [];
+    cauldronPrices.value = null;
+    cauldronPools.value = null;
+    exchangeRate.value = undefined;
+    walletHistory.value = undefined;
+    isHistoryPartial.value = false;
 
     if (resetDappConnections) {
       // Reset WC/CC/Wiz init-done flags so re-initialization runs after reset
@@ -666,21 +686,8 @@ export const useStore = defineStore('store', () => {
       networkChangeCallbacks = [];
     }
 
-    // cancel active listeners and intervals
-    stopRefetchIntervals();
+    // cancel active listeners
     await cancelWalletSubscriptions();
-    // reset wallet to default state
-    balance.value = undefined;
-    maxAmountToSend.value = undefined;
-    plannedTokenId.value = undefined;
-    tokenList.value = null;
-    bcmrRegistries.value = undefined;
-    queriedHistoryCategories = [];
-    cauldronPrices.value = null;
-    cauldronPools.value = null;
-    exchangeRate.value = undefined;
-    walletHistory.value = undefined;
-    isHistoryPartial.value = false;
   }
 
   // Avoid WalletClass.named() here: it creates a fresh random wallet if the name is missing.
@@ -973,7 +980,11 @@ export const useStore = defineStore('store', () => {
   // mainnet-js has its own ~4 min TTL cache but we store the rate centrally for reactive access
   async function fetchExchangeRate() {
     try {
-      exchangeRate.value = await ExchangeRate.get(settingsStore.currency, true);
+      const initialization = currentInitialization;
+      const rate = await ExchangeRate.get(settingsStore.currency, true);
+      // a rate arriving after a wallet or network switch belongs to the state that was reset
+      if (initialization !== currentInitialization) return;
+      exchangeRate.value = rate;
     } catch (error) {
       console.error("Failed to fetch exchange rate:", error);
     }

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -661,6 +661,7 @@ export const useStore = defineStore('store', () => {
     stopRefetchIntervals();
     balance.value = undefined;
     maxAmountToSend.value = undefined;
+    walletUtxos.value = undefined;
     plannedTokenId.value = undefined;
     tokenList.value = null;
     bcmrRegistries.value = undefined;
@@ -979,9 +980,11 @@ export const useStore = defineStore('store', () => {
   async function fetchExchangeRate() {
     try {
       const initialization = currentInitialization;
-      const rate = await ExchangeRate.get(settingsStore.currency, true);
-      // a rate arriving after a wallet or network switch belongs to the state that was reset
-      if (initialization !== currentInitialization) return;
+      const currency = settingsStore.currency;
+      const rate = await ExchangeRate.get(currency, true);
+      // discard a rate that no longer belongs: the state may have been reset, or the user may
+      // have switched currency, which starts a second fetch that can resolve before this one
+      if (initialization !== currentInitialization || currency !== settingsStore.currency) return;
       exchangeRate.value = rate;
     } catch (error) {
       console.error("Failed to fetch exchange rate:", error);

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia"
-import { ref, reactive, computed, watch } from 'vue'
+import { ref, shallowRef, reactive, computed, watch } from 'vue'
 import {
   HDWallet,
   TestNetHDWallet,
@@ -100,9 +100,13 @@ export const useStore = defineStore('store', () => {
   const activeWalletName = ref(localStorage.getItem('activeWalletName') ?? defaultWalletName);
   const availableWallets = ref([] as WalletInfo[]);
   // Wallet State
-  // _wallet is the actual reactive wallet object and is null until the wallet is set
-  // so _wallet is used for mutating properties of the wallet, like changing the provider
-  const _wallet = ref(null as (WalletType | null));
+  // _wallet is the actual wallet object and is null until the wallet is set
+  // so _wallet is used for mutating properties of the wallet, like changing the provider.
+  // A shallowRef because only swapping in another wallet drives the UI. Deep reactivity would
+  // proxy the key cache and the address histories, yet mainnet-js mutates those from callbacks
+  // holding the unproxied wallet, so it would fire only part of the time. Code that reacts to
+  // wallet-internal changes depends on walletUtxos instead.
+  const _wallet = shallowRef(null as (WalletType | null));
   const balance = ref(undefined as (bigint | undefined));
   const maxAmountToSend = ref(undefined as (bigint | undefined));
   const walletUtxos = ref(undefined as (Utxo[] | undefined));

--- a/src/stores/walletconnectStore.ts
+++ b/src/stores/walletconnectStore.ts
@@ -4,7 +4,6 @@ import { Core } from '@walletconnect/core'
 import { WalletKit, type WalletKitTypes, type IWalletKit } from '@reown/walletkit'
 import type { SessionTypes } from '@walletconnect/types'
 import { convert, NetworkType, HDWallet } from "mainnet-js";
-import type { WalletType } from "src/interfaces/interfaces";
 import { useStore } from "./store"
 import {
   hexToBin,
@@ -278,8 +277,7 @@ export const useWalletconnectStore = defineStore("walletconnectStore", () => {
   // Branches on the wallet object itself (not wallet-type metadata) so a
   // desync during wallet switching can never yield mismatched key material.
   function getSessionSigningInfo(topic: string) {
-    // cast undoes Pinia's ref-unwrapping of the class union; instanceof below does the real check
-    const wallet = mainStore.wallet as WalletType;
+    const wallet = mainStore.wallet;
     if (wallet instanceof HDWallet) {
       const sessionAddress = getSessionAddress(topic);
       if (!sessionAddress) throw new Error(t('walletConnect.errors.noAddressForSession'));

--- a/src/stores/wizardconnectStore.ts
+++ b/src/stores/wizardconnectStore.ts
@@ -27,7 +27,7 @@ import {
   type HdPrivateNodeValid,
 } from "@bitauth/libauth";
 import type { WcSignTransactionRequest } from "@bch-wc2/interfaces";
-import type { WalletType, DappMetadata } from "src/interfaces/interfaces";
+import type { DappMetadata } from "src/interfaces/interfaces";
 import { useStore } from "./store";
 import { useSettingsStore } from "./settingsStore";
 import { walletConnectMetadata } from "./constants";
@@ -85,8 +85,7 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
     // Make sure we don't start more than once, otherwise we'd register multiple
     // handlers and end up with multiple dialogs.
     if (manager) return;
-    // cast undoes Pinia's ref-unwrapping of the class union; instanceof below does the real check
-    const wallet = mainStore.wallet as WalletType;
+    const wallet = mainStore.wallet;
     // WizardConnect shares chain-level xpubs so dapps can derive addresses, which requires
     // an HD wallet. For single-address wallets the manager stays undefined and pairing
     // attempts get a clear error in pair().
@@ -143,8 +142,7 @@ export const useWizardconnectStore = defineStore("wizardconnectStore", () => {
 
   async function pair(wizUri: string) {
     if (!manager) {
-      const wallet = mainStore.wallet as WalletType;
-      if (!(wallet instanceof HDWallet)) throw new Error(t('wizardConnect.errors.hdWalletRequired'));
+      if (!(mainStore.wallet instanceof HDWallet)) throw new Error(t('wizardConnect.errors.hdWalletRequired'));
       throw new Error(t('wizardConnect.errors.notInitialized'));
     }
     const trimmedUri = wizUri.trim();

--- a/src/utils/cauldronPools.ts
+++ b/src/utils/cauldronPools.ts
@@ -20,13 +20,7 @@ import {
   deriveHdPublicNode,
   deriveHdPublicNodeChild,
 } from "@bitauth/libauth";
-import type { Utxo } from "mainnet-js";
-
-// The wallet's provider reaches this through a reactive store ref, which strips the private
-// members off the ElectrumNetworkProvider class type, so it is matched structurally instead
-interface ElectrumProvider {
-  getUtxos(cashaddr: string): Promise<Utxo[]>;
-}
+import type { ElectrumNetworkProvider } from "mainnet-js";
 
 // Pool lookups are pipelined over the same electrum connection in batches
 const LOOKUP_BATCH_SIZE = 10;
@@ -93,7 +87,7 @@ export function publicKeyHashFromAddress(address: string): string | undefined {
 // Cauldron indexer answers the same question from an owner public key hash, but that would hand
 // the wallet's list of addresses to a third party.
 export async function fetchCauldronPools(
-  provider: ElectrumProvider,
+  provider: ElectrumNetworkProvider,
   ownerPkhs: string[],
   networkPrefix: string
 ): Promise<CauldronPool[]> {

--- a/test/store.race.test.ts
+++ b/test/store.race.test.ts
@@ -76,6 +76,32 @@ describe('network switch race conditions', () => {
     expect(store.walletUtxos).toEqual(freshUtxos)
   })
 
+  it('ignores stale getUtxos result after resetWalletState', async () => {
+    const staleUtxosDeferred = createDeferred<unknown[]>()
+    const wallet = createMockWallet()
+    wallet.getUtxos.mockImplementation(() => staleUtxosDeferred.promise)
+
+    const store = useStore()
+    store.setWallet(wallet as never)
+
+    // First init blocks at getUtxos
+    const oldInit = store.initializeWallet()
+    await flushAsyncWork()
+
+    // Resetting bumps the epoch as well, so the init still in flight is stale from here on.
+    // Without that bump the late result below lands after the reset cleared the state.
+    await store.resetWalletState({ resetDappConnections: false })
+
+    expect(store.walletUtxos).toBeUndefined()
+
+    // Old deferred resolves late — should be ignored
+    staleUtxosDeferred.resolve([{ satoshis: 1111n }])
+    await oldInit
+    await flushAsyncWork()
+
+    expect(store.walletUtxos).toBeUndefined()
+  })
+
   it('ignores stale getHistory result after re-initialization', async () => {
     const staleHistoryDeferred = createDeferred<unknown[]>()
     const wallet = createMockWallet()


### PR DESCRIPTION
> ## Hold the wallet outside Vue's deep reactivity
> 
> ### Why
> 
> `_wallet` was a deep `ref()`, so Vue proxied the entire mainnet-js wallet: the key cache, the address histories, the provider and the electrum client.
> 
> That never worked properly. mainnet-js owns that state and mutates it behind its own references, including from electrum callbacks that captured the wallet before it ever reached the store. Vue's docs say to *"work exclusively with the reactive proxy and avoid relying on the original object"*, which a third-party library holding its own reference cannot do. Wallet-internal changes therefore reached the UI only part of the time, depending on which reference mainnet-js happened to use.
> 
> `shallowRef` is the primitive Vue documents for exactly this case (*"integration with external state management systems"*). Swapping in another wallet stays reactive, which is the only wallet change the UI is actually driven by.
> 
> ### What changed
> 
> - **`_wallet` is a `shallowRef`.** This also removes four casts and one structural interface that existed only to undo what the proxy did to the wallet's type, across `cauldronPools.ts`, `walletconnectStore`, `wizardconnectStore` and `cashconnectStore`.
> - **New `store.walletHasAddress()`.** `hasAddress` reads the HD address cache, so callers in computed properties and templates need an explicit dependency on `walletUtxos` (assigned right after every `getUtxos()`, which is what advances that cache). Two sites already did this by hand, three did not. The dependency is now declared once at the store boundary instead of being a convention every call site has to remember.
> - **Comments and one CLAUDE.md line** recording that mainnet-js owns the wallet's internal state, since that is what decides the reactivity primitive.
> 
> ### Behaviour
> 
> Display only: the "this wallet" tags on transaction inputs and outputs, which went from updating unreliably to updating on a declared dependency.
> 
> Not changed: the balance-change summary in the WC2 sign dialog is computed once at setup and always was, so it stays frozen at the moment the request is presented.
> 
> ### Testing
> 
> `vue-tsc`, lint and 259 tests pass. A manual pass is still worth doing, since a stale UI here fails silently rather than throwing:
> 
> - switch wallets, single ↔ HD and mainnet ↔ chipnet
> - change the electrum server in settings (the one place a deep write stops triggering)
> - HD addresses view updating as a transaction arrives
> - "this wallet" tags in a WC2 sign dialog and a transaction dialog
