### PR TITLE
prefill a suggested wallet name in the add-wallet flow

### DIFF
--- a/src/components/settings/addWallet.vue
+++ b/src/components/settings/addWallet.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-  import { ref, computed } from "vue"
+  import { ref, computed, onMounted } from "vue"
   import { useQuasar } from 'quasar'
   import { useStore } from 'src/stores/store'
   import { namedWalletExistsInDb } from 'src/utils/dbUtils'
-  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet } from 'src/utils/walletUtils'
+  import { createNewWallet as createWallet, importWallet as importWalletUtil, createNewHDWallet, importHDWallet, suggestNextWalletName } from 'src/utils/walletUtils'
   import type { DerivationPathType } from 'src/utils/walletUtils'
   import seedPhraseInput from '../general/seedPhraseInput.vue'
   import derivationPathSelect from '../general/derivationPathSelect.vue'
@@ -21,6 +21,17 @@
   const walletType = ref<'single' | 'hd'>('single');
 
   const effectiveWalletName = computed(() => walletName.value.trim());
+
+  // Prefill a suggested name like "wallet 2" so users don't have to invent one
+  onMounted(async () => {
+    const suggestedName = await suggestNextWalletName();
+    if (!walletName.value) walletName.value = suggestedName;
+  });
+
+  // Let users replace the prefilled name by just starting to type
+  function selectNameOnFocus(event: Event) {
+    (event.target as HTMLInputElement).select();
+  }
 
   async function proceedToStep2() {
     const name = walletName.value.trim();
@@ -112,7 +123,11 @@
           id="walletName"
           :placeholder="t('addWallet.walletName.placeholder')"
           style="width: 100%; max-width: 300px; padding: 8px;"
+          @focus="selectNameOnFocus"
         >
+        <div style="font-size: smaller; color: grey; margin-top: 5px;">
+          {{ t('onboarding.walletName.tip') }}
+        </div>
       </div>
       <input
         @click="proceedToStep2()"

--- a/src/components/walletOnboarding.vue
+++ b/src/components/walletOnboarding.vue
@@ -51,6 +51,11 @@
     step.value = 1;
   }
 
+  // Let users replace the prefilled name by just starting to type
+  function selectNameOnFocus(event: Event) {
+    (event.target as HTMLInputElement).select();
+  }
+
   // Defensive: block concurrent create/import (double-click, key auto-repeat) — a second
   // concurrent call could race the async existence check and generate a second seed
   const isCreating = ref(false);
@@ -193,7 +198,11 @@
             type="text"
             :placeholder="t('onboarding.walletName.placeholder')"
             style="padding: 8px; min-width: 200px;"
+            @focus="selectNameOnFocus"
           >
+          <div style="font-size: smaller; color: grey; margin-top: 5px;">
+            {{ t('onboarding.walletName.tip') }}
+          </div>
         </div>
         <div style="margin: 15px 0;">
           <label style="display: block; margin-bottom: 8px;">{{ t('onboarding.walletType.label') }}</label>
@@ -222,7 +231,11 @@
             type="text"
             :placeholder="t('onboarding.walletName.placeholder')"
             style="padding: 8px; min-width: 200px;"
+            @focus="selectNameOnFocus"
           >
+          <div style="font-size: smaller; color: grey; margin-top: 5px;">
+            {{ t('onboarding.walletName.tip') }}
+          </div>
         </div>
         <div style="margin: 20px 0;">
           <seedPhraseInput v-model="seedPhrase" v-model:isValid="seedPhraseValid" />

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -103,7 +103,8 @@
     },
     "walletName": {
       "label": "Wallet-Name:",
-      "placeholder": "Wallet-Name eingeben"
+      "placeholder": "Wallet-Name eingeben",
+      "tip": "Tipp: Benenne die Wallet nach ihrem Verwendungszweck, z. B. \"Ersparnisse\" oder \"Trading\""
     },
     "walletType": {
       "label": "Wallet-Typ:",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -103,7 +103,8 @@
     },
     "walletName": {
       "label": "Wallet name:",
-      "placeholder": "Enter wallet name"
+      "placeholder": "Enter wallet name",
+      "tip": "Tip: name the wallet after what you'll use it for, like \"savings\" or \"trading\""
     },
     "walletType": {
       "label": "Wallet type:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -103,7 +103,8 @@
     },
     "walletName": {
       "label": "Nombre de billetera:",
-      "placeholder": "Ingresa el nombre de la billetera"
+      "placeholder": "Ingresa el nombre de la billetera",
+      "tip": "Consejo: nombra la billetera según el uso que le darás, como \"ahorros\" o \"trading\""
     },
     "walletType": {
       "label": "Tipo de billetera:",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -103,7 +103,8 @@
     },
     "walletName": {
       "label": "Nom du portefeuille :",
-      "placeholder": "Entrez le nom du portefeuille"
+      "placeholder": "Entrez le nom du portefeuille",
+      "tip": "Astuce : nommez le portefeuille selon l'usage prévu, comme « épargne » ou « trading »"
     },
     "walletType": {
       "label": "Type de portefeuille :",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -103,7 +103,8 @@
     },
     "walletName": {
       "label": "Nome da carteira:",
-      "placeholder": "Insira o nome da carteira"
+      "placeholder": "Insira o nome da carteira",
+      "tip": "Dica: nomeie a carteira de acordo com o uso pretendido, como \"poupança\" ou \"trading\""
     },
     "walletType": {
       "label": "Tipo de carteira:",

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -1,7 +1,7 @@
 import { Wallet, TestNetWallet, HDWallet, TestNetHDWallet, Config } from "mainnet-js"
 import { useStore } from 'src/stores/store'
 import { useSettingsStore } from 'src/stores/settingsStore'
-import { namedWalletExistsInDb } from 'src/utils/dbUtils'
+import { namedWalletExistsInDb, getAllWalletsWithNetworkInfo } from 'src/utils/dbUtils'
 import { isQuotaExceededError } from 'src/utils/errorHandling'
 import { isValidBip39Mnemonic, normalizeSeedPhrase } from 'src/utils/utils'
 import { i18n } from 'src/boot/i18n'
@@ -128,6 +128,22 @@ export function validateWalletName(name: string): WalletError | null {
     return makeError(t('walletUtils.errors.walletNameInvalidChars'), true);
   }
   return null;
+}
+
+// Suggest a name for the user's next wallet, continuing the "wallet <number>" convention.
+// Counts past the highest number in use instead of filling gaps, so a deleted wallet's
+// name (and any leftover localStorage data keyed on it) is never reused.
+export async function suggestNextWalletName(): Promise<string> {
+  const existingWallets = await getAllWalletsWithNetworkInfo();
+  let highestNumber = 0;
+  for (const walletInfo of existingWallets) {
+    const match = walletInfo.name.match(/^wallet (\d+)$/);
+    if (match) highestNumber = Math.max(highestNumber, Number(match[1]));
+  }
+  // No numbered names yet (e.g. only "mywallet"): number by wallet count, so the
+  // second wallet is suggested as "wallet 2"
+  const nextNumber = highestNumber ? highestNumber + 1 : existingWallets.length + 1;
+  return `wallet ${nextNumber}`;
 }
 
 /**


### PR DESCRIPTION
Suggest "wallet <n>" by continuing past the highest number in use, so a deleted wallet's name (and any leftover localStorage data keyed on it) is never reused. Also add a naming tip under the name inputs and select the prefilled name on focus so typing replaces it.