### PR TITLE
add an export xpub page to the wallet tools

### DIFF
--- a/src/components/settings/exportXpub.vue
+++ b/src/components/settings/exportXpub.vue
@@ -4,6 +4,7 @@
   import { useStore } from 'src/stores/store'
   import { useI18n } from 'vue-i18n'
   import { copyToClipboard } from 'src/utils/utils'
+  import InfoPopup from 'src/components/general/InfoPopup.vue'
 
   const store = useStore()
   const { t } = useI18n()
@@ -25,7 +26,13 @@
   <fieldset class="item" style="padding-bottom: 20px;">
     <legend>{{ t('exportXpub.title') }}</legend>
 
-    <div>{{ t('exportXpub.description') }}</div>
+    <div>
+      {{ t('exportXpub.description') }}
+      <InfoPopup>
+        <div style="max-width: 300px;">{{ t('exportXpub.usageHint') }}</div>
+        <div class="info-popup-note" style="max-width: 300px;">{{ t('exportXpub.usageHintNote') }}</div>
+      </InfoPopup>
+    </div>
 
     <div style="margin-top: 15px; color: orange;">
       {{ t('exportXpub.privacyWarning') }}
@@ -38,7 +45,7 @@
       <div style="margin-bottom: 15px;">
         {{ t('exportXpub.derivationPath') }} <span style="font-family: monospace;">{{ derivationPath }}</span>
       </div>
-      <div class="qr-frame" style="margin-bottom: 15px;">
+      <div class="qr-frame" style="margin: 0 auto 15px;">
         <qr-code :contents="xpub" class="qr-code" @click="copyToClipboard(xpub)"></qr-code>
       </div>
       <div class="xpub-result" @click="copyToClipboard(xpub)">{{ xpub }}</div>

--- a/src/components/settings/exportXpub.vue
+++ b/src/components/settings/exportXpub.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+  import { ref, computed, watch } from 'vue'
+  import { HDWallet } from 'mainnet-js'
+  import { useStore } from 'src/stores/store'
+  import { useI18n } from 'vue-i18n'
+  import { copyToClipboard } from 'src/utils/utils'
+
+  const store = useStore()
+  const { t } = useI18n()
+
+  const revealed = ref(false);
+
+  // wallet can briefly be non-HD mid wallet-switch, the KeepAlive-cached view guards itself
+  const hdWallet = computed(() => store._wallet instanceof HDWallet ? store._wallet : undefined);
+  const xpub = computed(() => hdWallet.value?.xPub);
+  const derivationPath = computed(() => hdWallet.value?.derivation);
+
+  // Hide the xpub again when the user switches wallets or networks
+  watch(() => store._wallet, () => {
+    revealed.value = false;
+  });
+</script>
+
+<template>
+  <fieldset class="item" style="padding-bottom: 20px;">
+    <legend>{{ t('exportXpub.title') }}</legend>
+
+    <div>{{ t('exportXpub.description') }}</div>
+
+    <div style="margin-top: 15px; color: orange;">
+      {{ t('exportXpub.privacyWarning') }}
+    </div>
+
+    <div v-if="!revealed" style="margin-top: 15px;">
+      <input @click="revealed = true" type="button" class="primaryButton" :value="t('exportXpub.revealButton')">
+    </div>
+    <div v-else-if="xpub" style="margin-top: 15px;">
+      <div style="margin-bottom: 15px;">
+        {{ t('exportXpub.derivationPath') }} <span style="font-family: monospace;">{{ derivationPath }}</span>
+      </div>
+      <div class="qr-frame" style="margin-bottom: 15px;">
+        <qr-code :contents="xpub" class="qr-code" @click="copyToClipboard(xpub)"></qr-code>
+      </div>
+      <div class="xpub-result" @click="copyToClipboard(xpub)">{{ xpub }}</div>
+      <div class="xpub-button-row">
+        <input @click="copyToClipboard(xpub)" type="button" class="button" :value="t('exportXpub.copyButton')">
+        <input @click="revealed = false" type="button" class="button" :value="t('exportXpub.hideButton')">
+      </div>
+      <div style="font-size: smaller; color: grey; margin-top: 8px;">
+        {{ t('exportXpub.safetyHint') }}
+      </div>
+    </div>
+  </fieldset>
+</template>
+
+<style scoped>
+.xpub-result {
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background-color: rgba(128, 128, 128, 0.06);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: monospace;
+  word-break: break-all;
+  cursor: pointer;
+}
+.xpub-button-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/components/settings/walletTools.vue
+++ b/src/components/settings/walletTools.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
   import { computed } from 'vue'
   import { useStore } from 'src/stores/store'
+  import { useSettingsStore } from 'src/stores/settingsStore'
   import { useI18n } from 'vue-i18n'
   const store = useStore()
+  const settingsStore = useSettingsStore()
   const { t } = useI18n()
 
   // Highlights token utxos holding significant bch, same check as the settings menu entry
@@ -25,6 +27,10 @@
 
     <div style="margin-bottom: 15px; cursor: pointer;" @click="() => store.changeView(13)">
       → {{ t('settings.menu.signVerifyMessage') }}
+    </div>
+
+    <div v-if="settingsStore.getWalletType(store.activeWalletName) === 'hd'" style="margin-bottom: 15px; cursor: pointer;" @click="() => store.changeView(15)">
+      → {{ t('settings.menu.exportXpub') }}
     </div>
   </fieldset>
 </template>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -760,6 +760,16 @@
       "notChipnetWif": "Kein QR-Code, der einen Chipnet-Privatschlüssel im WIF-Format enthält"
     }
   },
+  "exportXpub": {
+    "title": "Xpub exportieren",
+    "description": "Ein Xpub erlaubt einer anderen App, dieses Wallet zu beobachten: Guthaben und gesamten Verlauf sehen und neue Empfangsadressen erzeugen, ohne ausgeben zu können. Nützlich für einen Portfolio-Tracker oder eine Watch-Only-Kopie auf einem anderen Gerät.",
+    "privacyWarning": "Wer dein Xpub hat, kann alle Adressen und Transaktionen dieses Wallets sehen, vergangene und zukünftige. Das Teilen lässt sich nicht rückgängig machen. Teile es nur mit Diensten, denen du deinen gesamten Finanzverlauf anvertraust.",
+    "revealButton": "Xpub anzeigen",
+    "hideButton": "Verbergen",
+    "derivationPath": "Ableitungspfad:",
+    "copyButton": "Xpub kopieren",
+    "safetyHint": "Ein Watch-Only-Wallet aus diesem Xpub kann dein Guthaben nicht ausgeben."
+  },
   "signVerifyMessage": {
     "title": "Nachricht signieren / verifizieren",
     "descriptionSign": "Signiere eine Nachricht mit einer Adresse deines Wallets, um zu beweisen, dass du sie kontrollierst.",
@@ -1013,6 +1023,7 @@
       "utxoManagement": "UTXO-Verwaltung",
       "sweepPrivateKey": "Privaten Schlüssel sweepen",
       "signVerifyMessage": "Nachricht signieren / verifizieren",
+      "exportXpub": "Xpub exportieren",
       "tokenCreationPage": "Token-Erstellungsseite",
       "aboutCashonize": "Über Cashonize"
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -762,7 +762,9 @@
   },
   "exportXpub": {
     "title": "Xpub exportieren",
-    "description": "Ein Xpub erlaubt einer anderen App, dieses Wallet zu beobachten: Guthaben und gesamten Verlauf sehen und neue Empfangsadressen erzeugen, ohne ausgeben zu können. Nützlich für einen Portfolio-Tracker oder eine Watch-Only-Kopie auf einem anderen Gerät.",
+    "description": "Ein Xpub erlaubt einer anderen App, dieses Wallet zu beobachten, ohne ausgeben zu können.",
+    "usageHint": "Eine beobachtende App kann Guthaben und gesamten Verlauf des Wallets sehen und neue Empfangsadressen erzeugen. Nützlich für einen Portfolio-Tracker oder eine Watch-Only-Kopie auf einem anderen Gerät.",
+    "usageHintNote": "Das Verbinden einer App über WizardConnect teilt bereits Xpubs mit ihr im Hintergrund.",
     "privacyWarning": "Wer dein Xpub hat, kann alle Adressen und Transaktionen dieses Wallets sehen, vergangene und zukünftige. Das Teilen lässt sich nicht rückgängig machen. Teile es nur mit Diensten, denen du deinen gesamten Finanzverlauf anvertraust.",
     "revealButton": "Xpub anzeigen",
     "hideButton": "Verbergen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -762,7 +762,9 @@
   },
   "exportXpub": {
     "title": "Export Xpub",
-    "description": "An xpub lets another app watch this wallet: see its balance and full history and generate new receive addresses, without being able to spend. Useful for a portfolio tracker or a watch-only copy on another device.",
+    "description": "An xpub lets another app watch this wallet, without being able to spend.",
+    "usageHint": "A watching app can see the wallet's balance and full history and generate new receive addresses. Useful for a portfolio tracker or a watch-only copy on another device.",
+    "usageHintNote": "Connecting an app over WizardConnect already shares xpubs with it in the background.",
     "privacyWarning": "Whoever has your xpub can see all of this wallet's addresses and transactions, past and future. Sharing it cannot be undone. Only share it with services you trust with your full financial history.",
     "revealButton": "Reveal Xpub",
     "hideButton": "Hide",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -760,6 +760,16 @@
       "notChipnetWif": "Not a QR code encoding a Chipnet Private Key in WIF format"
     }
   },
+  "exportXpub": {
+    "title": "Export Xpub",
+    "description": "An xpub lets another app watch this wallet: see its balance and full history and generate new receive addresses, without being able to spend. Useful for a portfolio tracker or a watch-only copy on another device.",
+    "privacyWarning": "Whoever has your xpub can see all of this wallet's addresses and transactions, past and future. Sharing it cannot be undone. Only share it with services you trust with your full financial history.",
+    "revealButton": "Reveal Xpub",
+    "hideButton": "Hide",
+    "derivationPath": "Derivation path:",
+    "copyButton": "Copy Xpub",
+    "safetyHint": "A watch-only wallet made from this xpub cannot spend your funds."
+  },
   "signVerifyMessage": {
     "title": "Sign / Verify Message",
     "descriptionSign": "Sign a message with an address of your wallet to prove you control it.",
@@ -1013,6 +1023,7 @@
       "utxoManagement": "UTXO Management",
       "sweepPrivateKey": "Sweep Private Key",
       "signVerifyMessage": "Sign / Verify Message",
+      "exportXpub": "Export Xpub",
       "tokenCreationPage": "Token Creation Page",
       "aboutCashonize": "About Cashonize"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -760,6 +760,16 @@
       "notChipnetWif": "No es un código QR que codifica una clave privada de Chipnet en formato WIF"
     }
   },
+  "exportXpub": {
+    "title": "Exportar Xpub",
+    "description": "Un xpub permite que otra aplicación observe esta billetera: ver su saldo y todo su historial y generar nuevas direcciones de recepción, sin poder gastar. Útil para un rastreador de portafolio o una copia de solo lectura en otro dispositivo.",
+    "privacyWarning": "Quien tenga tu xpub puede ver todas las direcciones y transacciones de esta billetera, pasadas y futuras. Compartirlo no se puede deshacer. Compártelo solo con servicios a los que confíes todo tu historial financiero.",
+    "revealButton": "Revelar Xpub",
+    "hideButton": "Ocultar",
+    "derivationPath": "Ruta de derivación:",
+    "copyButton": "Copiar Xpub",
+    "safetyHint": "Una billetera de solo lectura creada con este xpub no puede gastar tus fondos."
+  },
   "signVerifyMessage": {
     "title": "Firmar / Verificar mensaje",
     "descriptionSign": "Firma un mensaje con una dirección de tu billetera para demostrar que la controlas.",
@@ -1013,6 +1023,7 @@
       "utxoManagement": "Gestión de UTXO",
       "sweepPrivateKey": "Barrer clave privada",
       "signVerifyMessage": "Firmar / Verificar mensaje",
+      "exportXpub": "Exportar Xpub",
       "tokenCreationPage": "Página de creación de tokens",
       "aboutCashonize": "Acerca de Cashonize"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -762,7 +762,9 @@
   },
   "exportXpub": {
     "title": "Exportar Xpub",
-    "description": "Un xpub permite que otra aplicación observe esta billetera: ver su saldo y todo su historial y generar nuevas direcciones de recepción, sin poder gastar. Útil para un rastreador de portafolio o una copia de solo lectura en otro dispositivo.",
+    "description": "Un xpub permite que otra aplicación observe esta billetera, sin poder gastar.",
+    "usageHint": "Una aplicación observadora puede ver el saldo y todo el historial de la billetera y generar nuevas direcciones de recepción. Útil para un rastreador de portafolio o una copia de solo lectura en otro dispositivo.",
+    "usageHintNote": "Conectar una aplicación por WizardConnect ya comparte xpubs con ella en segundo plano.",
     "privacyWarning": "Quien tenga tu xpub puede ver todas las direcciones y transacciones de esta billetera, pasadas y futuras. Compartirlo no se puede deshacer. Compártelo solo con servicios a los que confíes todo tu historial financiero.",
     "revealButton": "Revelar Xpub",
     "hideButton": "Ocultar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -762,7 +762,9 @@
   },
   "exportXpub": {
     "title": "Exporter la xpub",
-    "description": "Une xpub permet à une autre application d'observer ce portefeuille : voir son solde et tout son historique et générer de nouvelles adresses de réception, sans pouvoir dépenser. Utile pour un suivi de portefeuille ou une copie en lecture seule sur un autre appareil.",
+    "description": "Une xpub permet à une autre application d'observer ce portefeuille, sans pouvoir dépenser.",
+    "usageHint": "Une application observatrice peut voir le solde et tout l'historique du portefeuille et générer de nouvelles adresses de réception. Utile pour un suivi de portefeuille ou une copie en lecture seule sur un autre appareil.",
+    "usageHintNote": "Connecter une application via WizardConnect partage déjà des xpubs avec elle en arrière-plan.",
     "privacyWarning": "Quiconque possède votre xpub peut voir toutes les adresses et transactions de ce portefeuille, passées et futures. Le partage ne peut pas être annulé. Ne la partagez qu'avec des services à qui vous confiez tout votre historique financier.",
     "revealButton": "Révéler la xpub",
     "hideButton": "Masquer",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -760,6 +760,16 @@
       "notChipnetWif": "Ce n'est pas un code QR encodant une clé privée Chipnet au format WIF"
     }
   },
+  "exportXpub": {
+    "title": "Exporter la xpub",
+    "description": "Une xpub permet à une autre application d'observer ce portefeuille : voir son solde et tout son historique et générer de nouvelles adresses de réception, sans pouvoir dépenser. Utile pour un suivi de portefeuille ou une copie en lecture seule sur un autre appareil.",
+    "privacyWarning": "Quiconque possède votre xpub peut voir toutes les adresses et transactions de ce portefeuille, passées et futures. Le partage ne peut pas être annulé. Ne la partagez qu'avec des services à qui vous confiez tout votre historique financier.",
+    "revealButton": "Révéler la xpub",
+    "hideButton": "Masquer",
+    "derivationPath": "Chemin de dérivation :",
+    "copyButton": "Copier la xpub",
+    "safetyHint": "Un portefeuille en lecture seule créé à partir de cette xpub ne peut pas dépenser vos fonds."
+  },
   "signVerifyMessage": {
     "title": "Signer / Vérifier un message",
     "descriptionSign": "Signez un message avec une adresse de votre portefeuille pour prouver que vous la contrôlez.",
@@ -1013,6 +1023,7 @@
       "utxoManagement": "Gestion des UTXO",
       "sweepPrivateKey": "Balayer une clé privée",
       "signVerifyMessage": "Signer / Vérifier un message",
+      "exportXpub": "Exporter la xpub",
       "tokenCreationPage": "Page de création de tokens",
       "aboutCashonize": "À propos de Cashonize"
     },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -762,7 +762,9 @@
   },
   "exportXpub": {
     "title": "Exportar Xpub",
-    "description": "Um xpub permite que outro aplicativo observe esta carteira: ver o saldo e todo o histórico e gerar novos endereços de recebimento, sem poder gastar. Útil para um rastreador de portfólio ou uma cópia somente leitura em outro dispositivo.",
+    "description": "Um xpub permite que outro aplicativo observe esta carteira, sem poder gastar.",
+    "usageHint": "Um aplicativo observador pode ver o saldo e todo o histórico da carteira e gerar novos endereços de recebimento. Útil para um rastreador de portfólio ou uma cópia somente leitura em outro dispositivo.",
+    "usageHintNote": "Conectar um aplicativo via WizardConnect já compartilha xpubs com ele em segundo plano.",
     "privacyWarning": "Quem tiver seu xpub pode ver todos os endereços e transações desta carteira, passados e futuros. O compartilhamento não pode ser desfeito. Compartilhe apenas com serviços aos quais você confia todo o seu histórico financeiro.",
     "revealButton": "Revelar Xpub",
     "hideButton": "Ocultar",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -760,6 +760,16 @@
       "notChipnetWif": "Não é um QR code com chave privada Chipnet no formato WIF"
     }
   },
+  "exportXpub": {
+    "title": "Exportar Xpub",
+    "description": "Um xpub permite que outro aplicativo observe esta carteira: ver o saldo e todo o histórico e gerar novos endereços de recebimento, sem poder gastar. Útil para um rastreador de portfólio ou uma cópia somente leitura em outro dispositivo.",
+    "privacyWarning": "Quem tiver seu xpub pode ver todos os endereços e transações desta carteira, passados e futuros. O compartilhamento não pode ser desfeito. Compartilhe apenas com serviços aos quais você confia todo o seu histórico financeiro.",
+    "revealButton": "Revelar Xpub",
+    "hideButton": "Ocultar",
+    "derivationPath": "Caminho de derivação:",
+    "copyButton": "Copiar Xpub",
+    "safetyHint": "Uma carteira somente leitura criada com este xpub não pode gastar seus fundos."
+  },
   "signVerifyMessage": {
     "title": "Assinar / Verificar mensagem",
     "descriptionSign": "Assine uma mensagem com um endereço da sua carteira para provar que você o controla.",
@@ -1013,6 +1023,7 @@
       "utxoManagement": "Gerenciamento de UTXOs",
       "sweepPrivateKey": "Sweep de Chave Privada",
       "signVerifyMessage": "Assinar / Verificar mensagem",
+      "exportXpub": "Exportar Xpub",
       "tokenCreationPage": "Página de Criação de Tokens",
       "aboutCashonize": "Sobre o Cashonize"
     },

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -11,6 +11,7 @@
   import sweepPrivateKey from 'src/components/settings/sweepPrivateKey.vue'
   import signVerifyMessageView from 'src/components/settings/signVerifyMessage.vue'
   import walletToolsView from 'src/components/settings/walletTools.vue'
+  import exportXpubView from 'src/components/settings/exportXpub.vue'
   import hdAddressesView from 'src/components/settings/hdAddresses.vue'
   import aboutCashonizeView from 'src/components/settings/aboutCashonize.vue'
   import portfolioView from 'src/components/portfolio/portfolioView.vue'
@@ -69,6 +70,7 @@
       case 12: return portfolioView;
       case 13: return signVerifyMessageView;
       case 14: return walletToolsView;
+      case 15: return exportXpubView;
       default: return walletOnboardingView; // undefined or 0 shows onboarding
     }
   });


### PR DESCRIPTION
An xpub lets another app watch the wallet for portfolio tracking or a watch-only copy on another device. The page leads with the privacy implications, the xpub itself sits behind a reveal button and hides again on wallet switch. Shown with its derivation path and a QR code for cross-device import. HD wallets only, the entry is hidden for single-address wallets like the hd addresses entry.

closes #242 