### PR TITLE
Add the SLP derivation path as an import option

### DIFF
--- a/src/components/general/derivationPathSelect.vue
+++ b/src/components/general/derivationPathSelect.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-  import { ref, watch } from 'vue'
+  import { computed, ref, watch } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { DERIVATION_PATHS, scanDerivationPaths } from 'src/utils/walletUtils'
-  import type { DerivationPathType, DerivationPathDetectionResult } from 'src/utils/walletUtils'
+  import type { DerivationPathType } from 'src/utils/walletUtils'
   const { t } = useI18n()
 
   const emit = defineEmits<{
@@ -25,8 +25,12 @@
 
   const SCAN_TIMEOUT_MS = 15_000
 
-  const detectionStatus = ref<'idle' | 'scanning' | DerivationPathDetectionResult>('idle')
+  const detectionStatus = ref<'idle' | 'scanning' | 'done'>('idle')
+  const foundPaths = ref<DerivationPathType[]>([])
   const multipleAddressesUsed = ref(false)
+
+  const singleFoundPath = computed(() => foundPaths.value.length === 1 ? foundPaths.value[0] : undefined)
+  const foundPathsList = computed(() => foundPaths.value.map(pathType => DERIVATION_PATHS[pathType].parent).join(', '))
 
   // Bumped on every seed phrase change so an in-flight scan can tell its result is
   // for an outdated seed phrase. Deliberately a counter instead of comparing against
@@ -37,6 +41,7 @@
   watch(() => props.seedPhrase, () => {
     scanGeneration++
     detectionStatus.value = 'idle'
+    foundPaths.value = []
     multipleAddressesUsed.value = false
   })
 
@@ -50,10 +55,12 @@
       )
       const result = await Promise.race([scanDerivationPaths(props.seedPhrase), timeout])
       if (scanGeneration !== startedForGeneration) return
-      detectionStatus.value = result.path
+      detectionStatus.value = 'done'
+      foundPaths.value = result.usedPaths
       multipleAddressesUsed.value = result.multipleAddressesUsed
-      if (result.path === 'standard' || result.path === 'bitcoindotcom') {
-        selectedPath.value = result.path
+      // Only select automatically when the scan found exactly one path, otherwise the user picks
+      if (singleFoundPath.value) {
+        selectedPath.value = singleFoundPath.value
       }
     } catch {
       // Scanning is best-effort: on electrum errors fall back to manual selection
@@ -69,6 +76,7 @@
     <select v-model="selectedPath">
       <option value="standard">{{ DERIVATION_PATHS.standard.parent }} ({{ t('derivationPathSelect.standard') }})</option>
       <option value="bitcoindotcom">{{ DERIVATION_PATHS.bitcoindotcom.parent }} ({{ t('derivationPathSelect.bitcoindotcom') }})</option>
+      <option value="slp">{{ DERIVATION_PATHS.slp.parent }} ({{ t('derivationPathSelect.slp') }})</option>
     </select>
     <div v-if="seedPhraseValid && detectionStatus === 'idle'" style="margin-top: 5px; font-size: smaller; color: grey;">
       <i18n-t keypath="derivationPathSelect.scanPrompt" tag="span">
@@ -79,14 +87,18 @@
     </div>
     <div v-else-if="detectionStatus !== 'idle'" style="margin-top: 5px; font-size: smaller; color: grey;">
       <span v-if="detectionStatus === 'scanning'">{{ t('derivationPathSelect.scanning') }}</span>
-      <span v-else-if="detectionStatus === 'standard' || detectionStatus === 'bitcoindotcom'">
-        {{ t('derivationPathSelect.detected', { path: DERIVATION_PATHS[detectionStatus].parent }) }}
+      <span v-else-if="singleFoundPath">
+        {{ t('derivationPathSelect.detected', { path: DERIVATION_PATHS[singleFoundPath].parent }) }}
       </span>
-      <span v-else-if="detectionStatus === 'both'">{{ t('derivationPathSelect.detectedBoth') }}</span>
+      <span v-else-if="foundPaths.length > 1">{{ t('derivationPathSelect.detectedMultiple', { paths: foundPathsList }) }}</span>
       <span v-else>{{ t('derivationPathSelect.noneFound') }}</span>
     </div>
     <div v-if="multipleAddressesUsed && walletType === 'single'" style="margin-top: 5px; font-size: smaller; color: orange;">
       {{ t('derivationPathSelect.multiAddressWarning') }}
+    </div>
+    <div v-if="selectedPath === 'slp'" class="warning-box" style="margin-top: 10px; font-size: smaller;">
+      <q-icon name="warning" size="20px" class="warning-box-icon" />
+      <div><b>{{ t('common.attention') }}</b> {{ t('derivationPathSelect.slpWarning') }}</div>
     </div>
   </div>
 </template>

--- a/src/components/settings/backupWallet.vue
+++ b/src/components/settings/backupWallet.vue
@@ -64,6 +64,7 @@
     const path = walletDerivationPath.value;
     if (path === DERIVATION_PATHS.standard.full || path === DERIVATION_PATHS.standard.parent) return t('backupWallet.derivationPath.standard');
     if (path === DERIVATION_PATHS.bitcoindotcom.full || path === DERIVATION_PATHS.bitcoindotcom.parent) return t('backupWallet.derivationPath.bitcoindotcom');
+    if (path === DERIVATION_PATHS.slp.full || path === DERIVATION_PATHS.slp.parent) return t('backupWallet.derivationPath.slp');
     return t('backupWallet.derivationPath.custom');
   })
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -532,6 +532,7 @@
       "label": "Derivation Path",
       "standard": "BCH-Standard",
       "bitcoindotcom": "Legacy, Bitcoin.com Wallet kompatibel",
+      "slp": "Legacy, SLP Wallet kompatibel",
       "custom": "Benutzerdefiniert"
     },
     "persistentStorage": {
@@ -850,13 +851,15 @@
     "label": "Ableitungspfad:",
     "standard": "Standard",
     "bitcoindotcom": "Bitcoin.com Wallet",
+    "slp": "SLP",
     "scanPrompt": "Unsicher? {link}",
-    "scanLinkText": "Beide Pfade prüfen",
+    "scanLinkText": "Nach Wallet-Aktivität suchen",
     "scanning": "Suche nach Wallet-Aktivität...",
     "detected": "Wallet-Aktivität gefunden, {path} ausgewählt",
-    "detectedBoth": "Wallet-Aktivität auf beiden Ableitungspfaden gefunden",
-    "noneFound": "Keine Wallet-Aktivität auf einem der beiden Ableitungspfade gefunden",
-    "multiAddressWarning": "Diese seed phrase wurde mit mehreren Adressen verwendet. Ein Wallet mit einzelner Adresse zeigt diese Guthaben nicht an. Ein HD Wallet wird empfohlen."
+    "detectedMultiple": "Wallet-Aktivität auf mehreren Ableitungspfaden gefunden: {paths}",
+    "noneFound": "Keine Wallet-Aktivität auf einem der Ableitungspfade gefunden",
+    "multiAddressWarning": "Diese seed phrase wurde mit mehreren Adressen verwendet. Ein Wallet mit einzelner Adresse zeigt diese Guthaben nicht an. Ein HD Wallet wird empfohlen.",
+    "slpWarning": "Dieser Pfad wurde von SLP Wallets verwendet. Cashonize erkennt keine SLP-Token, daher werden beim Ausgeben aus diesem Wallet alle darin enthaltenen SLP-Token zerstört. Die meisten SLP-Token haben keinen Wert und keine Infrastruktur mehr."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -532,6 +532,7 @@
       "label": "Derivation path",
       "standard": "BCH standard",
       "bitcoindotcom": "legacy, Bitcoin.com wallet compatible",
+      "slp": "legacy, SLP wallet compatible",
       "custom": "custom"
     },
     "persistentStorage": {
@@ -850,13 +851,15 @@
     "label": "Derivation path:",
     "standard": "standard",
     "bitcoindotcom": "Bitcoin.com wallet",
+    "slp": "SLP",
     "scanPrompt": "Unsure? {link}",
-    "scanLinkText": "Scan both for wallet activity",
+    "scanLinkText": "Scan for wallet activity",
     "scanning": "Checking for wallet activity...",
     "detected": "Wallet activity found, selected {path}",
-    "detectedBoth": "Wallet activity found on both derivation paths",
-    "noneFound": "No wallet activity found on either derivation path",
-    "multiAddressWarning": "This seed phrase was used with multiple addresses. A single address wallet will not show those funds. An HD wallet is recommended."
+    "detectedMultiple": "Wallet activity found on multiple derivation paths: {paths}",
+    "noneFound": "No wallet activity found on any derivation path",
+    "multiAddressWarning": "This seed phrase was used with multiple addresses. A single address wallet will not show those funds. An HD wallet is recommended.",
+    "slpWarning": "This path was used by SLP wallets. Cashonize does not recognize SLP tokens, so spending from this wallet will destroy any it holds. Most SLP tokens have no remaining value or infrastructure."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -532,6 +532,7 @@
       "label": "Ruta de derivación",
       "standard": "Estándar BCH",
       "bitcoindotcom": "legado, compatible con billetera Bitcoin.com",
+      "slp": "legado, compatible con billetera SLP",
       "custom": "personalizada"
     },
     "persistentStorage": {
@@ -850,13 +851,15 @@
     "label": "Ruta de derivación:",
     "standard": "estándar",
     "bitcoindotcom": "Billetera Bitcoin.com",
+    "slp": "SLP",
     "scanPrompt": "¿No estás seguro? {link}",
-    "scanLinkText": "Escanear ambas rutas",
+    "scanLinkText": "Escanear actividad de la billetera",
     "scanning": "Buscando actividad de la billetera...",
     "detected": "Actividad encontrada, se seleccionó {path}",
-    "detectedBoth": "Actividad encontrada en ambas rutas de derivación",
-    "noneFound": "No se encontró actividad en ninguna de las rutas de derivación",
-    "multiAddressWarning": "Esta frase semilla se usó con varias direcciones. Una billetera de dirección única no mostrará esos fondos. Se recomienda una billetera HD."
+    "detectedMultiple": "Actividad encontrada en varias rutas de derivación: {paths}",
+    "noneFound": "No se encontró actividad en ninguna ruta de derivación",
+    "multiAddressWarning": "Esta frase semilla se usó con varias direcciones. Una billetera de dirección única no mostrará esos fondos. Se recomienda una billetera HD.",
+    "slpWarning": "Esta ruta fue usada por billeteras SLP. Cashonize no reconoce los tokens SLP, por lo que gastar desde esta billetera destruirá los que tenga. La mayoría de los tokens SLP ya no tienen valor ni infraestructura."
   },
   "seedPhraseInput": {
     "label": "Frase semilla:",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -532,6 +532,7 @@
       "label": "Chemin de dérivation",
       "standard": "Standard BCH",
       "bitcoindotcom": "ancien, compatible avec le portefeuille Bitcoin.com",
+      "slp": "ancien, compatible avec les portefeuilles SLP",
       "custom": "personnalisé"
     },
     "persistentStorage": {
@@ -850,13 +851,15 @@
     "label": "Chemin de dérivation :",
     "standard": "standard",
     "bitcoindotcom": "Portefeuille Bitcoin.com",
+    "slp": "SLP",
     "scanPrompt": "Pas sûr ? {link}",
-    "scanLinkText": "Analyser les deux chemins",
+    "scanLinkText": "Rechercher l'activité du portefeuille",
     "scanning": "Recherche d'activité du portefeuille...",
     "detected": "Activité trouvée, {path} sélectionné",
-    "detectedBoth": "Activité trouvée sur les deux chemins de dérivation",
-    "noneFound": "Aucune activité de portefeuille trouvée sur les deux chemins de dérivation",
-    "multiAddressWarning": "Cette phrase de récupération a été utilisée avec plusieurs adresses. Un portefeuille à adresse unique n'affichera pas ces fonds. Un portefeuille HD est recommandé."
+    "detectedMultiple": "Activité trouvée sur plusieurs chemins de dérivation : {paths}",
+    "noneFound": "Aucune activité de portefeuille trouvée sur aucun chemin de dérivation",
+    "multiAddressWarning": "Cette phrase de récupération a été utilisée avec plusieurs adresses. Un portefeuille à adresse unique n'affichera pas ces fonds. Un portefeuille HD est recommandé.",
+    "slpWarning": "Ce chemin était utilisé par les portefeuilles SLP. Cashonize ne reconnaît pas les jetons SLP, donc dépenser depuis ce portefeuille détruira ceux qu'il contient. La plupart des jetons SLP n'ont plus de valeur ni d'infrastructure."
   },
   "seedPhraseInput": {
     "label": "Phrase de récupération :",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -532,6 +532,7 @@
       "label": "Derivation path",
       "standard": "Padrão BCH",
       "bitcoindotcom": "legado, compatível com carteira Bitcoin.com",
+      "slp": "legado, compatível com carteira SLP",
       "custom": "personalizado"
     },
     "persistentStorage": {
@@ -850,13 +851,15 @@
     "label": "Derivation path:",
     "standard": "padrão",
     "bitcoindotcom": "Carteira Bitcoin.com",
+    "slp": "SLP",
     "scanPrompt": "Não tem certeza? {link}",
-    "scanLinkText": "Verificar ambos os caminhos",
+    "scanLinkText": "Verificar atividade da carteira",
     "scanning": "Verificando atividade da carteira...",
     "detected": "Atividade encontrada, {path} selecionado",
-    "detectedBoth": "Atividade encontrada em ambos os caminhos de derivação",
-    "noneFound": "Nenhuma atividade encontrada em nenhum dos caminhos de derivação",
-    "multiAddressWarning": "Esta seed phrase foi usada com vários endereços. Uma carteira de endereço único não mostrará esses fundos. Uma carteira HD é recomendada."
+    "detectedMultiple": "Atividade encontrada em vários caminhos de derivação: {paths}",
+    "noneFound": "Nenhuma atividade encontrada em nenhum caminho de derivação",
+    "multiAddressWarning": "Esta seed phrase foi usada com vários endereços. Uma carteira de endereço único não mostrará esses fundos. Uma carteira HD é recomendada.",
+    "slpWarning": "Este caminho era usado por carteiras SLP. A Cashonize não reconhece tokens SLP, então gastar a partir desta carteira destruirá os que ela tiver. A maioria dos tokens SLP não tem mais valor nem infraestrutura."
   },
   "seedPhraseInput": {
     "label": "Seed phrase:",

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -7,26 +7,34 @@ import { isValidBip39Mnemonic, normalizeSeedPhrase } from 'src/utils/utils'
 import { i18n } from 'src/boot/i18n'
 const { t } = i18n.global
 
-export type DerivationPathType = "standard" | "bitcoindotcom";
+export type DerivationPathType = "standard" | "bitcoindotcom" | "slp";
 
 // BIP44 derivation paths for BCH wallets
 // - parent: used by mainnet-js Config when generating new wallets via Wallet.named()
 // - full: used in explicit walletId strings for Wallet.replaceNamed() imports
 export const DERIVATION_PATHS = {
+  // BCH coin type, used by the large majority of BCH wallets
   standard: {
     parent: "m/44'/145'/0'",
     full: "m/44'/145'/0'/0/0",
   },
+  // BTC coin type, used by the Bitcoin.com wallet and read.cash
   bitcoindotcom: {
     parent: "m/44'/0'/0'",
     full: "m/44'/0'/0'/0/0",
   },
+  // SLP coin type, used by Zapit and older SLP wallets
+  slp: {
+    parent: "m/44'/245'/0'",
+    full: "m/44'/245'/0'/0/0",
+  },
 } as const;
 
-export type DerivationPathDetectionResult = DerivationPathType | "both" | "none";
+// Order determines the order paths are reported in after a scan
+const SCANNED_PATH_TYPES: DerivationPathType[] = ["standard", "bitcoindotcom", "slp"];
 
 export interface DerivationPathScanResult {
-  path: DerivationPathDetectionResult;
+  usedPaths: DerivationPathType[];
   multipleAddressesUsed: boolean;
 }
 
@@ -70,14 +78,10 @@ export async function scanDerivationPaths(seedPhrase: string): Promise<Derivatio
     return false;
   }
 
-  const [standardUsed, bitcoindotcomUsed] = await Promise.all([
-    addressHasActivity(DERIVATION_PATHS.standard.full),
-    addressHasActivity(DERIVATION_PATHS.bitcoindotcom.full),
-  ]);
-
-  const usedPaths: DerivationPathType[] = [];
-  if (standardUsed) usedPaths.push("standard");
-  if (bitcoindotcomUsed) usedPaths.push("bitcoindotcom");
+  const pathHasActivity = await Promise.all(
+    SCANNED_PATH_TYPES.map((pathType) => addressHasActivity(DERIVATION_PATHS[pathType].full))
+  );
+  const usedPaths = SCANNED_PATH_TYPES.filter((_pathType, index) => pathHasActivity[index]);
 
   let multipleAddressesUsed = false;
   for (const usedPath of usedPaths) {
@@ -87,12 +91,7 @@ export async function scanDerivationPaths(seedPhrase: string): Promise<Derivatio
     }
   }
 
-  let path: DerivationPathDetectionResult = "none";
-  if (standardUsed && bitcoindotcomUsed) path = "both";
-  else if (standardUsed) path = "standard";
-  else if (bitcoindotcomUsed) path = "bitcoindotcom";
-
-  return { path, multipleAddressesUsed };
+  return { usedPaths, multipleAddressesUsed };
 }
 
 export interface CreateWalletResult {

--- a/test/mocks/walletUtils.mocks.ts
+++ b/test/mocks/walletUtils.mocks.ts
@@ -10,6 +10,7 @@ import { vi } from 'vitest'
 // Mock functions for wallet classes
 export const mockWalletNamed = vi.fn()
 export const mockWalletReplaceNamed = vi.fn()
+export const mockWalletFromSeed = vi.fn()
 export const mockTestNetWalletReplaceNamed = vi.fn()
 
 // Mock functions for HD wallet classes
@@ -62,6 +63,7 @@ vi.mock('mainnet-js', () => ({
   Wallet: {
     named: mockWalletNamed,
     replaceNamed: mockWalletReplaceNamed,
+    fromSeed: mockWalletFromSeed,
   },
   TestNetWallet: {
     replaceNamed: mockTestNetWalletReplaceNamed,

--- a/test/walletUtils.test.ts
+++ b/test/walletUtils.test.ts
@@ -18,11 +18,12 @@ import {
   mockSetWalletCreatedAt,
   mockSetBackupStatus,
   mockSetWalletType,
+  mockWalletFromSeed,
   localStorageMock,
 } from './mocks/walletUtils.mocks'
 
 // Import module under test after mocks
-import { createNewWallet, importWallet, createNewHDWallet, importHDWallet, validateWalletName } from '../src/utils/walletUtils'
+import { createNewWallet, importWallet, createNewHDWallet, importHDWallet, validateWalletName, scanDerivationPaths } from '../src/utils/walletUtils'
 
 describe('validateWalletName', () => {
   it('returns null for valid names', () => {
@@ -986,5 +987,64 @@ describe('importHDWallet', () => {
       expect(result.success).toBe(false)
       expect(result.success === false && result.isUserError).toBe(false)
     })
+  })
+})
+
+describe('scanDerivationPaths', () => {
+  const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+  // Every address of the seed phrase is derived through Wallet.fromSeed, only the
+  // listed derivation paths report an on-chain transaction history
+  function givenHistoryOnPaths(pathsWithHistory: string[]) {
+    mockWalletFromSeed.mockImplementation((_seedPhrase: string, derivationPath: string) => Promise.resolve({
+      getRawHistory: () => Promise.resolve(pathsWithHistory.includes(derivationPath) ? [{ tx_hash: 'abc' }] : [])
+    }))
+  }
+
+  function scannedPaths() {
+    return mockWalletFromSeed.mock.calls.map(call => call[1] as string)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('scans all three supported derivation paths', async () => {
+    givenHistoryOnPaths([])
+
+    const result = await scanDerivationPaths(seedPhrase)
+
+    expect(result.usedPaths).toEqual([])
+    expect(scannedPaths()).toEqual([
+      "m/44'/145'/0'/0/0",
+      "m/44'/0'/0'/0/0",
+      "m/44'/245'/0'/0/0",
+    ])
+  })
+
+  it('detects a wallet on the SLP path', async () => {
+    givenHistoryOnPaths(["m/44'/245'/0'/0/0"])
+
+    const result = await scanDerivationPaths(seedPhrase)
+
+    expect(result.usedPaths).toEqual(['slp'])
+    expect(result.multipleAddressesUsed).toBe(false)
+  })
+
+  it('reports every path with activity', async () => {
+    givenHistoryOnPaths(["m/44'/145'/0'/0/0", "m/44'/245'/0'/0/0"])
+
+    const result = await scanDerivationPaths(seedPhrase)
+
+    expect(result.usedPaths).toEqual(['standard', 'slp'])
+  })
+
+  it('flags activity beyond the first receive address of a used path', async () => {
+    givenHistoryOnPaths(["m/44'/245'/0'/0/0", "m/44'/245'/0'/1/0"])
+
+    const result = await scanDerivationPaths(seedPhrase)
+
+    expect(result.usedPaths).toEqual(['slp'])
+    expect(result.multipleAddressesUsed).toBe(true)
   })
 })


### PR DESCRIPTION
Zapit and older SLP wallets use coin type 245, so seed phrases from them could not be imported. Adds m/44'/245'/0' to the derivation path dropdown and to the activity scan, with a warning that spending from such a wallet destroys any SLP tokens it holds, as Cashonize does not recognize them.

The scan now reports the list of paths it found activity on instead of a "both" result, which only made sense for two paths.