### PR TITLE
Mark transactions that pay below the relay fee

### DIFF
--- a/src/components/history/transactionDialog.vue
+++ b/src/components/history/transactionDialog.vue
@@ -12,6 +12,7 @@
   import CharCounter from '../general/CharCounter.vue';
   import { formatReadableDate, formatRelativeTime, satsToBch, formatBchAmount, formatFiatAmount, tokenChangeChips } from 'src/utils/utils';
   import { maxTxNoteLength } from 'src/utils/history/txNotes';
+  import { feeRate, isBelowRelayFee, minRelayFeeRate } from 'src/utils/history/txFeeRate';
   import { useI18n } from 'vue-i18n'
 
   const store = useStore()
@@ -67,6 +68,13 @@
 
   // A transaction in the current tip block has 1 confirmation
   const confirmations = computed(() => (store.currentBlockHeight as number) - props.historyItem.blockHeight + 1);
+
+  // Below the relay fee the exact rate is what matters, and a single decimal would
+  // round a rate like 0.96 up to a reassuring 1.0
+  const feeRateText = computed(() => {
+    const rate = feeRate(props.historyItem);
+    return rate < minRelayFeeRate ? rate.toFixed(2) : rate.toFixed(1);
+  });
 
   function formatTokenAmount(amount: bigint, category: string) {
     const decimals = store.bcmrRegistries?.[category]?.token.decimals ?? 0;
@@ -153,9 +161,15 @@
                 <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
                 <InfoPopup v-if="historyItem.blockHeight < 0">
                   <template #trigger>
-                    <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                    <span class="warning-badge">{{ t('history.unconfirmedChain') }}</span>
                   </template>
                   {{ t('history.unconfirmedChainTooltip') }}
+                </InfoPopup>
+                <InfoPopup v-if="isBelowRelayFee(historyItem)">
+                  <template #trigger>
+                    <span class="warning-badge">{{ t('history.lowFee') }}</span>
+                  </template>
+                  {{ t('history.lowFeeTooltip') }}
                 </InfoPopup>
               </span>
               <!-- under the customary 6 confirmations, show progress toward finality -->
@@ -214,7 +228,7 @@
             </div>
             <div v-if="!isCoinbase">
               {{ t('transactionDialog.fee') }}
-                <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat ({{ (historyItem.fee / historyItem.size).toFixed(1) }} sat/byte)</span>
+                <span><template v-if="feeIncurrency !== undefined">{{ feeIncurrency }}{{ currencySymbol }} or </template>{{ historyItem.fee.toLocaleString("en-US") }} sat (<span :class="{ 'low-fee-rate': isBelowRelayFee(historyItem) }">{{ feeRateText }} sat/byte</span>)</span>
             </div>
             <div v-else>
               {{ t('transactionDialog.feesCollected') }}
@@ -375,7 +389,7 @@
     color: hsla(160, 100%, 37%, 1)
   }
   /* same amber pill as the history rows, the info popup carries the explanation */
-  .chain-badge {
+  .warning-badge {
     display: inline-block;
     margin-left: 2px;
     padding: 0 7px;
@@ -385,6 +399,11 @@
     vertical-align: middle;
     background-color: rgba(230, 162, 60, 0.18);
     color: #e6a23c;
+  }
+  /* the rate itself is tinted when it sits below what nodes relay by default */
+  .low-fee-rate {
+    color: #e6a23c;
+    font-weight: 600;
   }
 
   @media only screen and (max-width: 450px) {

--- a/src/components/history/txHistory.vue
+++ b/src/components/history/txHistory.vue
@@ -8,6 +8,7 @@
   import { historyToCsv } from 'src/utils/history/csvUtils';
   import { maxTxNoteLength } from 'src/utils/history/txNotes';
   import { txDirection, directionIcon, isCombined, isDappInteraction } from 'src/utils/history/txDirection';
+  import { isBelowRelayFee } from 'src/utils/history/txFeeRate';
   import TokenIcon from '../general/TokenIcon.vue';
   import InfoPopup from '../general/InfoPopup.vue';
   import InlineTextEdit from '../general/InlineTextEdit.vue';
@@ -257,11 +258,17 @@
                   {{ t('history.' + txDirection(transaction)) }}
                   <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
                   <!-- electrum reports height -1 for mempool transactions spending unconfirmed inputs -->
-                  <InfoPopup v-if="transaction.blockHeight < 0" class="chain-popup" @click.stop>
+                  <InfoPopup v-if="transaction.blockHeight < 0" class="badge-popup" @click.stop>
                     <template #trigger>
-                      <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                      <span class="warning-badge">{{ t('history.unconfirmedChain') }}</span>
                     </template>
                     {{ t('history.unconfirmedChainTooltip') }}
+                  </InfoPopup>
+                  <InfoPopup v-if="isBelowRelayFee(transaction)" class="badge-popup" @click.stop>
+                    <template #trigger>
+                      <span class="warning-badge">{{ t('history.lowFee') }}</span>
+                    </template>
+                    {{ t('history.lowFeeTooltip') }}
                   </InfoPopup>
                 </div>
                 <div class="tx-time">{{ transaction.timestamp ? formatTime(transaction.timestamp) : t('history.pending') }}</div>
@@ -303,13 +310,19 @@
                 {{ t('history.balanceLabel') }} {{ formatBchAmount(transaction.balance) }} {{ bchDisplayUnit }}
               </div>
             </div>
-            <div class="tx-badges-line" v-if="isDappInteraction(transaction, walletHasAddress) || transaction.blockHeight < 0">
+            <div class="tx-badges-line" v-if="isDappInteraction(transaction, walletHasAddress) || transaction.blockHeight < 0 || isBelowRelayFee(transaction)">
               <span v-if="isDappInteraction(transaction, walletHasAddress)" class="dapp-badge">{{ t('history.dapp') }}</span>
               <InfoPopup v-if="transaction.blockHeight < 0" @click.stop>
                 <template #trigger>
-                  <span class="chain-badge">{{ t('history.unconfirmedChain') }}</span>
+                  <span class="warning-badge">{{ t('history.unconfirmedChain') }}</span>
                 </template>
                 {{ t('history.unconfirmedChainTooltip') }}
+              </InfoPopup>
+              <InfoPopup v-if="isBelowRelayFee(transaction)" @click.stop>
+                <template #trigger>
+                  <span class="warning-badge">{{ t('history.lowFee') }}</span>
+                </template>
+                {{ t('history.lowFeeTooltip') }}
               </InfoPopup>
             </div>
           </div>
@@ -566,7 +579,9 @@ fieldset.item {
   gap: 4px;
 }
 
-.tx-badges-line .dapp-badge {
+/* the line spaces its badges with a gap, so they drop their own left margin */
+.tx-badges-line .dapp-badge,
+.tx-badges-line .warning-badge {
   margin-left: 0;
 }
 
@@ -576,9 +591,10 @@ fieldset.item {
   white-space: nowrap;
 }
 
-/* a transaction depending on unconfirmed inputs has a higher risk of not
-   confirming; the badge opens an info popup with the explanation */
-.chain-badge {
+/* transactions that carry a risk of not confirming, either because they depend on
+   unconfirmed inputs or because they pay below the relay fee; each badge opens an
+   info popup with the explanation */
+.warning-badge {
   display: inline-block;
   margin-left: 4px;
   padding: 0 7px;
@@ -761,7 +777,7 @@ body.dark .negative {
 @media only screen and (max-width: 400px) {
   /* the badges leave the crowded label line for their own line at the card bottom */
   .tx-type .dapp-badge,
-  .tx-type .chain-popup {
+  .tx-type .badge-popup {
     display: none;
   }
   .tx-badges-line {

--- a/src/components/walletconnect/WC2TransactionRequest.vue
+++ b/src/components/walletconnect/WC2TransactionRequest.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { toRefs, ref } from 'vue';
-  import { binToHex, decodeTransactionUnsafe, hexToBin, lockingBytecodeToCashAddress, type Output } from "@bitauth/libauth"
+  import { binToHex, decodeTransactionUnsafe, encodeTransaction, hexToBin, lockingBytecodeToCashAddress, type Output } from "@bitauth/libauth"
   import { useDialogPluginComponent } from 'quasar'
   import { useStore } from 'src/stores/store'
   import { convertToCurrency, formatFiatAmount, formatNumber, sanitizeUrl } from 'src/utils/utils'
@@ -8,6 +8,7 @@
   import { type DappMetadata } from "src/interfaces/interfaces"
   import { type WcSignTransactionRequest } from "@bch-wc2/interfaces"
   import { type BcmrTokenResponse } from 'src/utils/zodValidation';
+  import { minRelayFeeRate } from 'src/utils/history/txFeeRate';
   import TokenIcon from '../general/TokenIcon.vue';
   import { useI18n } from 'vue-i18n'
   const store = useStore()
@@ -69,6 +70,25 @@
   );
   const bchBalanceChange = bchReceivedOutputs - bchSpentInputs;
   const currencyBalanceChange = convertToCurrency(bchBalanceChange, exchangeRate.value);
+
+  // The fee is what all the inputs pay over all the outputs, third party ones included
+  const totalInputValue = sourceOutputs.reduce((total:bigint, sourceOutput) => total + sourceOutput.valueSatoshis, 0n);
+  const totalOutputValue = txDetails.outputs.reduce((total:bigint, output) => total + output.valueSatoshis, 0n);
+  const transactionFee = totalInputValue - totalOutputValue;
+
+  // The request holds an unsigned transaction, so its length is short by the signatures
+  // the wallet still has to add: for each of its own inputs that arrives empty, a 65 byte
+  // schnorr signature and a 33 byte public key, each behind a single byte push opcode.
+  const signedInputSize = 100;
+  const inputsAwaitingSignature = sourceOutputs.filter(sourceOutput =>
+    !sourceOutput.unlockingBytecode?.length && store.walletHasAddress(toCashaddr(sourceOutput.lockingBytecode))
+  ).length;
+  const transactionSize = encodeTransaction(txDetails).length + (inputsAwaitingSignature * signedInputSize);
+  const transactionFeeRate = Number(transactionFee) / transactionSize;
+  const paysBelowRelayFee = transactionFee < BigInt(transactionSize * minRelayFeeRate);
+  // below the relay fee the exact rate is what matters, and a single decimal would round
+  // a rate like 0.96 up to a reassuring 1.0
+  const feeRateText = transactionFeeRate < minRelayFeeRate ? transactionFeeRate.toFixed(2) : transactionFeeRate.toFixed(1);
 
   // Track net fungible token changes and separate NFT changes
   const ftNetChanges: Record<string, bigint> = {};
@@ -244,6 +264,12 @@
             * {{ Object.keys(unverifiedTokenMetadata).length === 1 ? t('walletConnect.transactionRequest.unverifiedTokenNoteSingular') : t('walletConnect.transactionRequest.unverifiedTokenNotePlural') }}
           </div>
 
+          <div class="wc-modal-heading" style="margin-top: 1.5rem;">{{ t('walletConnect.transactionRequest.networkFee') }}</div>
+          <div>
+            {{ satoshiToBCHString(transactionFee) }}
+            (<span :class="{ 'low-fee-rate': paysBelowRelayFee }">{{ feeRateText }} sat/byte</span>)
+          </div>
+
           <hr style="margin-top: 2rem;">
 
         <details>
@@ -333,6 +359,11 @@
             </table>
           </div>
         </details>
+        <div v-if="paysBelowRelayFee" class="warning-box" style="margin-top: 1.5rem;">
+          <q-icon name="warning" size="20px" class="warning-box-icon" />
+          <div><b>{{ t('common.attention') }}</b> {{ t('walletConnect.transactionRequest.lowFeeWarning', { rate: feeRateText }) }}</div>
+        </div>
+
         <div class="wc-modal-bottom-buttons">
           <input type="button" class="primaryButton" :value="t('walletConnect.transactionRequest.signButton')" @click="onDialogOK">
           <input type="button" :value="t('walletConnect.transactionRequest.cancelButton')" @click="onDialogCancel" v-close-popup>
@@ -394,6 +425,11 @@
     display: flex;
     align-items: center;
     gap: 6px;
+  }
+  /* the rate itself is tinted when it sits below what nodes relay by default */
+  .low-fee-rate {
+    color: #e6a23c;
+    font-weight: 600;
   }
 
   @media only screen and (max-width: 570px) {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1051,6 +1051,8 @@
       "capability": "Capability:",
       "signButton": "Signieren",
       "cancelButton": "Abbrechen",
+      "networkFee": "Netzwerkgebühr:",
+      "lowFeeWarning": "Diese Transaktion zahlt {rate} sat/Byte. Knoten leiten Transaktionen standardmäßig ab 1 sat/Byte weiter, daher kann sie beim Senden abgelehnt werden.",
       "unverifiedTokenNote": "{count, plural, one {Token} other {Tokens}} nicht in deinem Wallet. Neue Metadaten zur Vorschau abgerufen.",
       "unverifiedTokenNoteSingular": "Token nicht in deinem Wallet. Neue Metadaten zur Vorschau abgerufen.",
       "unverifiedTokenNotePlural": "Tokens nicht in deinem Wallet. Neue Metadaten zur Vorschau abgerufen."

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -471,6 +471,8 @@
     "confirmationsProgress": "{count}/6 Bestätigungen",
     "unconfirmedChain": "unbestätigte Kette",
     "unconfirmedChainTooltip": "Diese Transaktion hängt von einer anderen unbestätigten Transaktion ab, was das Risiko erhöht, dass sie nicht bestätigt wird.",
+    "lowFee": "niedrige Gebühr",
+    "lowFeeTooltip": "Diese Transaktion zahlt weniger als das 1 sat/Byte, das Knoten standardmäßig weiterleiten, daher kann die Bestätigung lange dauern oder ganz ausbleiben.",
     "transactionCountPartial": "{count}+ Transaktionen",
     "loadingFullHistory": "Lade vollständige Historie"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1051,6 +1051,8 @@
       "capability": "Capability:",
       "signButton": "Sign",
       "cancelButton": "Cancel",
+      "networkFee": "Network Fee:",
+      "lowFeeWarning": "This transaction pays {rate} sat/byte. Nodes relay transactions at 1 sat/byte by default, so it may be rejected when it is broadcast.",
       "unverifiedTokenNote": "{count, plural, one {Token} other {Tokens}} not in your wallet. New metadata fetched for preview.",
       "unverifiedTokenNoteSingular": "Token not in your wallet. New metadata fetched for preview.",
       "unverifiedTokenNotePlural": "Tokens not in your wallet. New metadata fetched for preview."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -471,6 +471,8 @@
     "confirmationsProgress": "{count}/6 confirmations",
     "unconfirmedChain": "unconfirmed chain",
     "unconfirmedChainTooltip": "This transaction depends on another unconfirmed transaction, which increases the risk that it does not confirm.",
+    "lowFee": "low fee",
+    "lowFeeTooltip": "This transaction pays less than the 1 sat/byte that nodes relay by default, so it may take a long time to confirm or may never confirm.",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Loading full history"
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1051,6 +1051,8 @@
       "capability": "Capacidad:",
       "signButton": "Firmar",
       "cancelButton": "Cancelar",
+      "networkFee": "Comisión de red:",
+      "lowFeeWarning": "Esta transacción paga {rate} sat/byte. Los nodos retransmiten transacciones a 1 sat/byte de forma predeterminada, por lo que puede ser rechazada al difundirse.",
       "unverifiedTokenNote": "{count, plural, one {Token} other {Tokens}} no {count, plural, one {está} other {están}} en tu billetera. Se obtuvieron nuevos metadatos para vista previa.",
       "unverifiedTokenNoteSingular": "El token no está en tu billetera. Se obtuvieron nuevos metadatos para vista previa.",
       "unverifiedTokenNotePlural": "Los tokens no están en tu billetera. Se obtuvieron nuevos metadatos para vista previa."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -471,6 +471,8 @@
     "confirmationsProgress": "{count}/6 confirmaciones",
     "unconfirmedChain": "cadena sin confirmar",
     "unconfirmedChainTooltip": "Esta transacción depende de otra transacción sin confirmar, lo que aumenta el riesgo de que no se confirme.",
+    "lowFee": "comisión baja",
+    "lowFeeTooltip": "Esta transacción paga menos de 1 sat/byte, la comisión que los nodos retransmiten de forma predeterminada, por lo que puede tardar mucho en confirmarse o no confirmarse nunca.",
     "transactionCountPartial": "{count}+ Transacciones",
     "loadingFullHistory": "Cargando historial completo"
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1051,6 +1051,8 @@
       "capability": "Capability :",
       "signButton": "Signer",
       "cancelButton": "Annuler",
+      "networkFee": "Frais de réseau :",
+      "lowFeeWarning": "Cette transaction paie {rate} sat/octet. Les nœuds relaient les transactions à 1 sat/octet par défaut, elle peut donc être rejetée lors de sa diffusion.",
       "unverifiedTokenNote": "{count, plural, one {Le token} other {Les tokens}} ne {count, plural, one {figure} other {figurent}} pas dans votre portefeuille. De nouvelles métadonnées ont été obtenues pour l'aperçu.",
       "unverifiedTokenNoteSingular": "Le token ne figure pas dans votre portefeuille. De nouvelles métadonnées ont été obtenues pour l'aperçu.",
       "unverifiedTokenNotePlural": "Les tokens ne figurent pas dans votre portefeuille. De nouvelles métadonnées ont été obtenues pour l'aperçu."

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -471,6 +471,8 @@
     "confirmationsProgress": "{count}/6 confirmations",
     "unconfirmedChain": "chaîne non confirmée",
     "unconfirmedChainTooltip": "Cette transaction dépend d'une autre transaction non confirmée, ce qui augmente le risque qu'elle ne soit pas confirmée.",
+    "lowFee": "frais faibles",
+    "lowFeeTooltip": "Cette transaction paie moins que les 1 sat/octet que les nœuds relaient par défaut, elle peut donc mettre longtemps à être confirmée ou ne jamais l'être.",
     "transactionCountPartial": "{count}+ Transactions",
     "loadingFullHistory": "Chargement de l'historique complet"
   },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1051,6 +1051,8 @@
       "capability": "Capability:",
       "signButton": "Assinar",
       "cancelButton": "Cancelar",
+      "networkFee": "Taxa de rede:",
+      "lowFeeWarning": "Esta transação paga {rate} sat/byte. Os nós retransmitem transações a 1 sat/byte por padrão, por isso pode ser rejeitada ao ser difundida.",
       "unverifiedTokenNote": "{count, plural, one {Token} other {Tokens}} não presente na sua carteira. Novos metadados obtidos para pré-visualização.",
       "unverifiedTokenNoteSingular": "Token não presente na sua carteira. Novos metadados obtidos para pré-visualização.",
       "unverifiedTokenNotePlural": "Tokens não presentes na sua carteira. Novos metadados obtidos para pré-visualização."

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -471,6 +471,8 @@
     "confirmationsProgress": "{count}/6 confirmações",
     "unconfirmedChain": "cadeia não confirmada",
     "unconfirmedChainTooltip": "Esta transação depende de outra transação não confirmada, o que aumenta o risco de que não seja confirmada.",
+    "lowFee": "taxa baixa",
+    "lowFeeTooltip": "Esta transação paga menos do que 1 sat/byte, a taxa que os nós retransmitem por padrão, por isso pode demorar muito a confirmar ou nunca confirmar.",
     "transactionCountPartial": "{count}+ Transações",
     "loadingFullHistory": "Carregando histórico completo"
   },

--- a/src/utils/history/txFeeRate.ts
+++ b/src/utils/history/txFeeRate.ts
@@ -1,0 +1,17 @@
+import type { TransactionHistoryItem } from "mainnet-js";
+
+// Nodes relay transactions at 1 sat/byte by default, below that a transaction is
+// non-standard and may sit unmined indefinitely. This is node policy, not consensus.
+export const minRelayFeeRate = 1;
+
+export function feeRate(transaction: TransactionHistoryItem): number {
+  return transaction.fee / transaction.size;
+}
+
+export function isBelowRelayFee(transaction: TransactionHistoryItem): boolean {
+  // once mined the fee rate no longer says anything about the transaction
+  if (transaction.timestamp) return false;
+  if (!transaction.size) return false;
+  // integer comparison, so a transaction paying exactly 1 sat/byte is never flagged
+  return transaction.fee < transaction.size * minRelayFeeRate;
+}

--- a/test/txFeeRate.test.ts
+++ b/test/txFeeRate.test.ts
@@ -1,0 +1,55 @@
+import { isBelowRelayFee, feeRate } from "../src/utils/history/txFeeRate";
+import type { TransactionHistoryItem } from "mainnet-js";
+
+// the base transaction is pending: no timestamp, and height 0 for the mempool
+const makeTx = (overrides: Partial<TransactionHistoryItem>): TransactionHistoryItem => ({
+  hash: "txhash123",
+  blockHeight: 0,
+  size: 250,
+  fee: 300,
+  balance: 150_000_000,
+  valueChange: -50_000_000,
+  inputs: [],
+  outputs: [],
+  tokenAmountChanges: [],
+  ...overrides,
+});
+
+describe('isBelowRelayFee', () => {
+  it('should not flag a pending transaction paying above the relay fee', () => {
+    expect(isBelowRelayFee(makeTx({ size: 250, fee: 300 }))).toBe(false);
+  });
+
+  it('should flag a pending transaction paying below the relay fee', () => {
+    expect(isBelowRelayFee(makeTx({ size: 250, fee: 240 }))).toBe(true);
+  });
+
+  it('should not flag a transaction paying exactly the relay fee', () => {
+    expect(isBelowRelayFee(makeTx({ size: 250, fee: 250 }))).toBe(false);
+  });
+
+  it('should flag a transaction one satoshi under the relay fee', () => {
+    expect(isBelowRelayFee(makeTx({ size: 250, fee: 249 }))).toBe(true);
+  });
+
+  it('should not flag a confirmed transaction, however low its fee', () => {
+    const tx = makeTx({ size: 250, fee: 10, blockHeight: 800_000, timestamp: 1700000000 });
+    expect(isBelowRelayFee(tx)).toBe(false);
+  });
+
+  it('should not flag a transaction of unknown size', () => {
+    expect(isBelowRelayFee(makeTx({ size: 0, fee: 0 }))).toBe(false);
+  });
+
+  it('should flag a transaction chained on an unconfirmed parent', () => {
+    // electrum reports height -1 for mempool transactions spending unconfirmed inputs,
+    // both warnings apply to it independently
+    expect(isBelowRelayFee(makeTx({ blockHeight: -1, size: 250, fee: 100 }))).toBe(true);
+  });
+});
+
+describe('feeRate', () => {
+  it('should report the rate in satoshis per byte', () => {
+    expect(feeRate(makeTx({ size: 250, fee: 240 }))).toBe(0.96);
+  });
+});


### PR DESCRIPTION
Nodes relay transactions at 1 sat/byte by default, so a pending transaction paying less than that may take a long time to confirm or never confirm at all. The history rows and the transaction dialog now carry a "low fee" pill for those, next to the existing unconfirmed chain pill, and the fee rate in the dialog details is tinted and shown to two decimals so a rate like 0.96 no longer rounds up to a reassuring 1.0.

Like Electron Cash, the pill only applies while a transaction is pending: once it is mined the fee rate no longer says anything about it. Unlike Electron Cash, an unconfirmed parent does not suppress the low fee pill, the two are independent facts and there is room for both.