### PR TITLE
Stop taking the fee rate from the electrum server

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -88,6 +88,12 @@ function setDefaultElectrumServers() {
 }
 setDefaultElectrumServers();
 
+// Pin the fee rate mainnet-js builds transactions at, instead of letting it ask the electrum
+// server: it reads these globals before calling blockchain.relayfee and skips the call. A
+// server can advertise a fee far below what the rest of the network relays, leaving the wallet
+// building transactions no peer will pass on. BCH per kB, so 0.00001 is 1 sat/byte.
+Object.assign(globalThis, { BCH_RELAY_FEE: 0.00001, tBCH_RELAY_FEE: 0.00001 });
+
 const isDesktop = import.meta.env.QUASAR_ELECTRON_MODE;
 const EXCHANGE_RATE_REFETCH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const CAULDRON_REFETCH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes


### PR DESCRIPTION
## The problem

mainnet-js asks the connected electrum server what it relays at (`blockchain.relayfee`) and builds every transaction at that rate, applying no floor to the answer. Probing all eight predefined mainnet servers, seven report the usual `0.00001` BCH/kB, which becomes 1 sat/byte:

| Server | `blockchain.relayfee` | resulting rate |
|---|---|---|
| electrum.imaginary.cash | 0.00001 | 1 sat/byte |
| bch.imaginary.cash | 0.00001 | 1 sat/byte |
| cashnode.bch.ninja | 0.00001 | 1 sat/byte |
| fulcrum.greyh.at | 0.00001 | 1 sat/byte |
| **electroncash.dk** | **1e-8** | **0.001 sat/byte** |
| fulcrum.jettscythe.xyz | 0.00001 | 1 sat/byte |
| bch.loping.net | 0.00001 | 1 sat/byte |
| fulcrum.criptolayer.net | 0.00001 | 1 sat/byte |

A user on that one server sent a token payment that paid **3 satoshis on 1598 bytes**, which is what `ceil(1598 × 0.001 + 1)` comes to. Such a transaction is accepted into that server's own mempool, so the wallet shows it pending, but no peer relays it on and no miner ever sees it. It was still unconfirmed hours later.

This applies to **every transaction the wallet builds**, not only token sends: `getRelayFeeCache` feeds both send paths, so a wallet holding no tokens at all was equally broken on that server.

## The fix

Set mainnet-js's relay fee globals at startup, next to the existing default-server override in `store.ts`. mainnet-js reads them before calling `blockchain.relayfee` and skips the call, so the rate is ours rather than the server's. This is the documented way to supply the value, not a way around the library.

```ts
Object.assign(globalThis, { BCH_RELAY_FEE: 0.00001, tBCH_RELAY_FEE: 0.00001 });
```

## Why decide it ourselves rather than clamp the server's answer

Electron Cash fetches `blockchain.relayfee`, stores it, wraps it in a helper that caps the top end, and then never uses it to build transactions. Its send fee comes from a local config value defaulting to 1 sat/byte (`simple_config.py`, `fee_per_kb`), and its dust threshold ignores the server value outright, with a comment saying it will reconsider "until/unless relay fees vary".

A wallet's fee policy should not depend on which server it happens to be connected to. What one server accepts into its own mempool is not what the network relays, and neither is what miners mine.

Flooring instead of pinning would mean querying the server anyway and taking `max(server, 1 sat/byte)`, since the global is read before the server is asked. That keeps the inverted dependency alive for no benefit. BCH has no fee market and the relay fee is a floor rather than a price, so a fixed 1 sat/byte is the same value a correctly configured server reports.

## Related

- The below-relay-fee warnings added earlier (`2d7ff46`, `c6040bc`, `6018cbe`) flag the reported transaction at `0.0 sat/byte`. They surface the symptom; this fixes the cause.
- Switching electrum server is a user-side workaround that works without this PR.
- Split out of this PR: the fungible token utxo selection defect, which has its own issue. It is unrelated to the fee and needs its own verification, since the behaviour it changes was put in place deliberately to prevent a token burn.
- Left for upstream: the fee estimate that picks the funding utxos is sized against the whole wallet rather than a plausible input set. It will show as over-selection now that the fee rate is no longer near zero.
