### PR TITLE
Wallet delete key cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,11 @@ v3 introduced breaking changes including HD wallet support with new classes (`HD
 - **@wizardconnect/core** & **@wizardconnect/wallet**: WizardConnect protocol for BCH HD-wallet dApp connections. Repo: https://gitlab.com/riftenlabs/lib/wizardconnect
 
 ### Persistent Storage
-- **IndexedDB** belongs to the libraries: mainnet-js keeps wallet key material there (via `@mainnet-cash/indexeddb-storage`, see Multi-Wallet Support) along with its electrum-history and HD-address caches, and WalletConnect keeps its session state there. The app itself only touches these databases through `dbUtils.ts` and the cache-size/clear and delete flows in the settings menu.
+- **IndexedDB** belongs to the libraries: mainnet-js keeps wallet key material there (via `@mainnet-cash/indexeddb-storage`, see Multi-Wallet Support) along with its electrum-history and HD-address caches, and WalletConnect keeps its session state there.
 - **localStorage** holds everything the app persists itself: all settings (one key each), the active wallet name and network, per-wallet-per-network private data (transaction notes, address marks and labels, WizardConnect session URIs), and a TTL cache of fetched metadata (`cachedFetch`).
+
+### Direct IndexedDB Access
+The app reaches into the libraries' databases with raw IndexedDB, in `dbUtils.ts` and the settings menu's cache-size/clear and delete flows, rather than through their APIs. Their internals are ours to get right there, versions and store names and key formats, and mistakes fail silently: opening one that does not exist yet creates it, and an owner that finds it already there never runs its own setup.
 
 ### Electrum Connections
 mainnet-js configures `@electrum-cash/web-socket` to keep connections alive across visibility changes (tab switches, app backgrounding, window minimizing) rather than disconnecting/reconnecting. This matters because wallet subscriptions (balance watches, token monitors) are fire-and-forget callbacks via `runAsyncVoid`, so forcibly rejected electrum requests would surface as uncaught promise errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ v3 introduced breaking changes including HD wallet support with new classes (`HD
 - **localStorage** holds everything the app persists itself: all settings (one key each), the active wallet name and network, per-wallet-per-network private data (transaction notes, address marks and labels, WizardConnect session URIs), and a TTL cache of fetched metadata (`cachedFetch`).
 
 ### Direct IndexedDB Access
-The app reaches into the libraries' databases with raw IndexedDB, in `dbUtils.ts` and the settings menu's cache-size/clear and delete flows, rather than through their APIs. Their internals are ours to get right there, versions and store names and key formats, and mistakes fail silently: opening one that does not exist yet creates it, and an owner that finds it already there never runs its own setup.
+The app reaches into mainnet-js's databases itself, in `dbUtils.ts` and the settings menu's cache-size/clear and delete flows. Some of that goes through mainnet-js's own storage provider, the rest is raw IndexedDB where not even that reaches. There we have to keep matching its versions, store names and key formats, and mistakes fail silently: opening a database that does not exist yet creates it, and mainnet-js finding it already there never runs its own setup.
 
 ### Electrum Connections
 mainnet-js configures `@electrum-cash/web-socket` to keep connections alive across visibility changes (tab switches, app backgrounding, window minimizing) rather than disconnecting/reconnecting. This matters because wallet subscriptions (balance watches, token monitors) are fire-and-forget callbacks via `runAsyncVoid`, so forcibly rejected electrum requests would surface as uncaught promise errors.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "autoprefixer": "^10.5.4",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.9.0",
     "jiti": "^2.7.0",
     "rollup-plugin-visualizer": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       eslint-plugin-vue:
         specifier: ^10.10.0
         version: 10.10.0(@typescript-eslint/parser@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       globals:
         specifier: ^17.9.0
         version: 17.9.0
@@ -1341,6 +1344,10 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4116,6 +4123,8 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.4.0: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/components/settings/walletsOverview.vue
+++ b/src/components/settings/walletsOverview.vue
@@ -87,9 +87,6 @@
     if (confirmed) {
       try {
         await store.deleteWallet(walletName);
-        // Clear backup status and metadata for deleted wallet
-        settingsStore.clearBackupStatus(walletName);
-        settingsStore.clearWalletMetadata(walletName);
         $q.notify({
           message: t('walletsOverview.deleteWallet.deleted', { name: walletName }),
           icon: 'info',

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -72,6 +72,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Das aktive Wallet kann nicht gelöscht werden",
+      "cachedKeysNotCleared": "Die Wallet wurde gelöscht, aber die von ihr zwischengespeicherten Schlüssel konnten nicht entfernt werden.",
       "walletNotFoundOnNetwork": "Wallet \"{name}\" existiert nicht auf {network}",
       "errorInitializingWalletConnect": "Fehler beim Initialisieren von WalletConnect",
       "errorInitializingCashConnect": "Fehler beim Initialisieren von CashConnect",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,6 +72,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Cannot delete the currently active wallet",
+      "cachedKeysNotCleared": "The wallet was deleted, but the keys it had cached could not be removed.",
       "walletNotFoundOnNetwork": "Wallet \"{name}\" does not exist on {network}",
       "errorInitializingWalletConnect": "Error initializing WalletConnect",
       "errorInitializingCashConnect": "Error initializing CashConnect",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -72,6 +72,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "No se puede eliminar la billetera actualmente activa",
+      "cachedKeysNotCleared": "La cartera fue eliminada, pero no se pudieron eliminar las claves que tenía en caché.",
       "walletNotFoundOnNetwork": "La billetera \"{name}\" no existe en {network}",
       "errorInitializingWalletConnect": "Error al inicializar WalletConnect",
       "errorInitializingCashConnect": "Error al inicializar CashConnect",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -72,6 +72,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Impossible de supprimer le portefeuille actuellement actif",
+      "cachedKeysNotCleared": "Le portefeuille a été supprimé, mais les clés qu'il avait mises en cache n'ont pas pu être retirées.",
       "walletNotFoundOnNetwork": "Le portefeuille \"{name}\" n'existe pas sur {network}",
       "errorInitializingWalletConnect": "Erreur lors de l'initialisation de WalletConnect",
       "errorInitializingCashConnect": "Erreur lors de l'initialisation de CashConnect",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -72,6 +72,7 @@
     },
     "errors": {
       "cannotDeleteActiveWallet": "Não é possível excluir a carteira ativa",
+      "cachedKeysNotCleared": "A carteira foi eliminada, mas as chaves que tinha em cache não puderam ser removidas.",
       "walletNotFoundOnNetwork": "A carteira \"{name}\" não existe em {network}",
       "errorInitializingWalletConnect": "Erro ao inicializar WalletConnect",
       "errorInitializingCashConnect": "Erro ao inicializar CashConnect",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -437,6 +437,13 @@ export const useSettingsStore = defineStore('settingsStore', () => {
     localStorage.setItem("walletMetadata", JSON.stringify(walletMetadata.value));
   }
 
+  // Everything per wallet is keyed by name, and a new wallet may take the name of a deleted one,
+  // so what the old one left has to go before the new one records anything of its own
+  function clearWalletSettings(walletName: string) {
+    clearBackupStatus(walletName);
+    clearWalletMetadata(walletName);
+  }
+
   function removeOldCacheData(){
     // remove tx- and header- keys from localStorage
     Object.keys(localStorage).forEach(key => {
@@ -481,6 +488,7 @@ export const useSettingsStore = defineStore('settingsStore', () => {
     getWalletType,
     setWalletType,
     clearWalletMetadata,
+    clearWalletSettings,
     mintNfts,
     authchains,
     strictWcSchema,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -437,8 +437,9 @@ export const useSettingsStore = defineStore('settingsStore', () => {
     localStorage.setItem("walletMetadata", JSON.stringify(walletMetadata.value));
   }
 
-  // Everything per wallet is keyed by name, and a new wallet may take the name of a deleted one,
-  // so what the old one left has to go before the new one records anything of its own
+  // A new wallet can take the name of a deleted one, and both the backup status and the wallet
+  // metadata are stored under that name, so the old wallet's have to go before the new one
+  // writes its own
   function clearWalletSettings(walletName: string) {
     clearBackupStatus(walletName);
     clearWalletMetadata(walletName);

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -48,7 +48,7 @@ import { useWizardconnectStore } from "./wizardconnectStore"
 import { displayAndLogError } from "src/utils/errorHandling"
 import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
-import { clearHdWalletKeyCache, deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/wallet/dbUtils"
+import { pruneHdWalletKeyCache, deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/wallet/dbUtils"
 import { fetchCauldronPrices, type CauldronPriceData } from "src/utils/defi/cauldronApi"
 import {
   fetchCauldronPools,
@@ -811,7 +811,7 @@ export const useStore = defineStore('store', () => {
     await deleteWalletFromDb(walletName, 'bchtest');
     // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
     // would still be able to spend from every address the deleted wallet used
-    await clearHdWalletKeyCache();
+    await pruneHdWalletKeyCache();
     removeTxNotes(walletName);
     removeAddressManagementData(walletName);
     // Refresh the available wallets list

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -721,11 +721,10 @@ export const useStore = defineStore('store', () => {
     if (!walletId) {
       throw new Error(t('store.errors.walletNotFoundOnNetwork', { name: walletName, network }));
     }
-    const metadata = settingsStore.getWalletMetadata(walletName);
-    if (!metadata?.walletType) {
-      const walletType = walletTypeFromWalletId(walletId);
-      settingsStore.setWalletType(walletName, walletType);
-    }
+    // The stored id says which kind this is, so write it every time rather than only when it is
+    // missing: metadata is keyed by wallet name, and a stale type from an earlier wallet of the
+    // same name would otherwise stand forever
+    settingsStore.setWalletType(walletName, walletTypeFromWalletId(walletId));
     const loadedWallet = await loadWalletFromId(walletId, network);
     loadedWallet.name = walletName;
     return loadedWallet;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -48,7 +48,7 @@ import { useWizardconnectStore } from "./wizardconnectStore"
 import { displayAndLogError } from "src/utils/errorHandling"
 import { cachedFetch } from "src/utils/cacheUtils"
 import { BcmrIndexerResponseSchema } from "src/utils/zodValidation"
-import { deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/wallet/dbUtils"
+import { clearHdWalletKeyCache, deleteWalletFromDb, getAllWalletsWithNetworkInfo, getNamedWalletIdFromDb, type WalletInfo } from "src/utils/wallet/dbUtils"
 import { fetchCauldronPrices, type CauldronPriceData } from "src/utils/defi/cauldronApi"
 import {
   fetchCauldronPools,
@@ -809,6 +809,9 @@ export const useStore = defineStore('store', () => {
     // Delete from both mainnet and testnet databases
     await deleteWalletFromDb(walletName, 'bitcoincash');
     await deleteWalletFromDb(walletName, 'bchtest');
+    // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
+    // would still be able to spend from every address the deleted wallet used
+    await clearHdWalletKeyCache();
     removeTxNotes(walletName);
     removeAddressManagementData(walletName);
     // Refresh the available wallets list

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -811,6 +811,8 @@ export const useStore = defineStore('store', () => {
     await deleteWalletFromDb(walletName, 'bchtest');
     removeTxNotes(walletName);
     removeAddressManagementData(walletName);
+    settingsStore.clearBackupStatus(walletName);
+    settingsStore.clearWalletMetadata(walletName);
     // Refresh the available wallets list
     await refreshAvailableWallets();
     // The seed is gone but mainnet-js caches a private key per address for HD wallets, which

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -815,9 +815,19 @@ export const useStore = defineStore('store', () => {
     // Refresh the available wallets list
     await refreshAvailableWallets();
     // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
-    // would still be able to spend from every address the deleted wallet used. Last, so that a
-    // failure here surfaces without leaving the rest of the deletion half done.
-    await pruneHdWalletKeyCache();
+    // would still be able to spend from every address the deleted wallet used. The wallet itself
+    // is already deleted by this point, so a failure here is reported on its own rather than
+    // making the whole deletion look like it failed.
+    try {
+      await pruneHdWalletKeyCache();
+    } catch (error) {
+      console.error(error);
+      Notify.create({
+        message: t('store.errors.cachedKeysNotCleared'),
+        icon: 'warning',
+        color: "red"
+      })
+    }
   }
 
   async function initializeWalletConnect() {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -813,10 +813,10 @@ export const useStore = defineStore('store', () => {
     settingsStore.clearWalletSettings(walletName);
     // Refresh the available wallets list
     await refreshAvailableWallets();
-    // mainnet-js caches a private key per address for HD wallets. This prunes every entry no
-    // remaining wallet owns rather than the departing one's, so it runs whichever kind just went
-    // and also collects what earlier deletions left behind. The wallet is already gone by now, so
-    // a failure here is reported on its own instead of failing the deletion.
+    // mainnet-js stores a private key for every address of an HD wallet. This deletes the cached
+    // keys of any wallet no longer in the databases, not only the one just deleted, so it also
+    // picks up keys left by wallets deleted before this existed, whatever kind just went.
+    // The wallet is already gone by now, so a failure here is not a failed deletion.
     try {
       await pruneHdWalletKeyCache();
     } catch (error) {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -810,14 +810,13 @@ export const useStore = defineStore('store', () => {
     await deleteWalletFromDb(walletName, 'bchtest');
     removeTxNotes(walletName);
     removeAddressManagementData(walletName);
-    settingsStore.clearBackupStatus(walletName);
-    settingsStore.clearWalletMetadata(walletName);
+    settingsStore.clearWalletSettings(walletName);
     // Refresh the available wallets list
     await refreshAvailableWallets();
-    // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
-    // would still be able to spend from every address the deleted wallet used. The wallet itself
-    // is already deleted by this point, so a failure here is reported on its own rather than
-    // making the whole deletion look like it failed.
+    // mainnet-js caches a private key per address for HD wallets. This prunes every entry no
+    // remaining wallet owns rather than the departing one's, so it runs whichever kind just went
+    // and also collects what earlier deletions left behind. The wallet is already gone by now, so
+    // a failure here is reported on its own instead of failing the deletion.
     try {
       await pruneHdWalletKeyCache();
     } catch (error) {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -809,13 +809,14 @@ export const useStore = defineStore('store', () => {
     // Delete from both mainnet and testnet databases
     await deleteWalletFromDb(walletName, 'bitcoincash');
     await deleteWalletFromDb(walletName, 'bchtest');
-    // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
-    // would still be able to spend from every address the deleted wallet used
-    await pruneHdWalletKeyCache();
     removeTxNotes(walletName);
     removeAddressManagementData(walletName);
     // Refresh the available wallets list
     await refreshAvailableWallets();
+    // The seed is gone but mainnet-js caches a private key per address for HD wallets, which
+    // would still be able to spend from every address the deleted wallet used. Last, so that a
+    // failure here surfaces without leaving the rest of the deletion half done.
+    await pruneHdWalletKeyCache();
   }
 
   async function initializeWalletConnect() {

--- a/src/utils/cacheUtils.ts
+++ b/src/utils/cacheUtils.ts
@@ -1,4 +1,4 @@
-import { binToHex, sha256, utf8ToBin } from 'mainnet-js';
+import { binToHex, sha256, utf8ToBin } from '@bitauth/libauth';
 
 const CACHE_TTL_DAYS = 7;
 const CACHE_TTL_MS = CACHE_TTL_DAYS * 24 * 60 * 60 * 1000;

--- a/src/utils/cacheUtils.ts
+++ b/src/utils/cacheUtils.ts
@@ -16,9 +16,14 @@ export async function clearElectrumCache(): Promise<void> {
 
 /* Native IndexedDB helper functions */
 
+// Object stores can only be created during an upgrade, which runs only when the version asked
+// for is higher than the one stored. Opening without a version creates this database at version
+// 1 with no store, and mainnet-js opens its caches at version 1 too, so it would never upgrade
+// and never add its own. Match its version and create the store, which it names after the database.
 export async function openIndexedDB(dbName: string): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const openRequest = indexedDB.open(dbName);
+    const openRequest = indexedDB.open(dbName, 1);
+    openRequest.onupgradeneeded = () => openRequest.result.createObjectStore(dbName);
     openRequest.onsuccess = () => resolve(openRequest.result);
     openRequest.onerror = () => reject(new Error("Error opening IndexedDB"));
   });

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -111,3 +111,49 @@ export async function deleteWalletFromDb(
     };
   });
 }
+
+// For HD wallets mainnet-js keeps a derived private key per address in a database of its own,
+// so deleting a wallet has to clear that too or spendable key material outlives the wallet it
+// belonged to. Single-address wallets hold their key in memory and leave nothing here.
+//
+// Everything goes rather than the one wallet's entry, for two reasons. The entries are keyed by
+// a hash of the seed rather than by the wallet name, so reproducing that derivation here would
+// silently stop matching if mainnet-js ever changed it, which is a poor failure mode for
+// deleting key material. And a cache entry costs only an address rescan to rebuild, so the
+// price of clearing another wallet's is small and paid once.
+//
+// The store is cleared rather than the database deleted: deleteDatabase blocks on the open
+// connection the running wallet holds, and nothing reloads the page here to close it.
+export async function clearHdWalletKeyCache(): Promise<void> {
+  // mainnet-js passes this one name as both the database and the object store
+  const CACHE_DB = "WalletCache";
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(CACHE_DB);
+
+    request.onerror = () => reject(new Error(`Failed to open database: ${CACHE_DB}`));
+
+    request.onsuccess = () => {
+      const db = request.result;
+      // nothing cached yet, so nothing to clear
+      if (!db.objectStoreNames.contains(CACHE_DB)) {
+        db.close();
+        resolve();
+        return;
+      }
+
+      const dbTx = db.transaction(CACHE_DB, "readwrite");
+      const clearRequest = dbTx.objectStore(CACHE_DB).clear();
+
+      clearRequest.onsuccess = () => {
+        db.close();
+        resolve();
+      };
+
+      clearRequest.onerror = () => {
+        db.close();
+        reject(new Error(`Failed to clear the HD wallet key cache`));
+      };
+    };
+  });
+}

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -136,16 +136,26 @@ export function hdWalletCacheKey(storedWalletId: string): string | undefined {
 }
 
 // Every wallet's stored id, both networks, for callers matching records that are keyed by
-// wallet rather than by name
-export async function getAllStoredWalletIds(): Promise<string[]> {
-  const wallets = await getAllWalletsWithNetworkInfo();
-  const lookups: Promise<string | undefined>[] = [];
-  for (const wallet of wallets) {
-    if (wallet.hasMainnet) lookups.push(getNamedWalletIdFromDb(wallet.name, "bitcoincash"));
-    if (wallet.hasChipnet) lookups.push(getNamedWalletIdFromDb(wallet.name, "bchtest"));
+// wallet rather than by name. Each database is read once, since getWallets already returns the
+// stored id alongside the name.
+async function getAllStoredWalletIds(): Promise<string[]> {
+  const mainnetDb = new IndexedDBProvider("bitcoincash");
+  const chipnetDb = new IndexedDBProvider("bchtest");
+  await Promise.all([mainnetDb.init(), chipnetDb.init()]);
+
+  try {
+    const [mainnetWallets, chipnetWallets] = await Promise.all([
+      mainnetDb.getWallets(),
+      chipnetDb.getWallets()
+    ]);
+    const storedIds: string[] = [];
+    for (const walletEntry of [...mainnetWallets, ...chipnetWallets]) {
+      if (walletEntry.wallet) storedIds.push(walletEntry.wallet);
+    }
+    return storedIds;
+  } finally {
+    await Promise.all([mainnetDb.close(), chipnetDb.close()]);
   }
-  const storedIds = await Promise.all(lookups);
-  return storedIds.filter((storedId): storedId is string => storedId !== undefined);
 }
 
 // Drops every cache entry that belongs to no wallet still in the databases. Pruning against the

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -84,6 +84,9 @@ export async function deleteWalletFromDb(
   const STORE_NAME = "wallet";
 
   return new Promise((resolve, reject) => {
+    // Opening without a version is safe for these two, unlike for the caches below:
+    // IndexedDBProvider asks for version 31, so a database created here at version 1 still gets
+    // its upgrade, and its store, the next time mainnet-js opens it.
     const request = indexedDB.open(dbName);
 
     request.onerror = () => reject(new Error(`Failed to open database: ${dbName}`));
@@ -190,7 +193,9 @@ export async function pruneHdWalletKeyCache(): Promise<void> {
 
     request.onsuccess = () => {
       const db = request.result;
-      // nothing has ever been cached, so nothing to prune
+      // a fresh database gets its store from the upgrade above, so reaching here means something
+      // else left this one without one. Adding it now would take a version mainnet-js never asks
+      // for, so the only safe move is to leave it be.
       if (!db.objectStoreNames.contains(CACHE_DB)) {
         db.close();
         resolve();

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -168,9 +168,14 @@ export async function pruneHdWalletKeyCache(): Promise<void> {
   }
 
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(CACHE_DB);
+    // Opening without a version creates the database empty when it does not exist yet, and
+    // mainnet-js only ever opens it at version 1, so its own upgrade would never fire and it
+    // could never add its store. Match its version and create the store the same way it does.
+    const request = indexedDB.open(CACHE_DB, 1);
 
     request.onerror = () => reject(new Error(`Failed to open database: ${CACHE_DB}`));
+
+    request.onupgradeneeded = () => request.result.createObjectStore(CACHE_DB);
 
     request.onsuccess = () => {
       const db = request.result;

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -168,9 +168,10 @@ export async function pruneHdWalletKeyCache(): Promise<void> {
   }
 
   return new Promise((resolve, reject) => {
-    // Opening without a version creates the database empty when it does not exist yet, and
-    // mainnet-js only ever opens it at version 1, so its own upgrade would never fire and it
-    // could never add its store. Match its version and create the store the same way it does.
+    // Object stores can only be created during an upgrade, which runs only when the version
+    // asked for is higher than the one stored. Opening without a version creates this database
+    // at version 1 with no store, and mainnet-js only ever asks for version 1, so it would never
+    // upgrade and never get to add its own. Match its version and create the store too.
     const request = indexedDB.open(CACHE_DB, 1);
 
     request.onerror = () => reject(new Error(`Failed to open database: ${CACHE_DB}`));

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -7,6 +7,15 @@ export interface WalletInfo {
   hasChipnet: boolean;
 }
 
+//-----------------------------------------------------------------------------
+// Through mainnet-js's own storage provider
+//-----------------------------------------------------------------------------
+// IndexedDBProvider is mainnet-js's own class, so the database name, its version and the shape
+// of a record stay its business. Only the layer above it is bypassed, for the reasons below.
+
+// BaseWallet.namedExists reads the same record, but constructs a wallet to get there, and that
+// builds an electrum client and network provider, which becomes the session's global one when
+// there is none yet.
 export async function namedWalletExistsInDb(
   name: string,
   dbName: "bitcoincash" | "bchtest"
@@ -22,6 +31,7 @@ export async function namedWalletExistsInDb(
   }
 }
 
+// mainnet-js has no wallet listing above the storage provider, so this uses its getWallets().
 export async function getAllWalletsWithNetworkInfo(): Promise<WalletInfo[]> {
   // Get wallets from both networks
   const mainnetDb = new IndexedDBProvider("bitcoincash");
@@ -56,8 +66,8 @@ export async function getAllWalletsWithNetworkInfo(): Promise<WalletInfo[]> {
   }
 }
 
-// Mirrors the IndexedDB lookup inside mainnet-js BaseWallet.named(), but stops after
-// reading the saved walletId. Calling .named() directly would create a new wallet if missing.
+// mainnet-js's getNamedWalletId reads the same record, but throws when the name is not in that
+// database. A wallet legitimately exists on one network only, so the caller needs that returned.
 export async function getNamedWalletIdFromDb(
   name: string,
   dbName: "bitcoincash" | "bchtest"
@@ -73,6 +83,12 @@ export async function getNamedWalletIdFromDb(
     await db.close();
   }
 }
+
+//-----------------------------------------------------------------------------
+// Raw IndexedDB
+//-----------------------------------------------------------------------------
+// Deleting is the one thing mainnet-js offers no way to do, neither on BaseWallet nor on the
+// StorageProvider interface, so the database is opened directly and its store name matched here.
 
 export async function deleteWalletFromDb(
   name: string,
@@ -117,7 +133,7 @@ export async function deleteWalletFromDb(
 }
 
 //-----------------------------------------------------------------------------
-// HD wallet key cache
+// HD wallet key cache (Raw IndexedDB)
 //-----------------------------------------------------------------------------
 // Everything above works on the mainnet-js wallet databases, everything below on the separate
 // one holding its HD address cache.
@@ -125,6 +141,9 @@ export async function deleteWalletFromDb(
 // For HD wallets mainnet-js keeps a derived private key per address in a database of its own,
 // so deleting a wallet has to clear that too or spendable key material outlives the wallet it
 // belonged to. Single-address wallets hold their key in memory and leave nothing here.
+//
+// mainnet-js does not export the class it reads that database with, and it could not list what
+// it holds anyway, which the prune needs.
 
 // mainnet-js keys those entries by a hash of the seed rather than by the wallet name, so the key
 // has to be rebuilt from the stored wallet record. Mirrors HDWallet's own derivation.

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -157,9 +157,9 @@ export function hdWalletCacheKey(storedWalletId: string): string | undefined {
   return `walletCache-${walletId}`;
 }
 
-// Every wallet's stored id, both networks, for callers matching records that are keyed by
-// wallet rather than by name. Each database is read once, since getWallets already returns the
-// stored id alongside the name.
+// Every wallet's stored id, from both databases. The prune needs these to work out which cached
+// keys still belong to a wallet. Each database is read once, since getWallets already returns the
+// stored id next to the name.
 async function getAllStoredWalletIds(): Promise<string[]> {
   const mainnetDb = new IndexedDBProvider("bitcoincash");
   const chipnetDb = new IndexedDBProvider("bchtest");
@@ -180,15 +180,13 @@ async function getAllStoredWalletIds(): Promise<string[]> {
   }
 }
 
-// Drops every cache entry that belongs to no wallet still in the databases. Pruning against the
-// wallets that remain, rather than deleting the entries of the one that just went, is what lets
-// this also collect what earlier deletions orphaned, from before anything cleaned up here at all.
+// Deletes the cached keys of every wallet that is no longer in the databases. Deleting a wallet
+// left these keys behind up to and including v0.12, so working from the wallets that remain
+// rather than from the one just deleted is what clears those too, and matching no current wallet
+// is the expected state for anyone upgrading rather than a sign something is wrong.
 //
-// It degrades safely too: if hdWalletCacheKey ever stopped agreeing with mainnet-js, every entry
-// would look orphaned and be dropped, costing an address rescan rather than leaving keys behind.
-//
-// The entries go one by one rather than the database being deleted, since deleteDatabase blocks
-// on the open connection the running wallet holds and nothing reloads the page here to close it.
+// Keys are deleted one at a time rather than the database dropped, because deleteDatabase waits
+// on the connection the running wallet holds open and nothing reloads the page here to close it.
 export async function pruneHdWalletKeyCache(): Promise<void> {
   // mainnet-js passes this one name as both the database and the object store
   const CACHE_DB = "WalletCache";

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -1,4 +1,5 @@
 import { IndexedDBProvider } from "@mainnet-cash/indexeddb-storage"
+import { binToHex, sha256, utf8ToBin } from "@bitauth/libauth"
 
 export interface WalletInfo {
   name: string;
@@ -115,18 +116,48 @@ export async function deleteWalletFromDb(
 // For HD wallets mainnet-js keeps a derived private key per address in a database of its own,
 // so deleting a wallet has to clear that too or spendable key material outlives the wallet it
 // belonged to. Single-address wallets hold their key in memory and leave nothing here.
+
+// mainnet-js keys those entries by a hash of the seed rather than by the wallet name, so the key
+// has to be rebuilt from the stored wallet record. Mirrors HDWallet's own derivation.
+export function hdWalletCacheKey(storedWalletId: string): string | undefined {
+  const [walletType, network, secret, fourthField] = storedWalletId.split(":");
+  if (walletType !== "hd" || !network || !secret) return undefined;
+  // mnemonic wallets store the derivation path after the mnemonic and hash the two together,
+  // xpriv and xpub wallets hash the key on its own
+  const seedSource = fourthField?.startsWith("m/") ? secret + fourthField : secret;
+  const walletId = binToHex(sha256.hash(utf8ToBin(`${seedSource}-${network}`)));
+  return `walletCache-${walletId}`;
+}
+
+// Every wallet's stored id, both networks, for callers matching records that are keyed by
+// wallet rather than by name
+export async function getAllStoredWalletIds(): Promise<string[]> {
+  const wallets = await getAllWalletsWithNetworkInfo();
+  const lookups: Promise<string | undefined>[] = [];
+  for (const wallet of wallets) {
+    if (wallet.hasMainnet) lookups.push(getNamedWalletIdFromDb(wallet.name, "bitcoincash"));
+    if (wallet.hasChipnet) lookups.push(getNamedWalletIdFromDb(wallet.name, "bchtest"));
+  }
+  const storedIds = await Promise.all(lookups);
+  return storedIds.filter((storedId): storedId is string => storedId !== undefined);
+}
+
+// Drops every cache entry that belongs to no wallet still in the databases. Pruning against the
+// wallets that remain, rather than deleting the entries of the one that just went, is what lets
+// this also collect what earlier deletions orphaned, from before anything cleaned up here at all.
 //
-// Everything goes rather than the one wallet's entry, for two reasons. The entries are keyed by
-// a hash of the seed rather than by the wallet name, so reproducing that derivation here would
-// silently stop matching if mainnet-js ever changed it, which is a poor failure mode for
-// deleting key material. And a cache entry costs only an address rescan to rebuild, so the
-// price of clearing another wallet's is small and paid once.
+// It degrades safely too: if hdWalletCacheKey ever stopped agreeing with mainnet-js, every entry
+// would look orphaned and be dropped, costing an address rescan rather than leaving keys behind.
 //
-// The store is cleared rather than the database deleted: deleteDatabase blocks on the open
-// connection the running wallet holds, and nothing reloads the page here to close it.
-export async function clearHdWalletKeyCache(): Promise<void> {
+// The entries go one by one rather than the database being deleted, since deleteDatabase blocks
+// on the open connection the running wallet holds and nothing reloads the page here to close it.
+export async function pruneHdWalletKeyCache(): Promise<void> {
   // mainnet-js passes this one name as both the database and the object store
   const CACHE_DB = "WalletCache";
+
+  const liveCacheKeys = (await getAllStoredWalletIds())
+    .map(hdWalletCacheKey)
+    .filter((cacheKey): cacheKey is string => cacheKey !== undefined);
 
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(CACHE_DB);
@@ -135,24 +166,39 @@ export async function clearHdWalletKeyCache(): Promise<void> {
 
     request.onsuccess = () => {
       const db = request.result;
-      // nothing cached yet, so nothing to clear
+      // nothing has ever been cached, so nothing to prune
       if (!db.objectStoreNames.contains(CACHE_DB)) {
         db.close();
         resolve();
         return;
       }
 
-      const dbTx = db.transaction(CACHE_DB, "readwrite");
-      const clearRequest = dbTx.objectStore(CACHE_DB).clear();
+      const objectStore = db.transaction(CACHE_DB, "readwrite").objectStore(CACHE_DB);
+      const keysRequest = objectStore.getAllKeys();
 
-      clearRequest.onsuccess = () => {
+      keysRequest.onerror = () => {
         db.close();
-        resolve();
+        reject(new Error("Failed to read the HD wallet key cache"));
       };
 
-      clearRequest.onerror = () => {
-        db.close();
-        reject(new Error(`Failed to clear the HD wallet key cache`));
+      keysRequest.onsuccess = () => {
+        // anything that is not one of mainnet-js's string keys is left alone rather than
+        // deleted, since it is not ours to interpret
+        const orphaned = keysRequest.result.filter(
+          (cacheKey) => typeof cacheKey === "string" && !liveCacheKeys.includes(cacheKey)
+        );
+        for (const cacheKey of orphaned) {
+          objectStore.delete(cacheKey);
+        }
+        // the transaction carries the deletes, so wait on it rather than on each request
+        objectStore.transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        objectStore.transaction.onerror = () => {
+          db.close();
+          reject(new Error("Failed to prune the HD wallet key cache"));
+        };
       };
     };
   });

--- a/src/utils/wallet/dbUtils.ts
+++ b/src/utils/wallet/dbUtils.ts
@@ -113,6 +113,12 @@ export async function deleteWalletFromDb(
   });
 }
 
+//-----------------------------------------------------------------------------
+// HD wallet key cache
+//-----------------------------------------------------------------------------
+// Everything above works on the mainnet-js wallet databases, everything below on the separate
+// one holding its HD address cache.
+//
 // For HD wallets mainnet-js keeps a derived private key per address in a database of its own,
 // so deleting a wallet has to clear that too or spendable key material outlives the wallet it
 // belonged to. Single-address wallets hold their key in memory and leave nothing here.
@@ -155,9 +161,11 @@ export async function pruneHdWalletKeyCache(): Promise<void> {
   // mainnet-js passes this one name as both the database and the object store
   const CACHE_DB = "WalletCache";
 
-  const liveCacheKeys = (await getAllStoredWalletIds())
-    .map(hdWalletCacheKey)
-    .filter((cacheKey): cacheKey is string => cacheKey !== undefined);
+  const liveCacheKeys: string[] = [];
+  for (const storedWalletId of await getAllStoredWalletIds()) {
+    const cacheKey = hdWalletCacheKey(storedWalletId);
+    if (cacheKey) liveCacheKeys.push(cacheKey);
+  }
 
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(CACHE_DB);

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -183,16 +183,14 @@ export async function createNewWallet(name: string): Promise<WalletOperationResu
     // Refresh available wallets list
     await store.refreshAvailableWallets();
 
+    // A new wallet can take the name of a deleted one, and everything per wallet is keyed by
+    // name, so drop what the old one left before recording anything of this one's
+    settingsStore.clearWalletSettings(trimmedName);
     // Fire-and-forget: don't wait on full wallet initialization
     void store.initializeWallet();
 
     // Store wallet creation date
     settingsStore.setWalletCreatedAt(trimmedName);
-    // Backup status is keyed by wallet name, so clear whatever a previous wallet of this name
-    // left behind. Nothing else on this path writes it, and a stale 'verified' would tell the
-    // user a seed they have never seen is already backed up.
-    settingsStore.clearBackupStatus(trimmedName);
-    settingsStore.setWalletType(trimmedName, 'single');
 
     return { success: true, walletName: trimmedName };
   } catch (error) {
@@ -271,9 +269,9 @@ export async function importWallet(params: ImportWalletParams): Promise<WalletOp
     // Fire-and-forget: don't wait on full wallet initialization
     void store.initializeWallet();
 
+    settingsStore.clearWalletSettings(trimmedName);
     // Mark as 'imported' - user already demonstrated having the seed phrase
     settingsStore.setBackupStatus(trimmedName, 'imported');
-    settingsStore.setWalletType(trimmedName, 'single');
 
     // Store wallet creation date (import date)
     settingsStore.setWalletCreatedAt(trimmedName);
@@ -322,11 +320,10 @@ export async function createNewHDWallet(name: string): Promise<WalletOperationRe
     await store.resetWalletState();
     store.setWallet(mainnetWallet);
 
+    settingsStore.clearWalletSettings(trimmedName);
     // Set wallet type BEFORE initializeWallet (which validates type matches)
     settingsStore.setWalletType(trimmedName, 'hd');
     settingsStore.setWalletCreatedAt(trimmedName);
-    // as in createNewWallet, drop a backup status an earlier wallet of this name left behind
-    settingsStore.clearBackupStatus(trimmedName);
 
     await store.refreshAvailableWallets();
     void store.initializeWallet();
@@ -393,6 +390,7 @@ export async function importHDWallet(params: ImportWalletParams): Promise<Wallet
     await store.resetWalletState();
     store.setWallet(mainnetWallet);
 
+    settingsStore.clearWalletSettings(trimmedName);
     // Set wallet type BEFORE initializeWallet (which validates type matches)
     settingsStore.setWalletType(trimmedName, 'hd');
     settingsStore.setBackupStatus(trimmedName, 'imported');

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -273,6 +273,7 @@ export async function importWallet(params: ImportWalletParams): Promise<WalletOp
 
     // Mark as 'imported' - user already demonstrated having the seed phrase
     settingsStore.setBackupStatus(trimmedName, 'imported');
+    settingsStore.setWalletType(trimmedName, 'single');
 
     // Store wallet creation date (import date)
     settingsStore.setWalletCreatedAt(trimmedName);

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -191,7 +191,7 @@ export async function createNewWallet(name: string): Promise<WalletOperationResu
     // Backup status is keyed by wallet name, so clear whatever a previous wallet of this name
     // left behind. Nothing else on this path writes it, and a stale 'verified' would tell the
     // user a seed they have never seen is already backed up.
-    settingsStore.setBackupStatus(trimmedName, 'none');
+    settingsStore.clearBackupStatus(trimmedName);
     settingsStore.setWalletType(trimmedName, 'single');
 
     return { success: true, walletName: trimmedName };
@@ -324,6 +324,8 @@ export async function createNewHDWallet(name: string): Promise<WalletOperationRe
     // Set wallet type BEFORE initializeWallet (which validates type matches)
     settingsStore.setWalletType(trimmedName, 'hd');
     settingsStore.setWalletCreatedAt(trimmedName);
+    // as in createNewWallet, drop a backup status an earlier wallet of this name left behind
+    settingsStore.clearBackupStatus(trimmedName);
 
     await store.refreshAvailableWallets();
     void store.initializeWallet();

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -266,10 +266,10 @@ export async function importWallet(params: ImportWalletParams): Promise<WalletOp
     // Refresh available wallets list
     await store.refreshAvailableWallets();
 
+    settingsStore.clearWalletSettings(trimmedName);
     // Fire-and-forget: don't wait on full wallet initialization
     void store.initializeWallet();
 
-    settingsStore.clearWalletSettings(trimmedName);
     // Mark as 'imported' - user already demonstrated having the seed phrase
     settingsStore.setBackupStatus(trimmedName, 'imported');
 

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -192,6 +192,7 @@ export async function createNewWallet(name: string): Promise<WalletOperationResu
     // left behind. Nothing else on this path writes it, and a stale 'verified' would tell the
     // user a seed they have never seen is already backed up.
     settingsStore.setBackupStatus(trimmedName, 'none');
+    settingsStore.setWalletType(trimmedName, 'single');
 
     return { success: true, walletName: trimmedName };
   } catch (error) {

--- a/src/utils/wallet/walletUtils.ts
+++ b/src/utils/wallet/walletUtils.ts
@@ -188,6 +188,10 @@ export async function createNewWallet(name: string): Promise<WalletOperationResu
 
     // Store wallet creation date
     settingsStore.setWalletCreatedAt(trimmedName);
+    // Backup status is keyed by wallet name, so clear whatever a previous wallet of this name
+    // left behind. Nothing else on this path writes it, and a stale 'verified' would tell the
+    // user a seed they have never seen is already backed up.
+    settingsStore.setBackupStatus(trimmedName, 'none');
 
     return { success: true, walletName: trimmedName };
   } catch (error) {

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -1,7 +1,7 @@
 import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { IndexedDBProvider } from "@mainnet-cash/indexeddb-storage";
-import { pruneHdWalletKeyCache, hdWalletCacheKey } from "../src/utils/wallet/dbUtils";
+import { pruneHdWalletKeyCache, hdWalletCacheKey, deleteWalletFromDb } from "../src/utils/wallet/dbUtils";
 import { openIndexedDB } from "../src/utils/cacheUtils";
 
 // These run against a real IndexedDB implementation rather than a mock on purpose: both bugs
@@ -62,7 +62,9 @@ async function cacheKeys(): Promise<IDBValidKey[]> {
 }
 
 // mainnet-js reads its cache through a transaction on that store, so a database left without one
-// throws here. This is what a wallet hits when creating or importing an HD wallet.
+// throws NotFoundError here. Its own try/catch covers only the JSON parse, so the throw takes
+// PersistentWalletCache.init() with it and creating or importing an HD wallet fails outright,
+// for that browser profile, permanently.
 async function mainnetJsCanUseCache(dbName: string): Promise<boolean> {
   const db = await openLikeMainnetJs(dbName);
   try {
@@ -175,5 +177,24 @@ describe('openIndexedDB', () => {
     db.close();
 
     expect(value).toBe("cached");
+  });
+});
+
+describe('deleteWalletFromDb', () => {
+  // This one opens without a version, unlike the caches, and is only safe because
+  // IndexedDBProvider asks for 31: a database created here at version 1 still gets its upgrade,
+  // and its store, when mainnet-js next opens it
+  it('leaves a database mainnet-js can still add wallets to', async () => {
+    // deleting from a network the wallet was never on is reachable today, since deleteWallet
+    // always tries both and wallets can exist on one network only
+    await deleteWalletFromDb("neverExisted", "bchtest");
+
+    const db = new IndexedDBProvider("bchtest");
+    await db.init();
+    await db.addWallet("later", hdWalletId(mnemonic, "testnet"));
+    const stored = await db.getWallet("later");
+    await db.close();
+
+    expect(stored?.wallet).toBe(hdWalletId(mnemonic, "testnet"));
   });
 });

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -184,6 +184,54 @@ describe('deleteWalletFromDb', () => {
   // This one opens without a version, unlike the caches, and is only safe because
   // IndexedDBProvider asks for 31: a database created here at version 1 still gets its upgrade,
   // and its store, when mainnet-js next opens it
+  it('removes the record it names and leaves the other wallets', async () => {
+    await addWallet("bitcoincash", "goes", hdWalletId(mnemonic, "mainnet"));
+    await addWallet("bitcoincash", "stays", hdWalletId(otherMnemonic, "mainnet"));
+
+    await deleteWalletFromDb("goes", "bitcoincash");
+
+    const db = new IndexedDBProvider("bitcoincash");
+    await db.init();
+    const goes = await db.getWallet("goes");
+    const stays = await db.getWallet("stays");
+    await db.close();
+
+    expect(goes).toBeUndefined();
+    expect(stays?.wallet).toBe(hdWalletId(otherMnemonic, "mainnet"));
+  });
+
+  // deleteWallet calls this once per network, so each call has to touch only its own database
+  it('leaves the same wallet on the other network alone', async () => {
+    await addWallet("bitcoincash", "both", hdWalletId(mnemonic, "mainnet"));
+    await addWallet("bchtest", "both", hdWalletId(mnemonic, "testnet"));
+
+    await deleteWalletFromDb("both", "bitcoincash");
+
+    const mainnetDb = new IndexedDBProvider("bitcoincash");
+    const chipnetDb = new IndexedDBProvider("bchtest");
+    await Promise.all([mainnetDb.init(), chipnetDb.init()]);
+    const fromMainnet = await mainnetDb.getWallet("both");
+    const fromChipnet = await chipnetDb.getWallet("both");
+    await Promise.all([mainnetDb.close(), chipnetDb.close()]);
+
+    expect(fromMainnet).toBeUndefined();
+    expect(fromChipnet?.wallet).toBe(hdWalletId(mnemonic, "testnet"));
+  });
+
+  // a database left without the wallet store holds no record to remove, so resolving is the
+  // honest answer rather than a failure
+  it('resolves when the database has no wallet store', async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("bitcoincash", 1);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(new Error("Failed to open bitcoincash"));
+    });
+    expect([...db.objectStoreNames]).toEqual([]);
+    db.close();
+
+    await expect(deleteWalletFromDb("anything", "bitcoincash")).resolves.toBeUndefined();
+  });
+
   it('leaves a database mainnet-js can still add wallets to', async () => {
     // deleting from a network the wallet was never on is reachable today, since deleteWallet
     // always tries both and wallets can exist on one network only

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -1,0 +1,179 @@
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { IndexedDBProvider } from "@mainnet-cash/indexeddb-storage";
+import { pruneHdWalletKeyCache, hdWalletCacheKey } from "../src/utils/wallet/dbUtils";
+import { openIndexedDB } from "../src/utils/cacheUtils";
+
+// These run against a real IndexedDB implementation rather than a mock on purpose: both bugs
+// this file guards against were in IndexedDB's own versioning rules, which a stub would model
+// however we told it to and would have reported as passing.
+
+const CACHE_DB = "WalletCache";
+const ELECTRUM_CACHE_DB = "ElectrumNetworkProviderCache";
+
+const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const otherMnemonic = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong";
+const derivation = "m/44'/145'/0'";
+const hdWalletId = (seed: string, network: string) => `hd:${network}:${seed}:${derivation}:0:0`;
+
+// every test starts from a browser profile that has never run the app
+beforeEach(() => {
+  globalThis.indexedDB = new IDBFactory();
+});
+
+async function addWallet(dbName: "bitcoincash" | "bchtest", name: string, storedWalletId: string) {
+  const db = new IndexedDBProvider(dbName);
+  await db.init();
+  await db.addWallet(name, storedWalletId);
+  await db.close();
+}
+
+// opens the key cache the way mainnet-js does: database and store share one name, version 1,
+// and the store is only ever created from the upgrade
+function openLikeMainnetJs(dbName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(dbName, 1);
+    request.onupgradeneeded = () => request.result.createObjectStore(dbName);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error(`Failed to open ${dbName}`));
+  });
+}
+
+async function seedCache(entries: [IDBValidKey, unknown][]) {
+  const db = await openLikeMainnetJs(CACHE_DB);
+  await new Promise<void>((resolve, reject) => {
+    const objectStore = db.transaction(CACHE_DB, "readwrite").objectStore(CACHE_DB);
+    for (const [key, value] of entries) objectStore.put(value, key);
+    objectStore.transaction.oncomplete = () => resolve();
+    objectStore.transaction.onerror = () => reject(new Error("Failed to seed the cache"));
+  });
+  db.close();
+}
+
+async function cacheKeys(): Promise<IDBValidKey[]> {
+  const db = await openLikeMainnetJs(CACHE_DB);
+  const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+    const request = db.transaction(CACHE_DB, "readonly").objectStore(CACHE_DB).getAllKeys();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error("Failed to read the cache keys"));
+  });
+  db.close();
+  return keys;
+}
+
+// mainnet-js reads its cache through a transaction on that store, so a database left without one
+// throws here. This is what a wallet hits when creating or importing an HD wallet.
+async function mainnetJsCanUseCache(dbName: string): Promise<boolean> {
+  const db = await openLikeMainnetJs(dbName);
+  try {
+    db.transaction(dbName, "readonly");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
+describe('pruneHdWalletKeyCache', () => {
+  it('removes the entries of wallets that are gone and keeps the ones still in the databases', async () => {
+    await addWallet("bitcoincash", "kept", hdWalletId(mnemonic, "mainnet"));
+    await addWallet("bchtest", "kept", hdWalletId(mnemonic, "testnet"));
+
+    const liveMainnet = hdWalletCacheKey(hdWalletId(mnemonic, "mainnet")) as string;
+    const liveTestnet = hdWalletCacheKey(hdWalletId(mnemonic, "testnet")) as string;
+    const orphan = hdWalletCacheKey(hdWalletId(otherMnemonic, "mainnet")) as string;
+    await seedCache([[liveMainnet, { a: 1 }], [liveTestnet, { a: 2 }], [orphan, { a: 3 }]]);
+
+    await pruneHdWalletKeyCache();
+
+    const remaining = await cacheKeys();
+    expect(remaining).toContain(liveMainnet);
+    expect(remaining).toContain(liveTestnet);
+    expect(remaining).not.toContain(orphan);
+  });
+
+  it('keeps a wallet that has only ever been used on one network', async () => {
+    await addWallet("bitcoincash", "kept", hdWalletId(mnemonic, "mainnet"));
+    await addWallet("bchtest", "kept", hdWalletId(mnemonic, "testnet"));
+    // used on mainnet only, so no chipnet entry was ever written
+    const liveMainnet = hdWalletCacheKey(hdWalletId(mnemonic, "mainnet")) as string;
+    await seedCache([[liveMainnet, { a: 1 }]]);
+
+    await pruneHdWalletKeyCache();
+
+    expect(await cacheKeys()).toEqual([liveMainnet]);
+  });
+
+  it('removes every entry once the last wallet is deleted', async () => {
+    const orphanOne = hdWalletCacheKey(hdWalletId(mnemonic, "mainnet")) as string;
+    const orphanTwo = hdWalletCacheKey(hdWalletId(otherMnemonic, "mainnet")) as string;
+    await seedCache([[orphanOne, { a: 1 }], [orphanTwo, { a: 2 }]]);
+
+    await pruneHdWalletKeyCache();
+
+    expect(await cacheKeys()).toEqual([]);
+  });
+
+  it('contributes no keys for single-address wallets, which cache nothing here', async () => {
+    await addWallet("bitcoincash", "single", `seed:mainnet:${mnemonic}:${derivation}`);
+    const orphan = hdWalletCacheKey(hdWalletId(mnemonic, "mainnet")) as string;
+    await seedCache([[orphan, { a: 1 }]]);
+
+    await pruneHdWalletKeyCache();
+
+    // the single-address wallet protects nothing, so the stale entry still goes
+    expect(await cacheKeys()).toEqual([]);
+  });
+
+  it('leaves keys that are not mainnet-js strings alone', async () => {
+    const orphan = hdWalletCacheKey(hdWalletId(mnemonic, "mainnet")) as string;
+    await seedCache([[42, { a: 1 }], [orphan, { a: 2 }]]);
+
+    await pruneHdWalletKeyCache();
+
+    expect(await cacheKeys()).toEqual([42]);
+  });
+
+  it('leaves a database mainnet-js can still initialise when nothing was ever cached', async () => {
+    // the reachable case: every wallet is single-address, so the user deletes one and the prune
+    // is the first thing ever to open this database
+    await pruneHdWalletKeyCache();
+
+    expect(await mainnetJsCanUseCache(CACHE_DB)).toBe(true);
+  });
+
+  it('resolves without error when nothing was ever cached', async () => {
+    await expect(pruneHdWalletKeyCache()).resolves.toBeUndefined();
+  });
+});
+
+describe('openIndexedDB', () => {
+  it('leaves a database mainnet-js can still initialise', async () => {
+    // reading the cache size from the settings menu must not be able to break the electrum cache
+    const db = await openIndexedDB(ELECTRUM_CACHE_DB);
+    db.close();
+
+    expect(await mainnetJsCanUseCache(ELECTRUM_CACHE_DB)).toBe(true);
+  });
+
+  it('opens an existing database without disturbing what it holds', async () => {
+    const existing = await openLikeMainnetJs(ELECTRUM_CACHE_DB);
+    await new Promise<void>((resolve) => {
+      const objectStore = existing.transaction(ELECTRUM_CACHE_DB, "readwrite").objectStore(ELECTRUM_CACHE_DB);
+      objectStore.put("cached", "header-mainnet-800000-false");
+      objectStore.transaction.oncomplete = () => resolve();
+    });
+    existing.close();
+
+    const db = await openIndexedDB(ELECTRUM_CACHE_DB);
+    const value = await new Promise((resolve) => {
+      const request = db.transaction(ELECTRUM_CACHE_DB, "readonly")
+        .objectStore(ELECTRUM_CACHE_DB).get("header-mainnet-800000-false");
+      request.onsuccess = () => resolve(request.result);
+    });
+    db.close();
+
+    expect(value).toBe("cached");
+  });
+});

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { IndexedDBProvider } from "@mainnet-cash/indexeddb-storage";
+import { HDWallet, Config, DefaultProvider } from "mainnet-js";
 import { pruneHdWalletKeyCache, hdWalletCacheKey, deleteWalletFromDb } from "../src/utils/wallet/dbUtils";
 import { openIndexedDB } from "../src/utils/cacheUtils";
 
@@ -244,5 +245,22 @@ describe('deleteWalletFromDb', () => {
     await db.close();
 
     expect(stored?.wallet).toBe(hdWalletId(mnemonic, "testnet"));
+  });
+});
+
+describe('hdWalletCacheKey against mainnet-js', () => {
+  // The derivation mirrors a private one, so this is the contract that would otherwise break
+  // silently on a version bump. Constructing the wallet is safe here: initialize() sets walletId
+  // and awaits only the cache, leaving address discovery unawaited, so the offline wedge that
+  // catches consumers of watchPromise does not catch this.
+  it('derives the key mainnet-js will store the entry under', async () => {
+    Config.UseIndexedDBCache = true;
+    // unroutable, so a connection attempt cannot reach anything or depend on the network
+    DefaultProvider.servers.mainnet = ["wss://127.0.0.1:1"];
+    const storedWalletId = hdWalletId(mnemonic, "mainnet");
+
+    const wallet = await HDWallet.fromId(storedWalletId);
+
+    expect(hdWalletCacheKey(storedWalletId)).toBe(`walletCache-${wallet.walletId}`);
   });
 });

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -2,7 +2,7 @@ import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { IndexedDBProvider } from "@mainnet-cash/indexeddb-storage";
 import { HDWallet, Config, DefaultProvider } from "mainnet-js";
-import { pruneHdWalletKeyCache, hdWalletCacheKey, deleteWalletFromDb } from "../src/utils/wallet/dbUtils";
+import { pruneHdWalletKeyCache, hdWalletCacheKey, deleteWalletFromDb, getAllWalletsWithNetworkInfo } from "../src/utils/wallet/dbUtils";
 import { openIndexedDB } from "../src/utils/cacheUtils";
 
 // These run against a real IndexedDB implementation rather than a mock on purpose: both bugs
@@ -262,5 +262,30 @@ describe('hdWalletCacheKey against mainnet-js', () => {
     const wallet = await HDWallet.fromId(storedWalletId);
 
     expect(hdWalletCacheKey(storedWalletId)).toBe(`walletCache-${wallet.walletId}`);
+  });
+});
+
+describe('getAllWalletsWithNetworkInfo', () => {
+  // The flags decide which network a fallback wallet loads on at startup, so getting one of them
+  // backwards would open the wrong chain rather than merely mislabel a list
+  it('reports each wallet once, with the networks it exists on', async () => {
+    await addWallet("bitcoincash", "mainnetOnly", hdWalletId(mnemonic, "mainnet"));
+    await addWallet("bchtest", "chipnetOnly", hdWalletId(mnemonic, "testnet"));
+    await addWallet("bitcoincash", "both", hdWalletId(otherMnemonic, "mainnet"));
+    await addWallet("bchtest", "both", hdWalletId(otherMnemonic, "testnet"));
+
+    const wallets = await getAllWalletsWithNetworkInfo();
+
+    expect(wallets).toHaveLength(3);
+    expect(wallets.find((wallet) => wallet.name === "mainnetOnly"))
+      .toEqual({ name: "mainnetOnly", hasMainnet: true, hasChipnet: false });
+    expect(wallets.find((wallet) => wallet.name === "chipnetOnly"))
+      .toEqual({ name: "chipnetOnly", hasMainnet: false, hasChipnet: true });
+    expect(wallets.find((wallet) => wallet.name === "both"))
+      .toEqual({ name: "both", hasMainnet: true, hasChipnet: true });
+  });
+
+  it('returns nothing before any wallet exists', async () => {
+    expect(await getAllWalletsWithNetworkInfo()).toEqual([]);
   });
 });

--- a/test/dbUtils.indexeddb.test.ts
+++ b/test/dbUtils.indexeddb.test.ts
@@ -78,6 +78,30 @@ async function mainnetJsCanUseCache(dbName: string): Promise<boolean> {
   }
 }
 
+// Every key in every database, so an assertion can find what mainnet-js wrote without being told
+// where it put it. If it ever moved its cache, this still sees the entry and the prune does not.
+async function everyStoredKey(): Promise<string[]> {
+  const found: string[] = [];
+  for (const { name } of await indexedDB.databases()) {
+    if (!name) continue;
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(name);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(new Error(`Failed to open ${name}`));
+    });
+    for (const storeName of [...db.objectStoreNames]) {
+      const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+        const request = db.transaction(storeName, "readonly").objectStore(storeName).getAllKeys();
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(new Error(`Failed to read ${name}`));
+      });
+      for (const key of keys) if (typeof key === "string") found.push(key);
+    }
+    db.close();
+  }
+  return found;
+}
+
 describe('pruneHdWalletKeyCache', () => {
   it('removes the entries of wallets that are gone and keeps the ones still in the databases', async () => {
     await addWallet("bitcoincash", "kept", hdWalletId(mnemonic, "mainnet"));
@@ -287,5 +311,24 @@ describe('getAllWalletsWithNetworkInfo', () => {
 
   it('returns nothing before any wallet exists', async () => {
     expect(await getAllWalletsWithNetworkInfo()).toEqual([]);
+  });
+});
+
+describe('pruneHdWalletKeyCache against mainnet-js', () => {
+  it('removes an entry mainnet-js wrote itself', async () => {
+    Config.UseIndexedDBCache = true;
+    DefaultProvider.servers.mainnet = ["wss://127.0.0.1:1"];
+    const wallet = await HDWallet.fromId(hdWalletId(mnemonic, "mainnet"));
+    // let mainnet-js write the entry through its own database name, store name and key prefix,
+    // so none of those are assumed here. persist does not await its own write.
+    await wallet.walletCache.persist();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const written = (await everyStoredKey()).filter((key) => key.startsWith("walletCache-"));
+    expect(written).toHaveLength(1);
+
+    // no wallet records exist, so everything is orphaned
+    await pruneHdWalletKeyCache();
+
+    expect(await everyStoredKey()).not.toContain(written[0]);
   });
 });

--- a/test/dbUtils.test.ts
+++ b/test/dbUtils.test.ts
@@ -1,0 +1,45 @@
+import { hdWalletCacheKey } from "../src/utils/wallet/dbUtils";
+
+// mainnet-js keys its HD address cache by sha256(`${mnemonic + derivation}-${network}`), or by
+// the extended key alone when there is no mnemonic. The expected hashes below were produced
+// independently with node's own crypto rather than through libauth, so these pin the derivation
+// itself and not just our implementation of it.
+//
+// What they do not catch is mainnet-js changing the derivation on a version bump. Nothing in a
+// unit test can, since constructing an HD wallet offline never settles. That case is handled at
+// runtime instead: deleteHdWalletKeyCache clears the whole store when no key matches.
+const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const derivation = "m/44'/145'/0'";
+const xpriv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
+
+describe('hdWalletCacheKey', () => {
+  it('derives the cache key of a mnemonic wallet from the mnemonic and derivation path', () => {
+    const storedWalletId = `hd:mainnet:${mnemonic}:${derivation}:0:0`;
+    expect(hdWalletCacheKey(storedWalletId))
+      .toBe("walletCache-d3218b82dd00c91c6b38057db7420c700f4c472944a6e3da9036531eafc01dd5");
+  });
+
+  it('derives a different key per network, so both of a wallet\'s entries are found', () => {
+    const mainnetKey = hdWalletCacheKey(`hd:mainnet:${mnemonic}:${derivation}:0:0`);
+    const testnetKey = hdWalletCacheKey(`hd:testnet:${mnemonic}:${derivation}:0:0`);
+    expect(testnetKey)
+      .toBe("walletCache-0b100d263ab20d413c47655ca198bdaaa3d9ea7ac8982fad80f43d8e5ab7cb6b");
+    expect(mainnetKey).not.toBe(testnetKey);
+  });
+
+  it('hashes the extended key alone when the wallet has no mnemonic', () => {
+    // this shape carries no derivation path, the field after the key is the deposit index
+    const storedWalletId = `hd:mainnet:${xpriv}:0:0`;
+    expect(hdWalletCacheKey(storedWalletId))
+      .toBe("walletCache-b7bc7594d73e33d3a53f1ba0160136e1671f8ff02662b2c4619ecee99c5654e1");
+  });
+
+  it('returns nothing for a single-address wallet, which caches no keys on disk', () => {
+    expect(hdWalletCacheKey(`seed:mainnet:${mnemonic}:${derivation}`)).toBe(undefined);
+  });
+
+  it('returns nothing for a malformed id rather than a key that matches nothing', () => {
+    expect(hdWalletCacheKey("hd:mainnet")).toBe(undefined);
+    expect(hdWalletCacheKey("")).toBe(undefined);
+  });
+});

--- a/test/dbUtils.test.ts
+++ b/test/dbUtils.test.ts
@@ -6,8 +6,9 @@ import { hdWalletCacheKey } from "../src/utils/wallet/dbUtils";
 // itself and not just our implementation of it.
 //
 // What they do not catch is mainnet-js changing the derivation on a version bump. Nothing in a
-// unit test can, since constructing an HD wallet offline never settles. That case is handled at
-// runtime instead: deleteHdWalletKeyCache clears the whole store when no key matches.
+// unit test can, since constructing an HD wallet offline never settles. That case degrades safely
+// at runtime instead: every entry would look orphaned to pruneHdWalletKeyCache and be cleared,
+// costing an address rescan rather than leaving keys behind.
 const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 const derivation = "m/44'/145'/0'";
 const xpriv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";

--- a/test/dbUtils.test.ts
+++ b/test/dbUtils.test.ts
@@ -5,10 +5,8 @@ import { hdWalletCacheKey } from "../src/utils/wallet/dbUtils";
 // independently with node's own crypto rather than through libauth, so these pin the derivation
 // itself and not just our implementation of it.
 //
-// What they do not catch is mainnet-js changing the derivation on a version bump. Nothing in a
-// unit test can, since constructing an HD wallet offline never settles. That case degrades safely
-// at runtime instead: every entry would look orphaned to pruneHdWalletKeyCache and be cleared,
-// costing an address rescan rather than leaving keys behind.
+// A version bump changing mainnet-js's own derivation is caught separately, by the contract test
+// in dbUtils.indexeddb.test.ts that compares this against a real HDWallet's walletId.
 const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 const derivation = "m/44'/145'/0'";
 const xpriv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -125,8 +125,7 @@ vi.mock('src/utils/wallet/dbUtils', () => ({
 }))
 
 // Mock settingsStore
-export const mockClearBackupStatus = vi.fn()
-export const mockClearWalletMetadata = vi.fn()
+export const mockClearWalletSettings = vi.fn()
 
 vi.mock('src/stores/settingsStore', () => ({
   useSettingsStore: vi.fn(() => ({
@@ -143,8 +142,7 @@ vi.mock('src/stores/settingsStore', () => ({
     getWalletType: vi.fn().mockReturnValue('single'),
     getWalletMetadata: vi.fn().mockReturnValue({ walletType: 'single' }),
     setWalletType: vi.fn(),
-    clearBackupStatus: mockClearBackupStatus,
-    clearWalletMetadata: mockClearWalletMetadata,
+    clearWalletSettings: mockClearWalletSettings,
   })),
 }))
 

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -101,6 +101,7 @@ vi.mock('@mainnet-cash/indexeddb-storage', () => ({
 // Mock dbUtils
 export const mockGetAllWalletsWithNetworkInfo = vi.fn()
 export const mockDeleteWalletFromDb = vi.fn()
+export const mockClearHdWalletKeyCache = vi.fn().mockResolvedValue(undefined)
 
 // Wallets exist in IndexedDB by default, override per-test to exercise the missing-wallet guard
 export const mockNamedWalletExistsInDb = vi.fn().mockResolvedValue(true)
@@ -118,6 +119,7 @@ export const mockGetNamedWalletIdFromDb = vi.fn(defaultGetNamedWalletIdFromDb)
 vi.mock('src/utils/wallet/dbUtils', () => ({
   getAllWalletsWithNetworkInfo: mockGetAllWalletsWithNetworkInfo,
   deleteWalletFromDb: mockDeleteWalletFromDb,
+  clearHdWalletKeyCache: mockClearHdWalletKeyCache,
   namedWalletExistsInDb: mockNamedWalletExistsInDb,
   getNamedWalletIdFromDb: mockGetNamedWalletIdFromDb,
 }))

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -125,6 +125,9 @@ vi.mock('src/utils/wallet/dbUtils', () => ({
 }))
 
 // Mock settingsStore
+export const mockClearBackupStatus = vi.fn()
+export const mockClearWalletMetadata = vi.fn()
+
 vi.mock('src/stores/settingsStore', () => ({
   useSettingsStore: vi.fn(() => ({
     currency: 'usd',
@@ -140,6 +143,8 @@ vi.mock('src/stores/settingsStore', () => ({
     getWalletType: vi.fn().mockReturnValue('single'),
     getWalletMetadata: vi.fn().mockReturnValue({ walletType: 'single' }),
     setWalletType: vi.fn(),
+    clearBackupStatus: mockClearBackupStatus,
+    clearWalletMetadata: mockClearWalletMetadata,
   })),
 }))
 

--- a/test/mocks/store.mocks.ts
+++ b/test/mocks/store.mocks.ts
@@ -101,7 +101,7 @@ vi.mock('@mainnet-cash/indexeddb-storage', () => ({
 // Mock dbUtils
 export const mockGetAllWalletsWithNetworkInfo = vi.fn()
 export const mockDeleteWalletFromDb = vi.fn()
-export const mockClearHdWalletKeyCache = vi.fn().mockResolvedValue(undefined)
+export const mockPruneHdWalletKeyCache = vi.fn().mockResolvedValue(undefined)
 
 // Wallets exist in IndexedDB by default, override per-test to exercise the missing-wallet guard
 export const mockNamedWalletExistsInDb = vi.fn().mockResolvedValue(true)
@@ -119,7 +119,7 @@ export const mockGetNamedWalletIdFromDb = vi.fn(defaultGetNamedWalletIdFromDb)
 vi.mock('src/utils/wallet/dbUtils', () => ({
   getAllWalletsWithNetworkInfo: mockGetAllWalletsWithNetworkInfo,
   deleteWalletFromDb: mockDeleteWalletFromDb,
-  clearHdWalletKeyCache: mockClearHdWalletKeyCache,
+  pruneHdWalletKeyCache: mockPruneHdWalletKeyCache,
   namedWalletExistsInDb: mockNamedWalletExistsInDb,
   getNamedWalletIdFromDb: mockGetNamedWalletIdFromDb,
 }))

--- a/test/mocks/walletUtils.mocks.ts
+++ b/test/mocks/walletUtils.mocks.ts
@@ -26,6 +26,7 @@ export const mockRefreshAvailableWallets = vi.fn()
 export const mockSetWalletCreatedAt = vi.fn()
 export const mockSetBackupStatus = vi.fn()
 export const mockSetWalletType = vi.fn()
+export const mockClearBackupStatus = vi.fn()
 
 // Mock localStorage
 export const localStorageMock = {
@@ -51,6 +52,7 @@ vi.mock('src/stores/settingsStore', () => ({
   useSettingsStore: vi.fn(() => ({
     setWalletCreatedAt: mockSetWalletCreatedAt,
     setBackupStatus: mockSetBackupStatus,
+    clearBackupStatus: mockClearBackupStatus,
     setWalletType: mockSetWalletType,
   }))
 }))

--- a/test/mocks/walletUtils.mocks.ts
+++ b/test/mocks/walletUtils.mocks.ts
@@ -27,6 +27,7 @@ export const mockSetWalletCreatedAt = vi.fn()
 export const mockSetBackupStatus = vi.fn()
 export const mockSetWalletType = vi.fn()
 export const mockClearBackupStatus = vi.fn()
+export const mockClearWalletSettings = vi.fn()
 
 // Mock localStorage
 export const localStorageMock = {
@@ -53,6 +54,7 @@ vi.mock('src/stores/settingsStore', () => ({
     setWalletCreatedAt: mockSetWalletCreatedAt,
     setBackupStatus: mockSetBackupStatus,
     clearBackupStatus: mockClearBackupStatus,
+    clearWalletSettings: mockClearWalletSettings,
     setWalletType: mockSetWalletType,
   }))
 }))

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -16,8 +16,7 @@ import {
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
   mockPruneHdWalletKeyCache,
-  mockClearBackupStatus,
-  mockClearWalletMetadata,
+  mockClearWalletSettings,
   mockGetNamedWalletIdFromDb,
 } from './mocks/store.mocks'
 
@@ -365,14 +364,13 @@ describe('deleteWallet', () => {
     expect(mockPruneHdWalletKeyCache).toHaveBeenCalled()
   })
 
-  it('clears the backup status and metadata of the deleted wallet', async () => {
+  it('clears the settings of the deleted wallet', async () => {
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)
 
     await store.deleteWallet('otherWallet')
 
-    expect(mockClearBackupStatus).toHaveBeenCalledWith('otherWallet')
-    expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
+    expect(mockClearWalletSettings).toHaveBeenCalledWith('otherWallet')
   })
 
   // The wallet is already gone when the prune runs, so its failure is reported on its own rather
@@ -384,8 +382,7 @@ describe('deleteWallet', () => {
 
     await expect(store.deleteWallet('otherWallet')).resolves.toBeUndefined()
 
-    expect(mockClearBackupStatus).toHaveBeenCalledWith('otherWallet')
-    expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
+    expect(mockClearWalletSettings).toHaveBeenCalledWith('otherWallet')
     expect(mockDeleteWalletFromDb).toHaveBeenCalledTimes(2)
   })
 

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -16,6 +16,8 @@ import {
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
   mockPruneHdWalletKeyCache,
+  mockClearBackupStatus,
+  mockClearWalletMetadata,
   mockGetNamedWalletIdFromDb,
 } from './mocks/store.mocks'
 
@@ -361,6 +363,29 @@ describe('deleteWallet', () => {
     await store.deleteWallet('otherWallet')
 
     expect(mockPruneHdWalletKeyCache).toHaveBeenCalled()
+  })
+
+  it('clears the backup status and metadata of the deleted wallet', async () => {
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+
+    await store.deleteWallet('otherWallet')
+
+    expect(mockClearBackupStatus).toHaveBeenCalledWith('otherWallet')
+    expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
+  })
+
+  // Both are keyed by wallet name, so a status surviving a failed deletion would be inherited by
+  // the next wallet of that name. The prune runs last precisely so it cannot skip them.
+  it('clears them even when the key cache prune fails', async () => {
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+    mockPruneHdWalletKeyCache.mockRejectedValueOnce(new Error('prune failed'))
+
+    await expect(store.deleteWallet('otherWallet')).rejects.toThrowError()
+
+    expect(mockClearBackupStatus).toHaveBeenCalledWith('otherWallet')
+    expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
   })
 
   it('does not prune the key cache when the delete is refused', async () => {

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -15,7 +15,7 @@ import {
   localStorageMock,
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
-  mockClearHdWalletKeyCache,
+  mockPruneHdWalletKeyCache,
   mockGetNamedWalletIdFromDb,
 } from './mocks/store.mocks'
 
@@ -354,16 +354,16 @@ describe('deleteWallet', () => {
 
   // The seed is deleted above, but mainnet-js caches a private key per address for HD wallets
   // in a database of its own, which would still be able to spend from the deleted wallet
-  it('clears the HD wallet key cache so no spendable keys outlive the wallet', async () => {
+  it('prunes the HD wallet key cache so no spendable keys outlive the wallet', async () => {
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)
 
     await store.deleteWallet('otherWallet')
 
-    expect(mockClearHdWalletKeyCache).toHaveBeenCalled()
+    expect(mockPruneHdWalletKeyCache).toHaveBeenCalled()
   })
 
-  it('does not clear the key cache when the delete is refused', async () => {
+  it('does not prune the key cache when the delete is refused', async () => {
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)
 
@@ -373,7 +373,7 @@ describe('deleteWallet', () => {
       // Expected to throw, deleting the active wallet is refused
     }
 
-    expect(mockClearHdWalletKeyCache).not.toHaveBeenCalled()
+    expect(mockPruneHdWalletKeyCache).not.toHaveBeenCalled()
   })
 
   it('refreshes available wallets after deletion', async () => {

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -15,6 +15,7 @@ import {
   localStorageMock,
   mockGetAllWalletsWithNetworkInfo,
   mockDeleteWalletFromDb,
+  mockClearHdWalletKeyCache,
   mockGetNamedWalletIdFromDb,
 } from './mocks/store.mocks'
 
@@ -349,6 +350,30 @@ describe('deleteWallet', () => {
     expect(mockDeleteWalletFromDb).toHaveBeenCalledWith('otherWallet', 'bitcoincash')
     expect(mockDeleteWalletFromDb).toHaveBeenCalledWith('otherWallet', 'bchtest')
     expect(mockDeleteWalletFromDb).toHaveBeenCalledTimes(2)
+  })
+
+  // The seed is deleted above, but mainnet-js caches a private key per address for HD wallets
+  // in a database of its own, which would still be able to spend from the deleted wallet
+  it('clears the HD wallet key cache so no spendable keys outlive the wallet', async () => {
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+
+    await store.deleteWallet('otherWallet')
+
+    expect(mockClearHdWalletKeyCache).toHaveBeenCalled()
+  })
+
+  it('does not clear the key cache when the delete is refused', async () => {
+    const store = useStore()
+    store.setWallet(mockMainnetWallet as never)
+
+    try {
+      await store.deleteWallet('mywallet')
+    } catch {
+      // Expected to throw, deleting the active wallet is refused
+    }
+
+    expect(mockClearHdWalletKeyCache).not.toHaveBeenCalled()
   })
 
   it('refreshes available wallets after deletion', async () => {

--- a/test/store.switchWallet.test.ts
+++ b/test/store.switchWallet.test.ts
@@ -375,17 +375,18 @@ describe('deleteWallet', () => {
     expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
   })
 
-  // Both are keyed by wallet name, so a status surviving a failed deletion would be inherited by
-  // the next wallet of that name. The prune runs last precisely so it cannot skip them.
-  it('clears them even when the key cache prune fails', async () => {
+  // The wallet is already gone when the prune runs, so its failure is reported on its own rather
+  // than making the deletion look like it failed and stranding the per-wallet cleanup with it
+  it('still succeeds and cleans up when the key cache prune fails', async () => {
     const store = useStore()
     store.setWallet(mockMainnetWallet as never)
     mockPruneHdWalletKeyCache.mockRejectedValueOnce(new Error('prune failed'))
 
-    await expect(store.deleteWallet('otherWallet')).rejects.toThrowError()
+    await expect(store.deleteWallet('otherWallet')).resolves.toBeUndefined()
 
     expect(mockClearBackupStatus).toHaveBeenCalledWith('otherWallet')
     expect(mockClearWalletMetadata).toHaveBeenCalledWith('otherWallet')
+    expect(mockDeleteWalletFromDb).toHaveBeenCalledTimes(2)
   })
 
   it('does not prune the key cache when the delete is refused', async () => {

--- a/test/walletUtils.test.ts
+++ b/test/walletUtils.test.ts
@@ -515,6 +515,17 @@ describe('importWallet', () => {
       expect(mockSetBackupStatus).toHaveBeenCalledWith('imported', 'imported')
     })
 
+    it('records the wallet type rather than relying on the default', async () => {
+      await importWallet({
+        name: 'imported',
+        seedPhrase: validSeedPhrase,
+        seedPhraseValid: true,
+        derivationPath: 'standard'
+      })
+
+      expect(mockSetWalletType).toHaveBeenCalledWith('imported', 'single')
+    })
+
     it('records wallet creation date', async () => {
       await importWallet({
         name: 'imported',

--- a/test/walletUtils.test.ts
+++ b/test/walletUtils.test.ts
@@ -18,6 +18,7 @@ import {
   mockSetWalletCreatedAt,
   mockSetBackupStatus,
   mockSetWalletType,
+  mockClearBackupStatus,
   mockWalletFromSeed,
   localStorageMock,
 } from './mocks/walletUtils.mocks'
@@ -213,7 +214,7 @@ describe('createNewWallet', () => {
     it('clears any backup status left by an earlier wallet of the same name', async () => {
       await createNewWallet('newWallet')
 
-      expect(mockSetBackupStatus).toHaveBeenCalledWith('newWallet', 'none')
+      expect(mockClearBackupStatus).toHaveBeenCalledWith('newWallet')
     })
 
     it('records the wallet type rather than relying on the default', async () => {
@@ -666,6 +667,12 @@ describe('createNewHDWallet', () => {
       await createNewHDWallet('newHDWallet')
 
       expect(mockSetWalletType).toHaveBeenCalledWith('newHDWallet', 'hd')
+    })
+
+    it('clears any backup status left by an earlier wallet of the same name', async () => {
+      await createNewHDWallet('newHDWallet')
+
+      expect(mockClearBackupStatus).toHaveBeenCalledWith('newHDWallet')
     })
 
     it('records wallet creation date in settings', async () => {

--- a/test/walletUtils.test.ts
+++ b/test/walletUtils.test.ts
@@ -18,7 +18,7 @@ import {
   mockSetWalletCreatedAt,
   mockSetBackupStatus,
   mockSetWalletType,
-  mockClearBackupStatus,
+  mockClearWalletSettings,
   mockWalletFromSeed,
   localStorageMock,
 } from './mocks/walletUtils.mocks'
@@ -211,16 +211,10 @@ describe('createNewWallet', () => {
     // value left behind by an earlier wallet of the same name would be inherited uncorrected:
     // a seed the user has never seen shown as backed up, or a single-address wallet offered
     // the HD-only features
-    it('clears any backup status left by an earlier wallet of the same name', async () => {
+    it('clears what a previous wallet of the same name left behind', async () => {
       await createNewWallet('newWallet')
 
-      expect(mockClearBackupStatus).toHaveBeenCalledWith('newWallet')
-    })
-
-    it('records the wallet type rather than relying on the default', async () => {
-      await createNewWallet('newWallet')
-
-      expect(mockSetWalletType).toHaveBeenCalledWith('newWallet', 'single')
+      expect(mockClearWalletSettings).toHaveBeenCalledWith('newWallet')
     })
 
     it('returns success with trimmed wallet name', async () => {
@@ -515,7 +509,7 @@ describe('importWallet', () => {
       expect(mockSetBackupStatus).toHaveBeenCalledWith('imported', 'imported')
     })
 
-    it('records the wallet type rather than relying on the default', async () => {
+    it('clears what a previous wallet of the same name left behind', async () => {
       await importWallet({
         name: 'imported',
         seedPhrase: validSeedPhrase,
@@ -523,7 +517,7 @@ describe('importWallet', () => {
         derivationPath: 'standard'
       })
 
-      expect(mockSetWalletType).toHaveBeenCalledWith('imported', 'single')
+      expect(mockClearWalletSettings).toHaveBeenCalledWith('imported')
     })
 
     it('records wallet creation date', async () => {
@@ -680,10 +674,10 @@ describe('createNewHDWallet', () => {
       expect(mockSetWalletType).toHaveBeenCalledWith('newHDWallet', 'hd')
     })
 
-    it('clears any backup status left by an earlier wallet of the same name', async () => {
+    it('clears what a previous wallet of the same name left behind', async () => {
       await createNewHDWallet('newHDWallet')
 
-      expect(mockClearBackupStatus).toHaveBeenCalledWith('newHDWallet')
+      expect(mockClearWalletSettings).toHaveBeenCalledWith('newHDWallet')
     })
 
     it('records wallet creation date in settings', async () => {

--- a/test/walletUtils.test.ts
+++ b/test/walletUtils.test.ts
@@ -206,6 +206,22 @@ describe('createNewWallet', () => {
       expect(mockSetWalletCreatedAt).toHaveBeenCalledWith('newWallet')
     })
 
+    // Both of these are keyed by wallet name, and nothing else on this path writes them, so a
+    // value left behind by an earlier wallet of the same name would be inherited uncorrected:
+    // a seed the user has never seen shown as backed up, or a single-address wallet offered
+    // the HD-only features
+    it('clears any backup status left by an earlier wallet of the same name', async () => {
+      await createNewWallet('newWallet')
+
+      expect(mockSetBackupStatus).toHaveBeenCalledWith('newWallet', 'none')
+    })
+
+    it('records the wallet type rather than relying on the default', async () => {
+      await createNewWallet('newWallet')
+
+      expect(mockSetWalletType).toHaveBeenCalledWith('newWallet', 'single')
+    })
+
     it('returns success with trimmed wallet name', async () => {
       const result = await createNewWallet('  newWallet  ')
 


### PR DESCRIPTION
claude:

# Clear mainnet-js's derived key cache when a wallet is deleted

Deleting a wallet removed its record from the mainnet-js wallet databases and left
mainnet-js's HD key cache untouched. For HD wallets that cache holds a derived private
key per address, so every address a deleted wallet had used kept a spendable key on
disk. This branch prunes that cache on deletion, fixes two ways the app's raw IndexedDB
access could leave a library database unusable, and closes a related class of stale
per-wallet state in localStorage.

13 commits. Source changes are 162 insertions across 10 files; the rest is tests and one
CLAUDE.md section.

## The leak

Verified against the mainnet-js source rather than inferred:

- `cache/walletCache.ts` — `PersistentWalletCache.getByIndex()` stores `privateKey` in
  each entry, and its `stringify` hex-encodes any field whose name contains `Key` before
  writing.
- Storage is `new IndexedDbCache("WalletCache")`, i.e. a database of its own, separate
  from the `bitcoincash` / `bchtest` wallet databases the delete flow already handled.
- `store.ts` sets `Config.UseIndexedDBCache = true`, so this is the live path.
- Entries are keyed `walletCache-${walletId}`, where `HDWallet` derives `walletId` as
  `sha256(utf8(\`${mnemonic + derivation ?? xPriv ?? xPub}-${network}\`))`.
- Single-address wallets are unaffected: `BaseWallet` uses an in-memory `Map` and writes
  nothing to this database.

**Severity, honestly.** This is local residue, not remote exposure. Anyone who can read
this database could already read the seed itself, in plaintext, before the deletion. And
IndexedDB deletion is not secure erasure at the storage layer. What it fixes is that
"delete wallet" now means what a user assumes it means, and it collects orphans left by
every earlier version rather than only the wallet just deleted.

`pruneHdWalletKeyCache()` in `src/utils/wallet/dbUtils.ts` derives the cache key of every
wallet still stored, on both networks, and deletes every string key that matches none of
them. Pruning against what remains, rather than removing the departed wallet's own key,
is what lets it also collect those older orphans. It deletes entries individually rather
than dropping the database, because `deleteDatabase` blocks on the connection the running
wallet holds and nothing reloads the page here.

If the derivation ever stopped agreeing with mainnet-js, every entry would look orphaned
and be dropped: an address rescan, not a key left behind.

## Two ways raw IndexedDB access can break a library database

An object store can only be created during a version upgrade, and an upgrade only runs
when the requested version is higher than the stored one. Opening a database that does not
exist creates it at version 1 with no store, so its owner, asking for version 1 too, never
upgrades and can never add its own store. Nothing fails at the point of the mistake.

- **`cacheUtils.ts`** — the settings menu's cache-size and clear helpers opened
  `ElectrumNetworkProviderCache` without a version. This is a regression that has been in
  released builds since `2106dbb` (2025-07-08), and the repo had already solved it once:
  `913e83e` (2025-04-28) replaced the raw open with Dexie and declared the store under
  `version(0.1)`, which is IndexedDB version 1, with a comment saying so, opened eagerly at
  module load. `2106dbb` removed Dexie for a genuine Capacitor freezing issue with
  `.toArray` on the main thread, and the versionless raw open came back without the version
  match or the store declaration. So the hazard was understood, handled, and silently
  dropped in a change about something else.

  Reachability of what came back is nonetheless close to nil: mainnet-js creates that
  database in `ElectrumNetworkProvider.connect()`, where `cache.init()` runs before the
  socket connect and therefore before any UI is reachable, and the settings tab only mounts
  once a wallet exists. A user would have to reach the settings tab before the first
  provider connect finished a local database open.
- **`dbUtils.ts`** — the same mistake in the new prune was genuinely reachable and severe.
  `WalletCache` is only ever created by HD wallets, and single-address is the default in
  both creation flows. A single-address-only user deleting a wallet would have had the
  prune create that database storeless, and the next HD wallet creation or import would
  then fail outright, permanently for that browser profile:
  `PersistentWalletCache.init()` awaits `getItem`, whose `db.transaction()` throws
  `NotFoundError`, and the surrounding try/catch covers only the JSON parse. Caught and
  fixed within this branch, never shipped.

`deleteWalletFromDb` deliberately keeps its versionless open: `IndexedDBProvider` asks for
version 31, so a database created here at version 1 still gets its upgrade and its store.
That exception is now commented and pinned by a test; matching version 31 there instead,
which the rule alone would suggest, fails it.

CLAUDE.md gains a short "Direct IndexedDB Access" section stating the rule. Two bugs on
this branch came from the same place, and the electrum one had already been fixed in
`913e83e` and lost again in `2106dbb`. Writing the rule down is what stops a third round.

## Deletion ordering and reporting

Per-wallet data (transaction notes, address management data, backup status, wallet
metadata) is now cleared inside `deleteWallet`, before the prune, rather than in the
overview component after it. Previously a prune failure skipped that cleanup and reported
the whole deletion as failed, in an untranslated internal string, while the wallet was in
fact gone.

The prune now runs last and is caught: the deletion is reported as successful, with a
separate warning that the wallet's cached keys could not be removed. The message
deliberately does not point at Clear cache in settings, which empties the electrum cache
and would leave those keys exactly where they are.

## Stale per-wallet state keyed by wallet name

Backup status and wallet type are keyed by wallet name in localStorage, so a value left
behind by a deleted wallet was inherited by a new wallet of the same name. The worst case
showed a seed the user had never seen as backed up and verified.

- Deletion now clears both.
- All four creation and import paths write both explicitly instead of relying on defaults.
- `loadExistingWallet` writes the wallet type on every load, derived from the stored id,
  rather than only filling it in when missing, which heals existing installs.

Backup status cannot be derived from anything, so clearing it on creation is the only
place that case can be closed. With deletion clearing them too, what remains is leftovers
from deletions performed by older versions.

## What this deliberately does not do

The deleted wallet's electrum residue is left alone. `ElectrumNetworkProviderCache` is
keyed by block height and txid and holds public chain data; the per-address material lives
in the `WalletCache` entry the prune does delete. Clearing it wholesale would make every
remaining wallet refetch its history, and targeting it by the pruned entry's `rawHistory`
would work for HD wallets only, on entries that are shared between wallets anyway. Settings
already offers Clear cache to anyone who wants it gone.

## Verification

- The cache-key derivation mirrors `HDWallet`'s own. The three test vectors in
  `test/dbUtils.test.ts` were recomputed independently with node's `crypto`, so they pin
  the derivation rather than this implementation of it.
- The IndexedDB tests run against a spec-compliant implementation, which reproduces the
  versioning behaviour both bugs turned on. Each guard was checked by reverting the fix it
  covers: versionless prune open, prune deleting everything, prune dropping the non-string
  guard, `openIndexedDB` reverted, cleanup moved back after the prune, and
  `deleteWalletFromDb` matching version 1. All fail as expected.
- 350 tests across 22 files, 10 of them in `test/dbUtils.indexeddb.test.ts`. `vue-tsc` and
  lint clean.

## New dev dependency

`fake-indexeddb` (dev only, Apache-2.0, zero dependencies). Imported per file rather than
in the shared setup, so the rest of the suite keeps its lightweight environment. A written
mock would not have caught either bug, since both live in IndexedDB's own versioning rules.

## Known trade-off

The prune re-implements a mainnet-js internal: the `walletId` derivation, the database and
store name, and the version to open at. mainnet-js exposes no way to drop a wallet's
cache, so there is no alternative today. It degrades safely for key material, but a
derivation change upstream would silently clear every remaining wallet's address cache,
costing a rescan. Worth raising upstream as a request for a supported API.
