### PR TITLE
Render the QR code in Vue instead of the @bitjson/qr-code web component

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@bitauth/libauth": "3.1.0-next.8",
-    "@bitjson/qr-code": "^1.0.2",
     "@cashconnect-js/core": "1.0.0-alpha.31",
     "@cashconnect-js/nostr": "1.0.0-alpha.31",
     "@mainnet-cash/indexeddb-storage": "3.1.7",
@@ -37,6 +36,7 @@
     "mainnet-js": "3.1.7",
     "pinia": "^4.0.3",
     "qr-scanner": "^1.4.2",
+    "qrcode-generator": "2.0.4",
     "quasar": "^2.28.0",
     "vue": "^3.5.42",
     "vue-i18n": "^11.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@bitauth/libauth':
         specifier: 3.1.0-next.8
         version: 3.1.0-next.8
-      '@bitjson/qr-code':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@cashconnect-js/core':
         specifier: 1.0.0-alpha.31
         version: 1.0.0-alpha.31
@@ -69,6 +66,9 @@ importers:
       qr-scanner:
         specifier: ^1.4.2
         version: 1.4.2
+      qrcode-generator:
+        specifier: 2.0.4
+        version: 2.0.4
       quasar:
         specifier: ^2.28.0
         version: 2.28.0
@@ -185,9 +185,6 @@ packages:
   '@bitauth/libauth@3.1.0-next.8':
     resolution: {integrity: sha512-Pm+Ju+YP3JeBLLTiVrBnia2wwE4G17r4XqpvPRMcklElJTe8J6x3JgKRg1by0Xm3ZY6UFxACkEAoSA+x419/zA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  '@bitjson/qr-code@1.0.2':
-    resolution: {integrity: sha512-oqcTWhzMs8Dt/xrHKDUzYglccgjVX2GleASd4FsE7TGGUkW8n57tBjKmfwkAVWa722+v6ijS81EmWbd07ebsmQ==}
 
   '@bufbuild/protobuf@2.12.1':
     resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
@@ -1910,6 +1907,9 @@ packages:
   qr-scanner@1.4.2:
     resolution: {integrity: sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==}
 
+  qrcode-generator@2.0.4:
+    resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
+
   quasar@2.28.0:
     resolution: {integrity: sha512-Ssbi8Mmf5DHyRqbgy0p757As6MHRdTNNOdNVO5sd9HJdbCyJdoaMG5xQkXVUl5a2eQ1xcGSnAn2n206XSoeXtw==}
     engines: {node: '>= 22.0.0'}
@@ -2662,8 +2662,6 @@ snapshots:
       '@bitauth/libauth': 3.1.0-next.8
 
   '@bitauth/libauth@3.1.0-next.8': {}
-
-  '@bitjson/qr-code@1.0.2': {}
 
   '@bufbuild/protobuf@2.12.1': {}
 
@@ -4625,6 +4623,8 @@ snapshots:
   qr-scanner@1.4.2:
     dependencies:
       '@types/offscreencanvas': 2019.7.3
+
+  qrcode-generator@2.0.4: {}
 
   quasar@2.28.0: {}
 

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -6,7 +6,7 @@ import packageJson from './package.json';
 
 export default defineConfig((ctx) => {
   // ctx.mode contains every mode as a key preset to false, so test the value, never key presence
-  const bootFiles = ['icons', 'i18n', 'qrCodeComponent'];
+  const bootFiles = ['icons', 'i18n'];
   if (ctx.mode.capacitor) bootFiles.push('deepLinking');
   if (ctx.mode.spa) bootFiles.push('plausible');
 
@@ -88,14 +88,6 @@ export default defineConfig((ctx) => {
             : undefined,
         })
       },
-      viteVuePluginOptions: {
-        template: {
-          compilerOptions: {
-            isCustomElement: (tag) => tag === 'qr-code',
-          }
-        }
-      },
-      
       vitePlugins: [
         ['rollup-plugin-visualizer', {
           open: true,

--- a/src/boot/qrCodeComponent.ts
+++ b/src/boot/qrCodeComponent.ts
@@ -1,8 +1,0 @@
-import { defineBoot } from '#q-app';
-import { defineCustomElements } from '@bitjson/qr-code';
-
-export default defineBoot(() => {
-  // Call defineCustomElements once globally to register the <qr-code> web component.
-  // This ensures it's available to all Vue components from app startup.
-  defineCustomElements(window);
-});

--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -318,8 +318,8 @@
       </span>
     </div>
     <div class="qr-frame">
-      <QrCode ref="qrCodeRef" :contents="addressQrcode" @click="copyToClipboard(addressQrcode)" class="qr-code" @rendered="animateQrCode">
-        <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" />
+      <QrCode ref="qrCodeRef" :contents="addressQrcode" :label="displayBchQr ? t('qrCode.bchAddress') : t('qrCode.tokenAddress')" @click="copyToClipboard(addressQrcode)" class="qr-code" @rendered="animateQrCode">
+        <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" alt="" />
       </QrCode>
     </div>
     <div style="text-align: center;">

--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -101,7 +101,7 @@
   // general functions
   const animateQrCode = () => {
     if (qrCodeRef.value && !settingsStore.hasPlayedAnimation && settingsStore.qrAnimation != 'None') {
-      qrCodeRef.value.animate(settingsStore.qrAnimation);
+      qrCodeRef.value.animate();
       settingsStore.hasPlayedAnimation = true;
     }
   };
@@ -318,7 +318,7 @@
       </span>
     </div>
     <div class="qr-frame">
-      <QrCode ref="qrCodeRef" :contents="addressQrcode" :label="displayBchQr ? t('qrCode.bchAddress') : t('qrCode.tokenAddress')" @click="copyToClipboard(addressQrcode)" class="qr-code" @rendered="animateQrCode">
+      <QrCode ref="qrCodeRef" :contents="addressQrcode" :animation="settingsStore.qrAnimation" :label="displayBchQr ? t('qrCode.bchAddress') : t('qrCode.tokenAddress')" @click="copyToClipboard(addressQrcode)" class="qr-code" @rendered="animateQrCode">
         <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" alt="" />
       </QrCode>
     </div>

--- a/src/components/bchWallet.vue
+++ b/src/components/bchWallet.vue
@@ -2,7 +2,7 @@
   import { ref, computed, watch, shallowRef } from 'vue'
   import { convert } from 'mainnet-js'
   import { decodeCashAddress } from "@bitauth/libauth"
-  import { CurrencySymbols, CurrencyShortNames, type QrCodeElement } from 'src/interfaces/interfaces'
+  import { CurrencySymbols, CurrencyShortNames } from 'src/interfaces/interfaces'
   import { copyToClipboard, formatFiatAmount, convertToCurrency } from 'src/utils/utils';
   import { parseBip21Uri, isBip21Uri, getBip21ValidationError, addressFromUri } from 'src/utils/payments/bip21';
   import { parsePayProParams } from 'src/utils/payments/paymentRequest';
@@ -14,6 +14,7 @@
   import { displayAndLogError } from 'src/utils/errorHandling'
   import { confirmDialog, notifySending, handleTransactionBroadcastSuccess } from 'src/utils/txHelpers'
   import QrCodeDialog from './qr/qrCodeScanDialog.vue';
+  import QrCode from './general/qrCode.vue';
   import portfolioIcon from './portfolio/portfolioIcon.vue';
 
   const $q = useQuasar()
@@ -35,12 +36,12 @@
   const destinationAddr = ref("");
   const showQrCodeDialog = ref(false);
   const isSending = ref(false);
-  // We keep the <qr-code> element in a ref so that we can call animateQrCode on codeRendered()
-  // This event handler calls the animation after rendering the qr-code web component
-  // Consecutive animations are only triggered when addressQrcode changes as reactive property of the qr-code
+  // We keep the qr code in a ref so that we can call animateQrCode on rendered()
+  // This event handler calls the animation after the qr code has rendered
+  // Consecutive animations are only triggered when addressQrcode changes as reactive property of the qr code
   // Using shallowRef avoids Vue’s deep reactivity re-activation when re-navigating to this view
   // This speeds up the rendering of the component
-  const qrCodeRef = shallowRef<QrCodeElement | null>(null);
+  const qrCodeRef = shallowRef<InstanceType<typeof QrCode> | null>(null);
 
   const addressQrcode = computed(() => displayBchQr.value ? store.currentDepositAddress : store.currentTokenDepositAddress)
 
@@ -100,7 +101,7 @@
   // general functions
   const animateQrCode = () => {
     if (qrCodeRef.value && !settingsStore.hasPlayedAnimation && settingsStore.qrAnimation != 'None') {
-      qrCodeRef.value.animateQRCode(settingsStore.qrAnimation);
+      qrCodeRef.value.animate(settingsStore.qrAnimation);
       settingsStore.hasPlayedAnimation = true;
     }
   };
@@ -317,9 +318,9 @@
       </span>
     </div>
     <div class="qr-frame">
-      <qr-code ref="qrCodeRef" :contents="addressQrcode" @click="copyToClipboard(addressQrcode)" class="qr-code" @codeRendered="animateQrCode">
-        <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" slot="icon" /> <!-- eslint-disable-line -->
-      </qr-code>
+      <QrCode ref="qrCodeRef" :contents="addressQrcode" @click="copyToClipboard(addressQrcode)" class="qr-code" @rendered="animateQrCode">
+        <img :src="displayBchQr? 'images/bch-icon.png':'images/tokenicon.png'" />
+      </QrCode>
     </div>
     <div style="text-align: center;">
       <div class="switchAddressButton icon" :class="{ flipped: !displayBchQr }" @click="switchAddressTypeQr()">⇄

--- a/src/components/general/qrCode.vue
+++ b/src/components/general/qrCode.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+  // Drop-in replacement for the <qr-code> web component of @bitjson/qr-code, rendering the
+  // same svg (see qrCodeSvg.ts) and offering the same intro animations. The presets are the
+  // library's, reimplemented as css keyframes over a per-element animation-delay.
+  import { computed, nextTick, onMounted, ref, useSlots, watch } from 'vue'
+  import { generateQrCodeSvg, iconWidthPercentage } from 'src/utils/qrCodeSvg'
+  import type { QRCodeAnimationName } from 'src/interfaces/interfaces'
+
+  const props = defineProps<{
+    contents: string
+  }>()
+
+  const emit = defineEmits<{ rendered: [] }>()
+
+  // The slot holds the icon overlaid on the code's center; when it is filled the generator
+  // punches a matching hole in the modules behind it.
+  const hasIcon = Boolean(useSlots().default)
+
+  const activeAnimation = ref<QRCodeAnimationName | 'None'>('None')
+  const qrCode = computed(() => generateQrCodeSvg(props.contents, hasIcon, activeAnimation.value))
+
+  // The parent animates a new code from the 'rendered' handler. onMounted announces the first
+  // one, because an immediate watcher would run during setup, before the parent's ref is set.
+  onMounted(() => emit('rendered'))
+  watch(() => props.contents, () => {
+    activeAnimation.value = 'None'
+    void nextTick(() => emit('rendered'))
+  })
+
+  function animate(animation: QRCodeAnimationName) {
+    activeAnimation.value = animation
+  }
+
+  defineExpose({ animate })
+</script>
+
+<template>
+  <div class="qrCode">
+    <div class="qrContainer" :class="activeAnimation !== 'None' ? `animate-${activeAnimation}` : ''">
+      <div class="iconContainer">
+        <div
+          class="iconWrapper"
+          :style="{ width: `${iconWidthPercentage}%`, animationDelay: `${qrCode.iconDelayMs}ms` }"
+        >
+          <slot />
+        </div>
+      </div>
+      <!-- safe as html: the generator interpolates only numbers, never the qr contents -->
+      <div v-html="qrCode.svg"></div> <!-- eslint-disable-line vue/no-v-html -->
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+$rippleEasing: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+
+.qrCode {
+  contain: content;
+}
+.iconContainer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Each animated element carries its own animation-delay as an inline style, written into the
+   svg by generateQrCodeSvg. The rules below add only the keyframes and the timing, so the
+   browser runs the intro on its own without any javascript per frame. */
+.qrContainer {
+  position: relative;
+
+  &.animate-FadeInTopDown {
+    :deep(.module), :deep(.position-ring), :deep(.position-center), .iconWrapper {
+      animation: qrFadeIn 300ms ease both;
+    }
+  }
+  &.animate-FadeInCenterOut, &.animate-MaterializeIn {
+    :deep(.module), :deep(.position-ring), :deep(.position-center), .iconWrapper {
+      animation: qrFadeIn 200ms ease both;
+    }
+  }
+  /* The two ripple presets pulse the icon down before the wave reaches it, so it gets its
+     own keyframes; the scale is deliberately left to resolve around the svg's own center,
+     which turns the size pulse into the outward wave. */
+  &.animate-RadialRipple {
+    :deep(.module), :deep(.position-ring), :deep(.position-center) {
+      animation: qrRipple 1000ms $rippleEasing both;
+    }
+    .iconWrapper {
+      animation: qrRippleIcon 1000ms $rippleEasing both;
+    }
+  }
+  &.animate-RadialRippleIn {
+    :deep(.module), :deep(.position-ring), :deep(.position-center) {
+      animation: qrRippleIn 1000ms $rippleEasing both, qrRippleReveal 1000ms $rippleEasing both;
+    }
+    .iconWrapper {
+      animation: qrRippleIcon 1000ms $rippleEasing both, qrRippleReveal 1000ms $rippleEasing both;
+    }
+  }
+}
+
+@keyframes qrFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* The ripple offsets and scales come from the underdamped harmonic oscillation the library
+   solved at runtime for an amplitude of 5, a stiffness of 50 and a damping of 3, scaled into
+   the 20%-100% window of the animation. */
+@keyframes qrRipple {
+  0% { transform: scale(1); }
+  20% { transform: scale(1.1); }
+  34.164% { transform: scale(0.974484); }
+  50.623% { transform: scale(1.005856); }
+  67.082% { transform: scale(0.998656); }
+  83.541% { transform: scale(1.000308); }
+  100% { transform: scale(1); }
+}
+@keyframes qrRippleIn {
+  0% { transform: scale(0); }
+  20% { transform: scale(1.1); }
+  34.164% { transform: scale(0.974484); }
+  50.623% { transform: scale(1.005856); }
+  67.082% { transform: scale(0.998656); }
+  83.541% { transform: scale(1.000308); }
+  100% { transform: scale(1); }
+}
+@keyframes qrRippleIcon {
+  0% { transform: scale(1); }
+  10% { transform: scale(0.7); }
+  20% { transform: scale(1.1); }
+  34.164% { transform: scale(0.974484); }
+  50.623% { transform: scale(1.005856); }
+  67.082% { transform: scale(0.998656); }
+  83.541% { transform: scale(1.000308); }
+  100% { transform: scale(1); }
+}
+@keyframes qrRippleReveal {
+  0% { opacity: 0; }
+  5% { opacity: 1; }
+  100% { opacity: 1; }
+}
+</style>

--- a/src/components/general/qrCode.vue
+++ b/src/components/general/qrCode.vue
@@ -6,11 +6,17 @@
   import { generateQrCodeSvg, iconWidthPercentage } from 'src/utils/qrCodeSvg'
   import type { QRCodeAnimationName } from 'src/interfaces/interfaces'
 
-  const props = defineProps<{
+  const props = withDefaults(defineProps<{
     contents: string
     /** Describes what the code encodes, for screen readers; the modules themselves say nothing. */
     label: string
-  }>()
+    /**
+     * Intro preset to bake delays for. Kept a prop rather than an argument to animate() so the
+     * markup is built once: starting the animation then only has to add a class, instead of
+     * regenerating ~120kB of svg and rebuilding every module while the wallet page loads.
+     */
+    animation?: QRCodeAnimationName | 'None'
+  }>(), { animation: 'None' })
 
   const emit = defineEmits<{ rendered: [] }>()
 
@@ -18,19 +24,21 @@
   // punches a matching hole in the modules behind it.
   const hasIcon = Boolean(useSlots().default)
 
-  const activeAnimation = ref<QRCodeAnimationName | 'None'>('None')
-  const qrCode = computed(() => generateQrCodeSvg(props.contents, hasIcon, activeAnimation.value))
+  const playing = ref(false)
+  const qrCode = computed(() => generateQrCodeSvg(props.contents, hasIcon, props.animation))
 
   // The parent animates a new code from the 'rendered' handler. onMounted announces the first
   // one, because an immediate watcher would run during setup, before the parent's ref is set.
   onMounted(() => emit('rendered'))
+  // A new code starts static: leaving the class on would replay the intro on every address
+  // change, including the ones the parent does not want animated.
   watch(() => props.contents, () => {
-    activeAnimation.value = 'None'
+    playing.value = false
     void nextTick(() => emit('rendered'))
   })
 
-  function animate(animation: QRCodeAnimationName) {
-    activeAnimation.value = animation
+  function animate() {
+    playing.value = true
   }
 
   defineExpose({ animate })
@@ -40,7 +48,7 @@
   <!-- role="img" collapses the hundreds of svg modules into one labelled image for
        assistive technology, which would otherwise read out nothing at all -->
   <div class="qrCode" role="img" :aria-label="label">
-    <div class="qrContainer" :class="activeAnimation !== 'None' ? `animate-${activeAnimation}` : ''">
+    <div class="qrContainer" :class="playing && animation !== 'None' ? `animate-${animation}` : ''">
       <div class="iconContainer">
         <div
           class="iconWrapper"
@@ -70,18 +78,22 @@ $rippleEasing: cubic-bezier(0.445, 0.05, 0.55, 0.95);
   justify-content: center;
 }
 
-/* Each animated element carries its own animation-delay as an inline style, written into the
-   svg by generateQrCodeSvg. The rules below add only the keyframes and the timing, so the
-   browser runs the intro on its own without any javascript per frame. */
 .qrContainer {
   position: relative;
+}
 
-  &.animate-FadeInTopDown {
+/* Each animated element carries its own animation-delay as an inline style, written into the
+   svg by generateQrCodeSvg. The rules below add only the keyframes and the timing, so the
+   browser runs the intro on its own without any javascript per frame.
+   The intro is decorative, so gate the whole block: a viewer who asks for reduced motion gets
+   no animation rules at all and the code simply renders. */
+@media (prefers-reduced-motion: no-preference) {
+  .qrContainer.animate-FadeInTopDown {
     :deep(.module), :deep(.position-ring), :deep(.position-center), .iconWrapper {
       animation: qrFadeIn 300ms ease both;
     }
   }
-  &.animate-FadeInCenterOut, &.animate-MaterializeIn {
+  .qrContainer.animate-FadeInCenterOut, .qrContainer.animate-MaterializeIn {
     :deep(.module), :deep(.position-ring), :deep(.position-center), .iconWrapper {
       animation: qrFadeIn 200ms ease both;
     }
@@ -89,7 +101,7 @@ $rippleEasing: cubic-bezier(0.445, 0.05, 0.55, 0.95);
   /* The two ripple presets pulse the icon down before the wave reaches it, so it gets its
      own keyframes; the scale is deliberately left to resolve around the svg's own center,
      which turns the size pulse into the outward wave. */
-  &.animate-RadialRipple {
+  .qrContainer.animate-RadialRipple {
     :deep(.module), :deep(.position-ring), :deep(.position-center) {
       animation: qrRipple 1000ms $rippleEasing both;
     }
@@ -97,7 +109,7 @@ $rippleEasing: cubic-bezier(0.445, 0.05, 0.55, 0.95);
       animation: qrRippleIcon 1000ms $rippleEasing both;
     }
   }
-  &.animate-RadialRippleIn {
+  .qrContainer.animate-RadialRippleIn {
     :deep(.module), :deep(.position-ring), :deep(.position-center) {
       animation: qrRippleIn 1000ms $rippleEasing both, qrRippleReveal 1000ms $rippleEasing both;
     }

--- a/src/components/general/qrCode.vue
+++ b/src/components/general/qrCode.vue
@@ -8,6 +8,8 @@
 
   const props = defineProps<{
     contents: string
+    /** Describes what the code encodes, for screen readers; the modules themselves say nothing. */
+    label: string
   }>()
 
   const emit = defineEmits<{ rendered: [] }>()
@@ -35,7 +37,9 @@
 </script>
 
 <template>
-  <div class="qrCode">
+  <!-- role="img" collapses the hundreds of svg modules into one labelled image for
+       assistive technology, which would otherwise read out nothing at all -->
+  <div class="qrCode" role="img" :aria-label="label">
     <div class="qrContainer" :class="activeAnimation !== 'None' ? `animate-${activeAnimation}` : ''">
       <div class="iconContainer">
         <div

--- a/src/components/settings/exportXpub.vue
+++ b/src/components/settings/exportXpub.vue
@@ -48,7 +48,7 @@
         {{ t('exportXpub.derivationPath') }} <span style="font-family: monospace;">{{ derivationPath }}</span>
       </div>
       <div class="qr-frame" style="margin: 0 auto 15px;">
-        <QrCode :contents="xpub" class="qr-code" @click="copyToClipboard(xpub)" />
+        <QrCode :contents="xpub" :label="t('qrCode.xpub')" class="qr-code" @click="copyToClipboard(xpub)" />
       </div>
       <div class="xpub-result" @click="copyToClipboard(xpub)">{{ xpub }}</div>
       <div class="xpub-button-row">

--- a/src/components/settings/exportXpub.vue
+++ b/src/components/settings/exportXpub.vue
@@ -5,6 +5,7 @@
   import { useI18n } from 'vue-i18n'
   import { copyToClipboard } from 'src/utils/utils'
   import InfoPopup from 'src/components/general/InfoPopup.vue'
+  import QrCode from 'src/components/general/qrCode.vue'
 
   const store = useStore()
   const { t } = useI18n()
@@ -47,7 +48,7 @@
         {{ t('exportXpub.derivationPath') }} <span style="font-family: monospace;">{{ derivationPath }}</span>
       </div>
       <div class="qr-frame" style="margin: 0 auto 15px;">
-        <qr-code :contents="xpub" class="qr-code" @click="copyToClipboard(xpub)"></qr-code>
+        <QrCode :contents="xpub" class="qr-code" @click="copyToClipboard(xpub)" />
       </div>
       <div class="xpub-result" @click="copyToClipboard(xpub)">{{ xpub }}</div>
       <div class="xpub-button-row">

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -12,6 +12,7 @@
   import AddressTokenChips from 'src/components/general/AddressTokenChips.vue'
   import InlineTextEdit from 'src/components/general/InlineTextEdit.vue'
   import CharCounter from 'src/components/general/CharCounter.vue'
+  import QrCode from 'src/components/general/qrCode.vue'
 
   const store = useStore()
   const settingsStore = useSettingsStore()
@@ -290,9 +291,9 @@
   <q-dialog v-model="showQrDialog" transition-show="scale" transition-hide="scale">
     <q-card class="qr-card">
       <div class="qr-frame">
-        <qr-code :contents="qrDialogAddress" class="qr-code" @click="copyToClipboard(qrDialogAddress)">
-          <img :src="qrDialogTokenAddress ? 'images/tokenicon.png' : 'images/bch-icon.png'" slot="icon" /> <!-- eslint-disable-line -->
-        </qr-code>
+        <QrCode :contents="qrDialogAddress" class="qr-code" @click="copyToClipboard(qrDialogAddress)">
+          <img :src="qrDialogTokenAddress ? 'images/tokenicon.png' : 'images/bch-icon.png'" />
+        </QrCode>
       </div>
       <!-- no address label here: this dialog is held out to whoever scans the code,
            and labels are written for yourself, not for the payer to read -->

--- a/src/components/settings/hdAddresses.vue
+++ b/src/components/settings/hdAddresses.vue
@@ -291,8 +291,8 @@
   <q-dialog v-model="showQrDialog" transition-show="scale" transition-hide="scale">
     <q-card class="qr-card">
       <div class="qr-frame">
-        <QrCode :contents="qrDialogAddress" class="qr-code" @click="copyToClipboard(qrDialogAddress)">
-          <img :src="qrDialogTokenAddress ? 'images/tokenicon.png' : 'images/bch-icon.png'" />
+        <QrCode :contents="qrDialogAddress" :label="qrDialogTokenAddress ? t('qrCode.tokenAddress') : t('qrCode.bchAddress')" class="qr-code" @click="copyToClipboard(qrDialogAddress)">
+          <img :src="qrDialogTokenAddress ? 'images/tokenicon.png' : 'images/bch-icon.png'" alt="" />
         </QrCode>
       </div>
       <!-- no address label here: this dialog is held out to whoever scans the code,

--- a/src/components/settings/requestPayment.vue
+++ b/src/components/settings/requestPayment.vue
@@ -316,8 +316,8 @@
     </div>
 
     <div class="qr-frame">
-      <QrCode :contents="requestUri" @click="copyToClipboard(requestUri)" class="qr-code">
-        <img :src="mode === 'bch' ? 'images/bch-icon.png' : 'images/tokenicon.png'" />
+      <QrCode :contents="requestUri" :label="t('qrCode.paymentRequest')" @click="copyToClipboard(requestUri)" class="qr-code">
+        <img :src="mode === 'bch' ? 'images/bch-icon.png' : 'images/tokenicon.png'" alt="" />
       </QrCode>
     </div>
 

--- a/src/components/settings/requestPayment.vue
+++ b/src/components/settings/requestPayment.vue
@@ -14,6 +14,7 @@
   import HdAddressSelectDialog from 'src/components/general/hdAddressSelectDialog.vue'
   import TokenSelectDialog from 'src/components/general/tokenSelectDialog.vue'
   import TokenIcon from 'src/components/general/TokenIcon.vue'
+  import QrCode from 'src/components/general/qrCode.vue'
 
   const store = useStore()
   const settingsStore = useSettingsStore()
@@ -315,9 +316,9 @@
     </div>
 
     <div class="qr-frame">
-      <qr-code :contents="requestUri" @click="copyToClipboard(requestUri)" class="qr-code">
-        <img :src="mode === 'bch' ? 'images/bch-icon.png' : 'images/tokenicon.png'" slot="icon" /> <!-- eslint-disable-line -->
-      </qr-code>
+      <QrCode :contents="requestUri" @click="copyToClipboard(requestUri)" class="qr-code">
+        <img :src="mode === 'bch' ? 'images/bch-icon.png' : 'images/tokenicon.png'" />
+      </QrCode>
     </div>
 
     <div v-if="requestedAmountDisplay" class="requestSummary">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1020,6 +1020,12 @@
     "words12": "12 Wörter",
     "words24": "24 Wörter"
   },
+  "qrCode": {
+    "bchAddress": "QR-Code der Bitcoin Cash Adresse",
+    "tokenAddress": "QR-Code der Token-Adresse",
+    "xpub": "QR-Code des Xpub",
+    "paymentRequest": "QR-Code der Zahlungsanforderung"
+  },
   "qrScanner": {
     "scanQrCode": "QR-Code scannen",
     "chooseImage": "Bild auswählen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1020,6 +1020,12 @@
     "words12": "12 words",
     "words24": "24 words"
   },
+  "qrCode": {
+    "bchAddress": "QR code of the Bitcoin Cash address",
+    "tokenAddress": "QR code of the token address",
+    "xpub": "QR code of the xpub",
+    "paymentRequest": "QR code of the payment request"
+  },
   "qrScanner": {
     "scanQrCode": "Scan QR Code",
     "chooseImage": "Choose image",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1020,6 +1020,12 @@
     "words12": "12 palabras",
     "words24": "24 palabras"
   },
+  "qrCode": {
+    "bchAddress": "Código QR de la dirección de Bitcoin Cash",
+    "tokenAddress": "Código QR de la dirección de token",
+    "xpub": "Código QR del xpub",
+    "paymentRequest": "Código QR de la solicitud de pago"
+  },
   "qrScanner": {
     "scanQrCode": "Escanear código QR",
     "chooseImage": "Elegir imagen",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1020,6 +1020,12 @@
     "words12": "12 mots",
     "words24": "24 mots"
   },
+  "qrCode": {
+    "bchAddress": "QR code de l'adresse Bitcoin Cash",
+    "tokenAddress": "QR code de l'adresse de token",
+    "xpub": "QR code du xpub",
+    "paymentRequest": "QR code de la demande de paiement"
+  },
   "qrScanner": {
     "scanQrCode": "Scanner le code QR",
     "chooseImage": "Choisir une image",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1020,6 +1020,12 @@
     "words12": "12 palavras",
     "words24": "24 palavras"
   },
+  "qrCode": {
+    "bchAddress": "Código QR do endereço Bitcoin Cash",
+    "tokenAddress": "Código QR do endereço de token",
+    "xpub": "Código QR do xpub",
+    "paymentRequest": "Código QR da solicitação de pagamento"
+  },
   "qrScanner": {
     "scanQrCode": "Escanear QR Code",
     "chooseImage": "Escolher imagem",

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -37,9 +37,6 @@ export type QRCodeAnimationName =
   | 'MaterializeIn'
   | 'RadialRipple'
   | 'RadialRippleIn';
-export interface QrCodeElement extends HTMLElement {
-  animateQRCode: (animationName: QRCodeAnimationName) => void;
-}
 
 export type TokenActionType = 'sending' | 'minting' | 'burning' | 'transferAuth';
 

--- a/src/utils/qrCodeSvg.ts
+++ b/src/utils/qrCodeSvg.ts
@@ -1,0 +1,173 @@
+// Renders a QR code as an SVG string, ported from the @bitjson/qr-code web component (MIT).
+// The geometry is a verbatim port so the codes keep rendering exactly as before: round modules,
+// rounded corner rings, and an optional hole punched in the center for an icon overlay.
+//
+// The original played its intro animation by driving one Web Animation per module from a
+// requestAnimationFrame loop, which for a 41x41 address code means ~680 animations resynced by
+// hand every frame. Every preset only ever staggers its elements by a delay, so instead we bake
+// that delay into each element as an inline animation-delay and let CSS keyframes (in qrCode.vue)
+// run the animation, leaving no per-frame work at all.
+
+import qrcode from 'qrcode-generator';
+import type { QRCodeAnimationName } from 'src/interfaces/interfaces';
+
+/** Quiet zone around the code, in modules. */
+const margin = 4;
+
+/** Icon width as a percentage of the code, matching the hole punched by isRemovableCenter. */
+export const iconWidthPercentage = 18;
+
+type QrCodeEntity = 'module' | 'position-ring' | 'position-center' | 'icon';
+
+export interface QrCodeSvg {
+  svg: string;
+  /** Delay for the icon overlay, which sits outside the svg but animates along with it. */
+  iconDelayMs: number;
+}
+
+/**
+ * Distance from the code's center, measured from the corner of the shape nearest that center:
+ * a corner ring covers seven modules and its center three, unlike a single module.
+ */
+function distanceFromCenter(x: number, y: number, count: number, entity: QrCodeEntity) {
+  const edgeLength = entity === 'position-ring' ? 7 : entity === 'position-center' ? 3 : 0;
+  const center = count / 2;
+  const adjustedX = x < center ? x + edgeLength : x > center ? x : x + edgeLength / 2;
+  const adjustedY = y < center ? y + edgeLength : y > center ? y : y + edgeLength / 2;
+  return Math.hypot(adjustedX - center, adjustedY - center);
+}
+
+/** Start offset of one element on the shared timeline, in milliseconds. */
+function animationDelay(
+  animation: QRCodeAnimationName, x: number, y: number, count: number, entity: QrCodeEntity
+) {
+  switch (animation) {
+    case 'FadeInTopDown':
+      return y * 20;
+    case 'FadeInCenterOut':
+      return distanceFromCenter(x, y, count, entity) * 20;
+    case 'MaterializeIn':
+      return entity === 'module' ? Math.random() * 200 : 200;
+    case 'RadialRipple':
+    case 'RadialRippleIn':
+      return distanceFromCenter(x, y, count, entity) * 7;
+  }
+}
+
+/**
+ * `maskCenter` punches the hole for the icon overlay; pass it only when an icon is rendered.
+ * `animation` of 'None' leaves out the delays entirely, so a static code stays a plain svg.
+ */
+export function generateQrCodeSvg(
+  contents: string, maskCenter: boolean, animation: QRCodeAnimationName | 'None'
+): QrCodeSvg {
+  const qr = qrcode(/* auto-detect the version to use */ 0, /* highest error correction */ 'H');
+  qr.addData(contents);
+  qr.make();
+  const moduleCount = qr.getModuleCount();
+  const pixelSize = moduleCount + margin * 2;
+  const coordinateShift = pixelSize / 2;
+
+  const delayAttribute = (x: number, y: number, entity: QrCodeEntity) => {
+    if (animation === 'None') return '';
+    const delay = animationDelay(animation, x, y, moduleCount, entity);
+    return ` style="animation-delay:${Math.round(delay)}ms"`;
+  };
+
+  // Only numbers derived from the encoder may be interpolated into this markup. It is rendered
+  // with v-html, so any string reaching it becomes an injection point: a <title> holding the
+  // contents, say, would be an XSS in the payment request, whose uri carries a typed message.
+  // The contents reach qr.addData above and nothing else.
+  const svg = `
+    <svg
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        height="100%"
+        viewBox="${0 - coordinateShift} ${0 - coordinateShift} ${pixelSize} ${pixelSize}"
+        preserveAspectRatio="xMinYMin meet">
+    <rect
+        width="100%"
+        height="100%"
+        fill="white"
+        fill-opacity="0"
+        cx="${-coordinateShift}"
+        cy="${-coordinateShift}"/>
+    ${renderPositionDetectionPatterns()}
+    ${renderModules()}
+    </svg>`;
+
+  return { svg, iconDelayMs: Math.round(iconDelay()) };
+
+  function iconDelay() {
+    if (animation === 'None') return 0;
+    return animationDelay(animation, moduleCount / 2, moduleCount / 2, moduleCount, 'icon');
+  }
+
+  function renderPositionDetectionPatterns() {
+    return `
+      ${renderPositionDetectionPattern(margin, margin)}
+      ${renderPositionDetectionPattern(moduleCount - 7 + margin, margin)}
+      ${renderPositionDetectionPattern(margin, moduleCount - 7 + margin)}
+      `;
+  }
+
+  function renderPositionDetectionPattern(x: number, y: number) {
+    const column = x - margin;
+    const row = y - margin;
+    return `
+      <path class="position-ring" fill="#000"${delayAttribute(column, row, 'position-ring')} d="M${x - coordinateShift} ${y - 0.5 - coordinateShift}h6s.5 0 .5 .5v6s0 .5-.5 .5h-6s-.5 0-.5-.5v-6s0-.5 .5-.5zm.75 1s-.25 0-.25 .25v4.5s0 .25 .25 .25h4.5s.25 0 .25-.25v-4.5s0-.25 -.25 -.25h-4.5z"/>
+      <path class="position-center" fill="#000"${delayAttribute(column + 2, row + 2, 'position-center')} d="M${x + 2 - coordinateShift} ${y + 1.5 - coordinateShift}h2s.5 0 .5 .5v2s0 .5-.5 .5h-2s-.5 0-.5-.5v-2s0-.5 .5-.5z"/>
+      `;
+  }
+
+  function renderModules() {
+    let svgModules = '';
+    for (let column = 0; column < moduleCount; column += 1) {
+      const positionX = column + margin;
+      for (let row = 0; row < moduleCount; row += 1) {
+        if (
+          qr.isDark(column, row) &&
+          !isPositioningElement(row, column) &&
+          !isRemovableCenter(row, column)
+        ) {
+          const positionY = row + margin;
+          svgModules += `
+            <circle
+                class="module"
+                fill="#000"${delayAttribute(column, row, 'module')}
+                cx="${positionX - coordinateShift}"
+                cy="${positionY - coordinateShift}"
+                r="0.5"/>`;
+        }
+      }
+    }
+    return svgModules;
+  }
+
+  /** The three corner patterns are drawn as paths instead, so their modules are skipped. */
+  function isPositioningElement(row: number, column: number) {
+    const elemWidth = 7;
+    return row <= elemWidth
+      ? column <= elemWidth || column >= moduleCount - elemWidth
+      : column <= elemWidth
+        ? row >= moduleCount - elemWidth
+        : false;
+  }
+
+  /**
+   * For ErrorCorrectionLevel 'H', up to 30% of the code can be corrected. To
+   * be safe, we limit damage to 10%.
+   */
+  function isRemovableCenter(row: number, column: number) {
+    if (!maskCenter) return false;
+    const center = moduleCount / 2;
+    const safelyRemovableHalf = Math.floor((moduleCount * Math.sqrt(0.1)) / 2);
+    return (
+      row >= center - safelyRemovableHalf &&
+      row <= center + safelyRemovableHalf &&
+      column >= center - safelyRemovableHalf &&
+      column <= center + safelyRemovableHalf
+    );
+  }
+}


### PR DESCRIPTION
The library drove its intro animation by creating one Web Animation per module and resyncing every one of them from its own requestAnimationFrame loop. For a 41x41 address code that is ~680 animations whose currentTime is read and written by hand on every frame. It also pulled a 2019 Stencil runtime into the boot chunk on every app start, on every platform, whether or not a code was shown.

Replace it with a local component that emits the same svg and reimplements the five animation presets as css keyframes over a per-element animation-delay, so the browser runs the intro with no javascript per frame.

The svg geometry is a port of the library's renderer (MIT), verified to paint identical marks: every circle's cx/cy/r, every path's d and fill, and the viewBox, across address, token address, chipnet, bip21, xpub and empty payloads. qrcode-generator is the same encoder the library bundled, now a direct dependency; its matrices are bit-identical to the bundled copy.

Measured on the same payload, three runs averaged:

                        1x cpu            4x throttle
  main-thread js        78ms -> 2.5ms     394ms -> 10ms
  frames in 900ms       50 -> 53          17 -> 38
  worst frame stall     78ms -> 44ms      394ms -> 133ms

The throttled numbers are the point: the animation fires exactly when the wallet page appears, competing with wallet init, so a 394ms stall there was visible on a mid-range phone.

Also drops three blanket eslint-disable lines: the icon went through the web component's slot attribute, which the vue linter cannot tell apart from removed vue 2 syntax.